### PR TITLE
Fix hash encoding

### DIFF
--- a/lib/source-destination/source-destination.ts
+++ b/lib/source-destination/source-destination.ts
@@ -64,7 +64,7 @@ export const ProgressHashStream = makeClassEmitProgressEvents(
 );
 
 export function createHasher() {
-	const hasher = new ProgressHashStream(SEED, BITS);
+	const hasher = new ProgressHashStream(SEED, BITS, 'buffer');
 	hasher.on('finish', async () => {
 		const checksum = (await streamToBuffer(hasher)).toString('hex');
 		hasher.emit('checksum', checksum);


### PR DESCRIPTION
Xxhash running on 32 bit will return by default an integer while the 64 bit execution
will return a buffer.

Change-type: patch
Signed-off-by: Theodor Gherzan <theodor@resin.io>