### PR TITLE
Update drivelist to 8.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build
 *~
 node_modules
+package-lock.json
+

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "blockmap": "^3.4.2",
     "bluebird": "^3.5.1",
     "debug": "^3.1.0",
-    "drivelist": "^8.0.0",
+    "drivelist": "^8.0.1",
     "file-disk": "^5.0.0",
     "file-type": "^8.0.0",
     "lodash": "^4.17.10",


### PR DESCRIPTION
Updates drivelist to 8.0.1, which contains the segfault fix for macOS. Also adds `package-lock.json` into `.gitignore`, it's generated, but not in the repo.