### PR TITLE
Make UsbbootDrive.usbDevice public again

### DIFF
--- a/lib/source-destination/usbboot.ts
+++ b/lib/source-destination/usbboot.ts
@@ -34,7 +34,7 @@ export class UsbbootDrive extends SourceDestination
 	public size = null;
 	public emitsProgress = true;
 
-	constructor(usbDevice: UsbbootDevice) {
+	constructor(public usbDevice: UsbbootDevice) {
 		super();
 		usbDevice.on('progress', this.emit.bind(this, 'progress'));
 	}


### PR DESCRIPTION
It was made private in 4499277eef906f54827bae7ba68f0b54e49ffaac

Change-type: patch