### PR TITLE
Exclude virtual drives

### DIFF
--- a/lib/scanner/adapters/block-device.ts
+++ b/lib/scanner/adapters/block-device.ts
@@ -114,7 +114,9 @@ export class BlockDeviceAdapter extends Adapter {
 					// Exclude system drives if needed
 					(this.includeSystemDrives() || !drive.isSystem) &&
 					// Exclude drives with no size
-					typeof drive.size === 'number'
+					typeof drive.size === 'number' &&
+					// Exclude virtual drives (DMG, TimeMachine, ... on macOS)
+					!drive.isVirtual
 				)
 			) {
 				continue;


### PR DESCRIPTION
Exclude drives with `isVirtual` flag set to `true`.

Once [drivelist#fix-is-virtual-macos](https://github.com/balena-io-modules/drivelist/pull/333) is merged then all mounted DMG images & TimeMachine disks should disappear from the drive list in etcher and it should fix https://github.com/balena-io/etcher/issues/2661 & https://github.com/balena-io/etcher/issues/2671.

Change-type: patch
Signed-off-by: Robert Vojta <robert@balena.io>