### PR TITLE
Don't try to get mbr logical partitions in getPartitions()

### DIFF
--- a/lib/source-destination/source-destination.ts
+++ b/lib/source-destination/source-destination.ts
@@ -413,7 +413,7 @@ export class SourceDestination extends EventEmitter {
 		const stream = await this.createReadStream(false, 0, 65535); // TODO: constant
 		const buffer = await streamToBuffer(stream);
 		try {
-			return await getPartitions(buffer);
+			return await getPartitions(buffer, { getLogical: false });
 		} catch {}
 	}
 }


### PR DESCRIPTION
They're not in the first bytes of the disk.

Change-type: patch