### PR TITLE
dependencies: use upstream xxhash again, now that Node12 support is merged

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -42,9 +42,7 @@ function blocksVerificationErrorMessage(
 	const lastBlock =
 		blocksWithChecksum.blocks[blocksWithChecksum.blocks.length - 1];
 	const end = lastBlock.offset + lastBlock.length - 1;
-	return `Checksum does not match for range [${start}, ${end}]: "${
-		blocksWithChecksum.checksum
-	}" != "${checksum}"`;
+	return `Checksum does not match for range [${start}, ${end}]: "${blocksWithChecksum.checksum}" != "${checksum}"`;
 }
 
 export class BlocksVerificationError extends VerificationError {

--- a/lib/source-destination/configured-source/configured-source.ts
+++ b/lib/source-destination/configured-source/configured-source.ts
@@ -227,9 +227,7 @@ export class ConfiguredSource extends SourceSource {
 		if (metadata.size !== undefined) {
 			const percentage = Math.round((discardedBytes / metadata.size) * 100);
 			debug(
-				`discarded ${
-					discards.length
-				} chunks, ${discardedBytes} bytes, ${percentage}% of the image`,
+				`discarded ${discards.length} chunks, ${discardedBytes} bytes, ${percentage}% of the image`,
 			);
 		}
 	}

--- a/lib/source-destination/source-destination.ts
+++ b/lib/source-destination/source-destination.ts
@@ -168,9 +168,7 @@ export class StreamVerifier extends Verifier {
 				this.emit(
 					'error',
 					new ChecksumVerificationError(
-						`Source and destination checksums do not match: ${
-							this.checksum
-						} !== ${streamChecksum}`,
+						`Source and destination checksums do not match: ${this.checksum} !== ${streamChecksum}`,
 						streamChecksum,
 						this.checksum,
 					),

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "udif": "^0.15.7",
     "unbzip2-stream": "balena-io-modules/unbzip2-stream#942fc218013c14adab01cf693b0500cf6ac83193",
     "unzip-stream": "^0.3.0",
-    "xxhash": "balena-io-modules/node-xxhash#cc9d14d8409cd81e77ca1cfd6bcf58cccb68435e",
+    "xxhash": "^0.3.0",
     "yauzl": "^2.9.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Previously we were using our own patched fork.
This is what we were waiting for: https://github.com/mscdex/node-xxhash/pull/30

Change-type: patch
Signed-off-by: Gergely Imreh <gergely@balena.io>