### PR TITLE
Update and typedoc / typedoc-plugin-markdown 

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,5 +1,6 @@
+[etcher-sdk](README.md)
 
-#  etcher-sdk
+# etcher-sdk
 
 ## Index
 
@@ -79,312 +80,287 @@
 
 ### Type aliases
 
-* [AnyHasher](#anyhasher)
-* [ChecksumType](#checksumtype)
-* [ConfigureFunction](#configurefunction)
-* [Constructor](#constructor)
-* [Name](#name)
-* [OnFailFunction](#onfailfunction)
-* [OnProgressFunction](#onprogressfunction)
-* [OperationCommand](#operationcommand)
-* [WriteStep](#writestep)
+* [AnyHasher](README.md#anyhasher)
+* [ChecksumType](README.md#checksumtype)
+* [ConfigureFunction](README.md#configurefunction)
+* [Constructor](README.md#constructor)
+* [Name](README.md#name)
+* [OnFailFunction](README.md#onfailfunction)
+* [OnProgressFunction](README.md#onprogressfunction)
+* [OperationCommand](README.md#operationcommand)
+* [WriteStep](README.md#writestep)
 
 ### Variables
 
-* [BITS](#bits)
-* [CHUNK_SIZE](#chunk_size)
-* [DEFAULT_BLOCK_SIZE](#default_block_size)
-* [DISKPART_DELAY](#diskpart_delay)
-* [DISKPART_RETRIES](#diskpart_retries)
-* [DriverlessDeviceAdapter](#driverlessdeviceadapter)
-* [ISIZE_LENGTH](#isize_length)
-* [MBR_LAST_PRIMARY_PARTITION](#mbr_last_primary_partition)
-* [NETWORK_SETTINGS_KEYS](#network_settings_keys)
-* [NO_MATCHING_FILE_MSG](#no_matching_file_msg)
-* [PARTITION_FIELDS](#partition_fields)
-* [PATTERN](#pattern)
-* [PROGRESS_EMISSION_INTERVAL](#progress_emission_interval)
-* [ProgressBlockReadStream](#progressblockreadstream)
-* [ProgressBlockWriteStream](#progressblockwritestream)
-* [ProgressHashStream](#progresshashstream)
-* [ProgressSparseWriteStream](#progresssparsewritestream)
-* [ProgressWritable](#progresswritable)
-* [ProgressWriteStream](#progresswritestream)
-* [RETRY_BASE_TIMEOUT](#retry_base_timeout)
-* [SCAN_INTERVAL](#scan_interval)
-* [TMP_DIR](#tmp_dir)
-* [TMP_RANDOM_BYTES](#tmp_random_bytes)
-* [TRIES](#tries)
-* [UNMOUNT_ON_SUCCESS_TIMEOUT_MS](#unmount_on_success_timeout_ms)
-* [USBBOOT_RPI_COMPUTE_MODULE_NAMES](#usbboot_rpi_compute_module_names)
-* [USE_ALIGNED_IO](#use_aligned_io)
-* [UsbbootScanner](#usbbootscanner)
-* [WIN32_FIRST_BYTES_TO_KEEP](#win32_first_bytes_to_keep)
-* [XXHASH_SEED](#xxhash_seed)
-* [debug](#debug)
-* [parseFileIndexAsync](#parsefileindexasync)
-* [unmountDiskAsync](#unmountdiskasync)
+* [BITS](README.md#const-bits)
+* [CHUNK_SIZE](README.md#const-chunk_size)
+* [DEFAULT_BLOCK_SIZE](README.md#const-default_block_size)
+* [DISKPART_DELAY](README.md#const-diskpart_delay)
+* [DISKPART_RETRIES](README.md#const-diskpart_retries)
+* [DriverlessDeviceAdapter](README.md#const-driverlessdeviceadapter)
+* [ISIZE_LENGTH](README.md#const-isize_length)
+* [MBR_LAST_PRIMARY_PARTITION](README.md#const-mbr_last_primary_partition)
+* [NETWORK_SETTINGS_KEYS](README.md#const-network_settings_keys)
+* [NO_MATCHING_FILE_MSG](README.md#const-no_matching_file_msg)
+* [PARTITION_FIELDS](README.md#const-partition_fields)
+* [PATTERN](README.md#const-pattern)
+* [PROGRESS_EMISSION_INTERVAL](README.md#const-progress_emission_interval)
+* [ProgressBlockReadStream](README.md#const-progressblockreadstream)
+* [ProgressBlockWriteStream](README.md#const-progressblockwritestream)
+* [ProgressHashStream](README.md#const-progresshashstream)
+* [ProgressSparseWriteStream](README.md#const-progresssparsewritestream)
+* [ProgressWritable](README.md#const-progresswritable)
+* [ProgressWriteStream](README.md#const-progresswritestream)
+* [RETRY_BASE_TIMEOUT](README.md#const-retry_base_timeout)
+* [SCAN_INTERVAL](README.md#const-scan_interval)
+* [TMP_DIR](README.md#const-tmp_dir)
+* [TMP_RANDOM_BYTES](README.md#const-tmp_random_bytes)
+* [TRIES](README.md#const-tries)
+* [UNMOUNT_ON_SUCCESS_TIMEOUT_MS](README.md#const-unmount_on_success_timeout_ms)
+* [USBBOOT_RPI_COMPUTE_MODULE_NAMES](README.md#const-usbboot_rpi_compute_module_names)
+* [USE_ALIGNED_IO](README.md#const-use_aligned_io)
+* [UsbbootScanner](README.md#let-usbbootscanner)
+* [WIN32_FIRST_BYTES_TO_KEEP](README.md#const-win32_first_bytes_to_keep)
+* [XXHASH_SEED](README.md#const-xxhash_seed)
+* [debug](README.md#const-debug)
+* [parseFileIndexAsync](README.md#const-parsefileindexasync)
+* [speedometer](README.md#speedometer)
+* [unbzip2Stream](README.md#unbzip2stream)
+* [unmountDiskAsync](README.md#const-unmountdiskasync)
+* [zlib](README.md#zlib)
 
 ### Functions
 
-* [asCallback](#ascallback)
-* [blockmapToBlocks](#blockmaptoblocks)
-* [blocksLength](#blockslength)
-* [blocksVerificationErrorMessage](#blocksverificationerrormessage)
-* [clean](#clean)
-* [close](#close)
-* [configure](#configure)
-* [copy](#copy)
-* [createHasher](#createhasher)
-* [createNetworkConfigFiles](#createnetworkconfigfiles)
-* [createSparseReaderStateIterator](#createsparsereaderstateiterator)
-* [difference](#difference)
-* [driveKey](#drivekey)
-* [execFileAsync](#execfileasync)
-* [execute](#execute)
-* [executeOperation](#executeoperation)
-* [fstat](#fstat)
-* [fsync](#fsync)
-* [getDiskDeviceType](#getdiskdevicetype)
-* [getEta](#geteta)
-* [getFileStreamFromZipStream](#getfilestreamfromzipstream)
-* [getPartitionIndex](#getpartitionindex)
-* [getRootStream](#getrootstream)
-* [isSourceTransform](#issourcetransform)
-* [isTransientError](#istransienterror)
-* [isntNull](#isntnull)
-* [looksLikeComputeModule](#lookslikecomputemodule)
-* [makeClassEmitProgressEvents](#makeclassemitprogressevents)
-* [matchSupportedExtensions](#matchsupportedextensions)
-* [nmWifiConfig](#nmwificonfig)
-* [open](#open)
-* [pad](#pad)
-* [pipeRegularSourceToDestination](#piperegularsourcetodestination)
-* [pipeSourceToDestinations](#pipesourcetodestinations)
-* [pipeSparseSourceToDestination](#pipesparsesourcetodestination)
-* [randomFilePath](#randomfilepath)
-* [read](#read)
-* [readFile](#readfile)
-* [require](#require)
-* [runDiskpart](#rundiskpart)
-* [runVerifier](#runverifier)
-* [sparseStreamToBuffer](#sparsestreamtobuffer)
-* [stat](#stat)
-* [streamToBuffer](#streamtobuffer)
-* [tmpFile](#tmpfile)
-* [tmpFileDisposer](#tmpfiledisposer)
-* [unlink](#unlink)
-* [verifyOrGenerateChecksum](#verifyorgeneratechecksum)
-* [write](#write)
-* [writeFile](#writefile)
+* [asCallback](README.md#ascallback)
+* [blockmapToBlocks](README.md#blockmaptoblocks)
+* [blocksLength](README.md#blockslength)
+* [blocksVerificationErrorMessage](README.md#blocksverificationerrormessage)
+* [clean](README.md#const-clean)
+* [close](README.md#close)
+* [configure](README.md#const-configure)
+* [copy](README.md#const-copy)
+* [createHasher](README.md#createhasher)
+* [createNetworkConfigFiles](README.md#const-createnetworkconfigfiles)
+* [createSparseReaderStateIterator](README.md#createsparsereaderstateiterator)
+* [difference](README.md#difference)
+* [driveKey](README.md#const-drivekey)
+* [execFileAsync](README.md#const-execfileasync)
+* [execute](README.md#const-execute)
+* [executeOperation](README.md#const-executeoperation)
+* [fstat](README.md#fstat)
+* [fsync](README.md#fsync)
+* [getDiskDeviceType](README.md#const-getdiskdevicetype)
+* [getEta](README.md#geteta)
+* [getFileStreamFromZipStream](README.md#const-getfilestreamfromzipstream)
+* [getPartitionIndex](README.md#const-getpartitionindex)
+* [getRootStream](README.md#getrootstream)
+* [isSourceTransform](README.md#issourcetransform)
+* [isTransientError](README.md#istransienterror)
+* [isntNull](README.md#isntnull)
+* [looksLikeComputeModule](README.md#lookslikecomputemodule)
+* [makeClassEmitProgressEvents](README.md#makeclassemitprogressevents)
+* [matchSupportedExtensions](README.md#matchsupportedextensions)
+* [nmWifiConfig](README.md#const-nmwificonfig)
+* [open](README.md#open)
+* [pad](README.md#const-pad)
+* [pipeRegularSourceToDestination](README.md#piperegularsourcetodestination)
+* [pipeSourceToDestinations](README.md#pipesourcetodestinations)
+* [pipeSparseSourceToDestination](README.md#pipesparsesourcetodestination)
+* [randomFilePath](README.md#const-randomfilepath)
+* [read](README.md#read)
+* [readFile](README.md#readfile)
+* [require](README.md#require)
+* [runDiskpart](README.md#const-rundiskpart)
+* [runVerifier](README.md#runverifier)
+* [sparseStreamToBuffer](README.md#sparsestreamtobuffer)
+* [stat](README.md#stat)
+* [streamToBuffer](README.md#streamtobuffer)
+* [tmpFile](README.md#const-tmpfile)
+* [tmpFileDisposer](README.md#const-tmpfiledisposer)
+* [unlink](README.md#unlink)
+* [verifyOrGenerateChecksum](README.md#verifyorgeneratechecksum)
+* [write](README.md#write)
+* [writeFile](README.md#writefile)
 
 ### Object literals
 
-* [ACTIONS](#actions)
-
----
+* [ACTIONS](README.md#const-actions)
 
 ## Type aliases
 
-<a id="anyhasher"></a>
-
 ###  AnyHasher
 
-**Ƭ AnyHasher**: *[CRC32Hasher](classes/crc32hasher.md) \| `Hash` \| `XXHash` \| `XXHash64`*
+Ƭ **AnyHasher**: *[CRC32Hasher](classes/crc32hasher.md) | Hash | XXHash | XXHash64*
 
-*Defined in [sparse-stream/shared.ts:66](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L66)*
+*Defined in [lib/sparse-stream/shared.ts:66](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L66)*
 
 ___
-<a id="checksumtype"></a>
 
 ###  ChecksumType
 
-**Ƭ ChecksumType**: *"crc32" \| "sha1" \| "sha256" \| "xxhash32" \| "xxhash64"*
+Ƭ **ChecksumType**: *"crc32" | "sha1" | "sha256" | "xxhash32" | "xxhash64"*
 
-*Defined in [sparse-stream/shared.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L26)*
+*Defined in [lib/sparse-stream/shared.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L26)*
 
 ___
-<a id="configurefunction"></a>
 
 ###  ConfigureFunction
 
-**Ƭ ConfigureFunction**: *`function`*
+Ƭ **ConfigureFunction**: *function*
 
-*Defined in [source-destination/configured-source/configured-source.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L41)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L41)*
 
-#### Type declaration
-▸(disk: *`Disk`*, config: *`any`*): `Promise`<`void`>
+#### Type declaration:
+
+▸ (`disk`: Disk, `config`: any): *Promise‹void›*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| disk | `Disk` |
-| config | `any` |
-
-**Returns:** `Promise`<`void`>
+Name | Type |
+------ | ------ |
+`disk` | Disk |
+`config` | any |
 
 ___
-<a id="constructor"></a>
 
 ###  Constructor
 
-**Ƭ Constructor**: *`object`*
+Ƭ **Constructor**: *object*
 
-*Defined in [source-destination/progress.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/progress.ts#L25)*
+*Defined in [lib/source-destination/progress.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/progress.ts#L25)*
 
-#### Type declaration
+#### Type declaration:
 
 ___
-<a id="name"></a>
 
 ###  Name
 
-**Ƭ Name**: *"balena" \| "resin"*
+Ƭ **Name**: *"balena" | "resin"*
 
-*Defined in [source-destination/balena-s3-source.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L25)*
+*Defined in [lib/source-destination/balena-s3-source.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L25)*
 
 ___
-<a id="onfailfunction"></a>
 
 ###  OnFailFunction
 
-**Ƭ OnFailFunction**: *`function`*
+Ƭ **OnFailFunction**: *function*
 
-*Defined in [multi-write.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L60)*
+*Defined in [lib/multi-write.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L60)*
 
-#### Type declaration
-▸(destination: *[SourceDestination](classes/sourcedestination.md)*, error: *`Error`*): `void`
+#### Type declaration:
+
+▸ (`destination`: [SourceDestination](classes/sourcedestination.md), `error`: [Error](classes/notcapable.md#static-error)): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| destination | [SourceDestination](classes/sourcedestination.md) |
-| error | `Error` |
-
-**Returns:** `void`
+Name | Type |
+------ | ------ |
+`destination` | [SourceDestination](classes/sourcedestination.md) |
+`error` | [Error](classes/notcapable.md#static-error) |
 
 ___
-<a id="onprogressfunction"></a>
 
 ###  OnProgressFunction
 
-**Ƭ OnProgressFunction**: *`function`*
+Ƭ **OnProgressFunction**: *function*
 
-*Defined in [multi-write.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L65)*
+*Defined in [lib/multi-write.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L65)*
 
-#### Type declaration
-▸(progress: *[MultiDestinationProgress](interfaces/multidestinationprogress.md)*): `void`
+#### Type declaration:
+
+▸ (`progress`: [MultiDestinationProgress](interfaces/multidestinationprogress.md)): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| progress | [MultiDestinationProgress](interfaces/multidestinationprogress.md) |
-
-**Returns:** `void`
+Name | Type |
+------ | ------ |
+`progress` | [MultiDestinationProgress](interfaces/multidestinationprogress.md) |
 
 ___
-<a id="operationcommand"></a>
 
 ###  OperationCommand
 
-**Ƭ OperationCommand**: *"configure" \| "copy"*
+Ƭ **OperationCommand**: *"configure" | "copy"*
 
-*Defined in [source-destination/configured-source/configure.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configure.ts#L28)*
+*Defined in [lib/source-destination/configured-source/configure.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configure.ts#L28)*
 
 ___
-<a id="writestep"></a>
 
 ###  WriteStep
 
-**Ƭ WriteStep**: *"flashing" \| "verifying" \| "finished"*
+Ƭ **WriteStep**: *"flashing" | "verifying" | "finished"*
 
-*Defined in [multi-write.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L34)*
-
-___
+*Defined in [lib/multi-write.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L34)*
 
 ## Variables
 
-<a id="bits"></a>
+### `Const` BITS
 
-### `<Const>` BITS
+• **BITS**: *64 | 32* = arch === 'x64' || arch === 'aarch64' ? 64 : 32
 
-**● BITS**: *`64` \| `32`* =  arch === 'x64' || arch === 'aarch64' ? 64 : 32
-
-*Defined in [source-destination/source-destination.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L45)*
+*Defined in [lib/source-destination/source-destination.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L45)*
 
 ___
-<a id="chunk_size"></a>
 
-### `<Const>` CHUNK_SIZE
+### `Const` CHUNK_SIZE
 
-**● CHUNK_SIZE**: *`number`* =  1024 ** 2
+• **CHUNK_SIZE**: *number* = 1024 ** 2
 
-*Defined in [constants.ts:19](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/constants.ts#L19)*
-
-___
-<a id="default_block_size"></a>
-
-### `<Const>` DEFAULT_BLOCK_SIZE
-
-**● DEFAULT_BLOCK_SIZE**: *`512`* = 512
-
-*Defined in [source-destination/block-device.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L41)*
+*Defined in [lib/constants.ts:19](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/constants.ts#L19)*
 
 ___
-<a id="diskpart_delay"></a>
 
-### `<Const>` DISKPART_DELAY
+### `Const` DEFAULT_BLOCK_SIZE
 
-**● DISKPART_DELAY**: *`2000`* = 2000
+• **DEFAULT_BLOCK_SIZE**: *512* = 512
 
-*Defined in [diskpart.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/diskpart.ts#L27)*
-
-___
-<a id="diskpart_retries"></a>
-
-### `<Const>` DISKPART_RETRIES
-
-**● DISKPART_RETRIES**: *`5`* = 5
-
-*Defined in [diskpart.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/diskpart.ts#L28)*
+*Defined in [lib/source-destination/block-device.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L41)*
 
 ___
-<a id="driverlessdeviceadapter"></a>
 
-### `<Const>` DriverlessDeviceAdapter
+### `Const` DISKPART_DELAY
 
-**● DriverlessDeviceAdapter**: *`undefined` \| [DriverlessDeviceAdapter$](classes/driverlessdeviceadapter_.md)* = 
-	platform === 'win32' ? DriverlessDeviceAdapter$ : undefined
+• **DISKPART_DELAY**: *2000* = 2000
 
-*Defined in [scanner/adapters/driverless.ts:100](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/driverless.ts#L100)*
+*Defined in [lib/diskpart.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/diskpart.ts#L27)*
 
 ___
-<a id="isize_length"></a>
 
-### `<Const>` ISIZE_LENGTH
+### `Const` DISKPART_RETRIES
 
-**● ISIZE_LENGTH**: *`4`* = 4
+• **DISKPART_RETRIES**: *5* = 5
 
-*Defined in [source-destination/gzip.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/gzip.ts#L23)*
-
-___
-<a id="mbr_last_primary_partition"></a>
-
-### `<Const>` MBR_LAST_PRIMARY_PARTITION
-
-**● MBR_LAST_PRIMARY_PARTITION**: *`4`* = 4
-
-*Defined in [source-destination/configured-source/configure.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configure.ts#L36)*
+*Defined in [lib/diskpart.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/diskpart.ts#L28)*
 
 ___
-<a id="network_settings_keys"></a>
 
-### `<Const>` NETWORK_SETTINGS_KEYS
+### `Const` DriverlessDeviceAdapter
 
-**● NETWORK_SETTINGS_KEYS**: *`string`[]* =  [
+• **DriverlessDeviceAdapter**: *undefined | [DriverlessDeviceAdapter$](classes/driverlessdeviceadapter_.md)* = platform === 'win32' ? DriverlessDeviceAdapter$ : undefined
+
+*Defined in [lib/scanner/adapters/driverless.ts:100](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/driverless.ts#L100)*
+
+___
+
+### `Const` ISIZE_LENGTH
+
+• **ISIZE_LENGTH**: *4* = 4
+
+*Defined in [lib/source-destination/gzip.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/gzip.ts#L23)*
+
+___
+
+### `Const` MBR_LAST_PRIMARY_PARTITION
+
+• **MBR_LAST_PRIMARY_PARTITION**: *4* = 4
+
+*Defined in [lib/source-destination/configured-source/configure.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configure.ts#L36)*
+
+___
+
+### `Const` NETWORK_SETTINGS_KEYS
+
+• **NETWORK_SETTINGS_KEYS**: *string[]* = [
 	'wifiSsid',
 	'wifiKey',
 	'ip',
@@ -393,120 +369,110 @@ ___
 	'routeMetric',
 ]
 
-*Defined in [source-destination/configured-source/operations/configure.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/operations/configure.ts#L23)*
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/operations/configure.ts#L23)*
 
 ___
-<a id="no_matching_file_msg"></a>
 
-### `<Const>` NO_MATCHING_FILE_MSG
+### `Const` NO_MATCHING_FILE_MSG
 
-**● NO_MATCHING_FILE_MSG**: *"Can&#x27;t find a matching file in this zip archive"* = "Can't find a matching file in this zip archive"
+• **NO_MATCHING_FILE_MSG**: *"Can't find a matching file in this zip archive"* = "Can't find a matching file in this zip archive"
 
-*Defined in [constants.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/constants.ts#L20)*
-
-___
-<a id="partition_fields"></a>
-
-### `<Const>` PARTITION_FIELDS
-
-**● PARTITION_FIELDS**: *`string`[]* =  ['partition', 'to.partition', 'from.partition']
-
-*Defined in [source-destination/configured-source/configure.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configure.ts#L35)*
+*Defined in [lib/constants.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/constants.ts#L20)*
 
 ___
-<a id="pattern"></a>
 
-### `<Const>` PATTERN
+### `Const` PARTITION_FIELDS
 
-**● PATTERN**: *`RegExp`* =  /PHYSICALDRIVE(\d+)/i
+• **PARTITION_FIELDS**: *string[]* = ['partition', 'to.partition', 'from.partition']
 
-*Defined in [diskpart.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/diskpart.ts#L29)*
-
-___
-<a id="progress_emission_interval"></a>
-
-### `<Const>` PROGRESS_EMISSION_INTERVAL
-
-**● PROGRESS_EMISSION_INTERVAL**: *`number`* =  1000 / 2
-
-*Defined in [constants.ts:17](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/constants.ts#L17)*
+*Defined in [lib/source-destination/configured-source/configure.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configure.ts#L35)*
 
 ___
-<a id="progressblockreadstream"></a>
 
-### `<Const>` ProgressBlockReadStream
+### `Const` PATTERN
 
-**● ProgressBlockReadStream**: *`(Anonymous class)` & [BlockReadStream](classes/blockreadstream.md)* =  makeClassEmitProgressEvents(
+• **PATTERN**: *RegExp‹›* = /PHYSICALDRIVE(\d+)/i
+
+*Defined in [lib/diskpart.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/diskpart.ts#L29)*
+
+___
+
+### `Const` PROGRESS_EMISSION_INTERVAL
+
+• **PROGRESS_EMISSION_INTERVAL**: *number* = 1000 / 2
+
+*Defined in [lib/constants.ts:17](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/constants.ts#L17)*
+
+___
+
+### `Const` ProgressBlockReadStream
+
+• **ProgressBlockReadStream**: *(Anonymous class) & [BlockReadStream](classes/blockreadstream.md)* = makeClassEmitProgressEvents(
 	BlockReadStream,
 	'bytesRead',
 	'bytesRead',
 	PROGRESS_EMISSION_INTERVAL,
 )
 
-*Defined in [block-read-stream.ts:98](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-read-stream.ts#L98)*
+*Defined in [lib/block-read-stream.ts:98](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-read-stream.ts#L98)*
 
 ___
-<a id="progressblockwritestream"></a>
 
-### `<Const>` ProgressBlockWriteStream
+### `Const` ProgressBlockWriteStream
 
-**● ProgressBlockWriteStream**: *`(Anonymous class)` & [BlockWriteStream](classes/blockwritestream.md)* =  makeClassEmitProgressEvents(
+• **ProgressBlockWriteStream**: *(Anonymous class) & [BlockWriteStream](classes/blockwritestream.md)* = makeClassEmitProgressEvents(
 	BlockWriteStream,
 	'bytesWritten',
 	'bytesWritten',
 	PROGRESS_EMISSION_INTERVAL,
 )
 
-*Defined in [block-write-stream.ts:170](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-write-stream.ts#L170)*
+*Defined in [lib/block-write-stream.ts:170](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-write-stream.ts#L170)*
 
 ___
-<a id="progresshashstream"></a>
 
-### `<Const>` ProgressHashStream
+### `Const` ProgressHashStream
 
-**● ProgressHashStream**: *`(Anonymous class)` & [CountingHashStream](classes/countinghashstream.md)* =  makeClassEmitProgressEvents(
+• **ProgressHashStream**: *(Anonymous class) & [CountingHashStream](classes/countinghashstream.md)* = makeClassEmitProgressEvents(
 	CountingHashStream,
 	'bytesWritten',
 	'bytesWritten',
 	PROGRESS_EMISSION_INTERVAL,
 )
 
-*Defined in [source-destination/source-destination.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L58)*
+*Defined in [lib/source-destination/source-destination.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L58)*
 
 ___
-<a id="progresssparsewritestream"></a>
 
-### `<Const>` ProgressSparseWriteStream
+### `Const` ProgressSparseWriteStream
 
-**● ProgressSparseWriteStream**: *`(Anonymous class)` & [SparseWriteStream](classes/sparsewritestream.md)* =  makeClassEmitProgressEvents(
+• **ProgressSparseWriteStream**: *(Anonymous class) & [SparseWriteStream](classes/sparsewritestream.md)* = makeClassEmitProgressEvents(
 	SparseWriteStream,
 	'bytesWritten',
 	'position',
 	PROGRESS_EMISSION_INTERVAL,
 )
 
-*Defined in [sparse-stream/sparse-write-stream.ts:120](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-write-stream.ts#L120)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:120](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-write-stream.ts#L120)*
 
 ___
-<a id="progresswritable"></a>
 
-### `<Const>` ProgressWritable
+### `Const` ProgressWritable
 
-**● ProgressWritable**: *`(Anonymous class)` & [CountingWritable](classes/countingwritable.md)* =  makeClassEmitProgressEvents(
+• **ProgressWritable**: *(Anonymous class) & [CountingWritable](classes/countingwritable.md)* = makeClassEmitProgressEvents(
 	CountingWritable,
 	'bytesWritten',
 	'position',
 	PROGRESS_EMISSION_INTERVAL,
 )
 
-*Defined in [source-destination/progress.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/progress.ts#L110)*
+*Defined in [lib/source-destination/progress.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/progress.ts#L110)*
 
 ___
-<a id="progresswritestream"></a>
 
-### `<Const>` ProgressWriteStream
+### `Const` ProgressWriteStream
 
-**● ProgressWriteStream**: *`any`* =  makeClassEmitProgressEvents(
+• **ProgressWriteStream**: *any* = makeClassEmitProgressEvents(
 	// type definitions for node 6 export fs.WriteStream as an interface, but it's a class.
 	// @ts-ignore
 	fs.WriteStream,
@@ -515,71 +481,65 @@ ___
 	PROGRESS_EMISSION_INTERVAL,
 )
 
-*Defined in [source-destination/file.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L36)*
+*Defined in [lib/source-destination/file.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L36)*
 
 ___
-<a id="retry_base_timeout"></a>
 
-### `<Const>` RETRY_BASE_TIMEOUT
+### `Const` RETRY_BASE_TIMEOUT
 
-**● RETRY_BASE_TIMEOUT**: *`100`* = 100
+• **RETRY_BASE_TIMEOUT**: *100* = 100
 
-*Defined in [constants.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/constants.ts#L18)*
-
-___
-<a id="scan_interval"></a>
-
-### `<Const>` SCAN_INTERVAL
-
-**● SCAN_INTERVAL**: *`1000`* = 1000
-
-*Defined in [scanner/adapters/block-device.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/block-device.ts#L27)*
-*Defined in [scanner/adapters/driverless.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/driverless.ts#L26)*
+*Defined in [lib/constants.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/constants.ts#L18)*
 
 ___
-<a id="tmp_dir"></a>
 
-### `<Const>` TMP_DIR
+### `Const` SCAN_INTERVAL
 
-**● TMP_DIR**: *`string`* =  tmpdir()
+• **SCAN_INTERVAL**: *1000* = 1000
 
-*Defined in [tmp.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/tmp.ts#L25)*
+*Defined in [lib/scanner/adapters/block-device.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/block-device.ts#L27)*
 
-___
-<a id="tmp_random_bytes"></a>
-
-### `<Const>` TMP_RANDOM_BYTES
-
-**● TMP_RANDOM_BYTES**: *`6`* = 6
-
-*Defined in [tmp.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/tmp.ts#L24)*
+*Defined in [lib/scanner/adapters/driverless.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/driverless.ts#L26)*
 
 ___
-<a id="tries"></a>
 
-### `<Const>` TRIES
+### `Const` TMP_DIR
 
-**● TRIES**: *`5`* = 5
+• **TMP_DIR**: *string* = tmpdir()
 
-*Defined in [tmp.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/tmp.ts#L26)*
-
-___
-<a id="unmount_on_success_timeout_ms"></a>
-
-### `<Const>` UNMOUNT_ON_SUCCESS_TIMEOUT_MS
-
-**● UNMOUNT_ON_SUCCESS_TIMEOUT_MS**: *`2000`* = 2000
-
-*Defined in [source-destination/block-device.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L40)*
-
-*__summary__*: Time, in milliseconds, to wait before unmounting on success
+*Defined in [lib/tmp.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/tmp.ts#L25)*
 
 ___
-<a id="usbboot_rpi_compute_module_names"></a>
 
-### `<Const>` USBBOOT_RPI_COMPUTE_MODULE_NAMES
+### `Const` TMP_RANDOM_BYTES
 
-**● USBBOOT_RPI_COMPUTE_MODULE_NAMES**: *`string`[]* =  [
+• **TMP_RANDOM_BYTES**: *6* = 6
+
+*Defined in [lib/tmp.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/tmp.ts#L24)*
+
+___
+
+### `Const` TRIES
+
+• **TRIES**: *5* = 5
+
+*Defined in [lib/tmp.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/tmp.ts#L26)*
+
+___
+
+### `Const` UNMOUNT_ON_SUCCESS_TIMEOUT_MS
+
+• **UNMOUNT_ON_SUCCESS_TIMEOUT_MS**: *2000* = 2000
+
+*Defined in [lib/source-destination/block-device.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L40)*
+
+**`summary`** Time, in milliseconds, to wait before unmounting on success
+
+___
+
+### `Const` USBBOOT_RPI_COMPUTE_MODULE_NAMES
+
+• **USBBOOT_RPI_COMPUTE_MODULE_NAMES**: *string[]* = [
 	'0001',
 	'RPi-MSD- 0001',
 	'File-Stor Gadget',
@@ -589,1063 +549,1146 @@ ___
 	'Linux File-Stor Gadget Media',
 ]
 
-*Defined in [scanner/adapters/block-device.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/block-device.ts#L28)*
+*Defined in [lib/scanner/adapters/block-device.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/block-device.ts#L28)*
 
 ___
-<a id="use_aligned_io"></a>
 
-### `<Const>` USE_ALIGNED_IO
+### `Const` USE_ALIGNED_IO
 
-**● USE_ALIGNED_IO**: *`boolean`* =  platform() === 'win32' || platform() === 'darwin'
+• **USE_ALIGNED_IO**: *boolean* = platform() === 'win32' || platform() === 'darwin'
 
-*Defined in [source-destination/block-device.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L43)*
-
-___
-<a id="usbbootscanner"></a>
-
-### `<Let>` UsbbootScanner
-
-**● UsbbootScanner**: *`UsbbootScanner` \| `undefined`*
-
-*Defined in [scanner/adapters/usbboot.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/usbboot.ts#L27)*
+*Defined in [lib/source-destination/block-device.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L43)*
 
 ___
-<a id="win32_first_bytes_to_keep"></a>
 
-### `<Const>` WIN32_FIRST_BYTES_TO_KEEP
+### `Let` UsbbootScanner
 
-**● WIN32_FIRST_BYTES_TO_KEEP**: *`number`* =  64 * 1024
+• **UsbbootScanner**: *typeof UsbbootScannerType | undefined*
 
-*Defined in [source-destination/block-device.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L42)*
-
-___
-<a id="xxhash_seed"></a>
-
-### `<Const>` XXHASH_SEED
-
-**● XXHASH_SEED**: *`1163150152`* = 1163150152
-
-*Defined in [constants.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/constants.ts#L22)*
+*Defined in [lib/scanner/adapters/usbboot.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/usbboot.ts#L27)*
 
 ___
-<a id="debug"></a>
 
-### `<Const>` debug
+### `Const` WIN32_FIRST_BYTES_TO_KEEP
 
-**● debug**: *`IDebugger`* =  _debug('etcher-sdk:configured-source')
+• **WIN32_FIRST_BYTES_TO_KEEP**: *number* = 64 * 1024
 
-*Defined in [diskpart.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/diskpart.ts#L25)*
-*Defined in [block-write-stream.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-write-stream.ts#L31)*
-*Defined in [scanner/adapters/block-device.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/block-device.ts#L25)*
-*Defined in [scanner/scanner.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/scanner.ts#L22)*
-*Defined in [source-destination/configured-source/configured-source.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L39)*
+*Defined in [lib/source-destination/block-device.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L42)*
 
 ___
-<a id="parsefileindexasync"></a>
 
-### `<Const>` parseFileIndexAsync
+### `Const` XXHASH_SEED
 
-**● parseFileIndexAsync**: *`function`* =  promisify(parseFileIndex)
+• **XXHASH_SEED**: *1163150152* = 1163150152
 
-*Defined in [source-destination/xz.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/xz.ts#L24)*
+*Defined in [lib/constants.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/constants.ts#L22)*
 
-#### Type declaration
-▸(arg1: *`A1`*): `Bluebird`<`T`>
+___
+
+### `Const` debug
+
+• **debug**: *IDebugger* = _debug('etcher-sdk:configured-source')
+
+*Defined in [lib/diskpart.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/diskpart.ts#L25)*
+
+*Defined in [lib/block-write-stream.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-write-stream.ts#L31)*
+
+*Defined in [lib/scanner/adapters/block-device.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/block-device.ts#L25)*
+
+*Defined in [lib/scanner/scanner.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/scanner.ts#L22)*
+
+*Defined in [lib/source-destination/configured-source/configured-source.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L39)*
+
+___
+
+### `Const` parseFileIndexAsync
+
+• **parseFileIndexAsync**: *function* = promisify(parseFileIndex)
+
+*Defined in [lib/source-destination/xz.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/xz.ts#L24)*
+
+#### Type declaration:
+
+▸ (`arg1`: A1): *Bluebird‹T›*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| arg1 | `A1` |
-
-**Returns:** `Bluebird`<`T`>
+Name | Type |
+------ | ------ |
+`arg1` | A1 |
 
 ___
-<a id="unmountdiskasync"></a>
 
-### `<Const>` unmountDiskAsync
+###  speedometer
 
-**● unmountDiskAsync**: *`function`* =  promisify(unmountDisk)
+• **speedometer**: *[speedometer](README.md#speedometer)*
 
-*Defined in [source-destination/block-device.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L45)*
+*Defined in [lib/source-destination/progress.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/progress.ts#L21)*
 
-#### Type declaration
-▸(arg1: *`A1`*): `Bluebird`<`T`>
+___
+
+###  unbzip2Stream
+
+• **unbzip2Stream**: *[unbzip2Stream](README.md#unbzip2stream)*
+
+*Defined in [lib/source-destination/bzip2.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/bzip2.ts#L18)*
+
+___
+
+### `Const` unmountDiskAsync
+
+• **unmountDiskAsync**: *function* = promisify(unmountDisk)
+
+*Defined in [lib/source-destination/block-device.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L45)*
+
+#### Type declaration:
+
+▸ (`arg1`: A1): *Bluebird‹T›*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| arg1 | `A1` |
-
-**Returns:** `Bluebird`<`T`>
+Name | Type |
+------ | ------ |
+`arg1` | A1 |
 
 ___
+
+###  zlib
+
+• **zlib**: *"zlib"*
+
+*Defined in [lib/stream-limiter.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/stream-limiter.ts#L18)*
 
 ## Functions
 
-<a id="ascallback"></a>
-
 ###  asCallback
 
-▸ **asCallback**(promise: *`Promise`<`any`>*, callback: *`function`*): `void`
+▸ **asCallback**(`promise`: Promise‹any›, `callback`: function): *void*
 
-*Defined in [utils.ts:64](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/utils.ts#L64)*
+*Defined in [lib/utils.ts:64](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/utils.ts#L64)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| promise | `Promise`<`any`> |
-| callback | `function` |
+▪ **promise**: *Promise‹any›*
 
-**Returns:** `void`
+▪ **callback**: *function*
+
+▸ (`error`: [Error](classes/notcapable.md#static-error) | void, `value?`: any): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`error` | [Error](classes/notcapable.md#static-error) &#124; void |
+`value?` | any |
+
+**Returns:** *void*
 
 ___
-<a id="blockmaptoblocks"></a>
 
 ###  blockmapToBlocks
 
-▸ **blockmapToBlocks**(blockmap: *`BlockMap`*): [BlocksWithChecksum](interfaces/blockswithchecksum.md)[]
+▸ **blockmapToBlocks**(`blockmap`: BlockMap): *[BlocksWithChecksum](interfaces/blockswithchecksum.md)[]*
 
-*Defined in [source-destination/zip.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L46)*
+*Defined in [lib/source-destination/zip.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L46)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| blockmap | `BlockMap` |
+Name | Type |
+------ | ------ |
+`blockmap` | BlockMap |
 
-**Returns:** [BlocksWithChecksum](interfaces/blockswithchecksum.md)[]
+**Returns:** *[BlocksWithChecksum](interfaces/blockswithchecksum.md)[]*
 
 ___
-<a id="blockslength"></a>
 
 ###  blocksLength
 
-▸ **blocksLength**(blocks: *[BlocksWithChecksum](interfaces/blockswithchecksum.md)[]*): `number`
+▸ **blocksLength**(`blocks`: [BlocksWithChecksum](interfaces/blockswithchecksum.md)[]): *number*
 
-*Defined in [sparse-stream/shared.ts:128](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L128)*
+*Defined in [lib/sparse-stream/shared.ts:128](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L128)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| blocks | [BlocksWithChecksum](interfaces/blockswithchecksum.md)[] |
+Name | Type |
+------ | ------ |
+`blocks` | [BlocksWithChecksum](interfaces/blockswithchecksum.md)[] |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="blocksverificationerrormessage"></a>
 
 ###  blocksVerificationErrorMessage
 
-▸ **blocksVerificationErrorMessage**(blocksWithChecksum: *[BlocksWithChecksum](interfaces/blockswithchecksum.md)*, checksum: *`string`*): `string`
+▸ **blocksVerificationErrorMessage**(`blocksWithChecksum`: [BlocksWithChecksum](interfaces/blockswithchecksum.md), `checksum`: string): *string*
 
-*Defined in [errors.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/errors.ts#L37)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| blocksWithChecksum | [BlocksWithChecksum](interfaces/blockswithchecksum.md) |
-| checksum | `string` |
-
-**Returns:** `string`
-
-___
-<a id="clean"></a>
-
-### `<Const>` clean
-
-▸ **clean**(device: *`string`*): `Promise`<`void`>
-
-*Defined in [diskpart.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/diskpart.ts#L86)*
+*Defined in [lib/errors.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/errors.ts#L37)*
 
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| device | `string` |  device path |
+Name | Type |
+------ | ------ |
+`blocksWithChecksum` | [BlocksWithChecksum](interfaces/blockswithchecksum.md) |
+`checksum` | string |
 
-**Returns:** `Promise`<`void`>
+**Returns:** *string*
 
 ___
-<a id="close"></a>
+
+### `Const` clean
+
+▸ **clean**(`device`: string): *Promise‹void›*
+
+*Defined in [lib/diskpart.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/diskpart.ts#L86)*
+
+**`summary`** Clean a device's partition tables
+
+**`example`** 
+diskpart.clean('\\\\.\\PhysicalDrive2')
+  .then(...)
+  .catch(...)
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`device` | string | device path |
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  close
 
-▸ **close**(fd: *`number`*): `Promise`<`void`>
+▸ **close**(`fd`: number): *Promise‹void›*
 
-*Defined in [fs.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/fs.ts#L20)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| fd | `number` |
-
-**Returns:** `Promise`<`void`>
-
-___
-<a id="configure"></a>
-
-### `<Const>` configure
-
-▸ **configure**(disk: *`Disk`*, options?: *`object`*): `Promise`<`void`>
-
-*Defined in [source-destination/configured-source/configure.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configure.ts#L87)*
+*Defined in [lib/fs.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/fs.ts#L20)*
 
 **Parameters:**
 
-**disk: `Disk`**
+Name | Type |
+------ | ------ |
+`fd` | number |
 
-**`Default value` options: `object`**
-
-| Name | Type |
-| ------ | ------ |
-| `Optional` config | `any` |
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="copy"></a>
 
-### `<Const>` copy
+### `Const` configure
 
-▸ **copy**(sourceFs: *`AsyncFsLike`*, sourcePath: *`string`*, destinationFs: *`AsyncFsLike`*, destinationPath: *`string`*): `Promise`<`void`>
+▸ **configure**(`disk`: Disk, `options`: object): *Promise‹void›*
 
-*Defined in [source-destination/configured-source/operations/copy.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/operations/copy.ts#L22)*
+*Defined in [lib/source-destination/configured-source/configure.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configure.ts#L87)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| sourceFs | `AsyncFsLike` |
-| sourcePath | `string` |
-| destinationFs | `AsyncFsLike` |
-| destinationPath | `string` |
+▪ **disk**: *Disk*
 
-**Returns:** `Promise`<`void`>
+▪`Default value`  **options**: *object*= {}
+
+Name | Type |
+------ | ------ |
+`config?` | any |
+
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createhasher"></a>
+
+### `Const` copy
+
+▸ **copy**(`sourceFs`: AsyncFsLike, `sourcePath`: string, `destinationFs`: AsyncFsLike, `destinationPath`: string): *Promise‹void›*
+
+*Defined in [lib/source-destination/configured-source/operations/copy.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/operations/copy.ts#L22)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`sourceFs` | AsyncFsLike |
+`sourcePath` | string |
+`destinationFs` | AsyncFsLike |
+`destinationPath` | string |
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  createHasher
 
-▸ **createHasher**(checksumType?: *[ChecksumType](#checksumtype)*): `undefined` \| [AnyHasher](#anyhasher)
+▸ **createHasher**(`checksumType?`: [ChecksumType](README.md#checksumtype)): *undefined | [AnyHasher](README.md#anyhasher)*
 
-*Defined in [sparse-stream/shared.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L68)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| `Optional` checksumType | [ChecksumType](#checksumtype) |
-
-**Returns:** `undefined` \| [AnyHasher](#anyhasher)
-
-___
-<a id="createnetworkconfigfiles"></a>
-
-### `<Const>` createNetworkConfigFiles
-
-▸ **createNetworkConfigFiles**(networks: *`any`*): `object`
-
-*Defined in [source-destination/configured-source/operations/configure.ts:95](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/operations/configure.ts#L95)*
+*Defined in [lib/sparse-stream/shared.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L68)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| networks | `any` |
+Name | Type |
+------ | ------ |
+`checksumType?` | [ChecksumType](README.md#checksumtype) |
 
-**Returns:** `object`
+**Returns:** *undefined | [AnyHasher](README.md#anyhasher)*
 
 ___
-<a id="createsparsereaderstateiterator"></a>
+
+### `Const` createNetworkConfigFiles
+
+▸ **createNetworkConfigFiles**(`networks`: any): *object*
+
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:95](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/operations/configure.ts#L95)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`networks` | any |
+
+**Returns:** *object*
+
+* **ethernet**: *any[]* = _(networks)
+			.map('configuration')
+			.filter()
+			.value()
+
+* **wifi**: *string[]* = _(networks)
+			.filter('wifiSsid')
+			.map((network, index) => {
+				return nmWifiConfig(index + 1, network);
+			})
+			.value()
+
+___
 
 ###  createSparseReaderStateIterator
 
-▸ **createSparseReaderStateIterator**(blocks: *[BlocksWithChecksum](interfaces/blockswithchecksum.md)[]*, verify: *`boolean`*, generateChecksums: *`boolean`*): `Iterator`<[SparseReaderState](interfaces/sparsereaderstate.md)>
+▸ **createSparseReaderStateIterator**(`blocks`: [BlocksWithChecksum](interfaces/blockswithchecksum.md)[], `verify`: boolean, `generateChecksums`: boolean): *Iterator‹[SparseReaderState](interfaces/sparsereaderstate.md)›*
 
-*Defined in [sparse-stream/shared.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L86)*
+*Defined in [lib/sparse-stream/shared.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L86)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| blocks | [BlocksWithChecksum](interfaces/blockswithchecksum.md)[] |
-| verify | `boolean` |
-| generateChecksums | `boolean` |
+Name | Type |
+------ | ------ |
+`blocks` | [BlocksWithChecksum](interfaces/blockswithchecksum.md)[] |
+`verify` | boolean |
+`generateChecksums` | boolean |
 
-**Returns:** `Iterator`<[SparseReaderState](interfaces/sparsereaderstate.md)>
+**Returns:** *Iterator‹[SparseReaderState](interfaces/sparsereaderstate.md)›*
 
 ___
-<a id="difference"></a>
 
 ###  difference
 
-▸ **difference**<`T`>(setA: *`Set`<`T`>*, setB: *`Set`<`T`>*): `Set`<`T`>
+▸ **difference**<**T**>(`setA`: Set‹T›, `setB`: Set‹T›): *Set‹T›*
 
-*Defined in [utils.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/utils.ts#L56)*
+*Defined in [lib/utils.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/utils.ts#L56)*
 
 **Type parameters:**
 
-#### T 
+▪ **T**
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| setA | `Set`<`T`> |
-| setB | `Set`<`T`> |
+Name | Type |
+------ | ------ |
+`setA` | Set‹T› |
+`setB` | Set‹T› |
 
-**Returns:** `Set`<`T`>
+**Returns:** *Set‹T›*
 
 ___
-<a id="drivekey"></a>
 
-### `<Const>` driveKey
+### `Const` driveKey
 
-▸ **driveKey**(drive: *`$Drive`*): `string`
+▸ **driveKey**(`drive`: $Drive): *string*
 
-*Defined in [scanner/adapters/block-device.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/block-device.ts#L47)*
+*Defined in [lib/scanner/adapters/block-device.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/block-device.ts#L47)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| drive | `$Drive` |
+Name | Type |
+------ | ------ |
+`drive` | $Drive |
 
-**Returns:** `string`
+**Returns:** *string*
 
 ___
-<a id="execfileasync"></a>
 
-### `<Const>` execFileAsync
+### `Const` execFileAsync
 
-▸ **execFileAsync**(command: *`string`*, args?: *`string`[]*, options?: *`ExecFileOptions`*): `Promise`<[ExecResult](interfaces/execresult.md)>
+▸ **execFileAsync**(`command`: string, `args`: string[], `options`: ExecFileOptions): *Promise‹[ExecResult](interfaces/execresult.md)›*
 
-*Defined in [diskpart.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/diskpart.ts#L36)*
+*Defined in [lib/diskpart.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/diskpart.ts#L36)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| command | `string` | - |
-| `Default value` args | `string`[] |  [] |
-| `Default value` options | `ExecFileOptions` |  {} |
+Name | Type | Default |
+------ | ------ | ------ |
+`command` | string | - |
+`args` | string[] | [] |
+`options` | ExecFileOptions | {} |
 
-**Returns:** `Promise`<[ExecResult](interfaces/execresult.md)>
+**Returns:** *Promise‹[ExecResult](interfaces/execresult.md)›*
 
 ___
-<a id="execute"></a>
 
-### `<Const>` execute
+### `Const` execute
 
-▸ **execute**(operation: *`any`*, disk: *`Disk`*): `Promise`<`void`>
+▸ **execute**(`operation`: any, `disk`: Disk): *Promise‹void›*
 
-▸ **execute**(operation: *`any`*, disk: *`Disk`*): `Promise`<`void`>
-
-*Defined in [source-destination/configured-source/operations/configure.ts:114](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/operations/configure.ts#L114)*
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:114](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/operations/configure.ts#L114)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| operation | `any` |
-| disk | `Disk` |
+Name | Type |
+------ | ------ |
+`operation` | any |
+`disk` | Disk |
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
-*Defined in [source-destination/configured-source/operations/copy.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/operations/copy.ts#L39)*
+▸ **execute**(`operation`: any, `disk`: Disk): *Promise‹void›*
+
+*Defined in [lib/source-destination/configured-source/operations/copy.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/operations/copy.ts#L39)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| operation | `any` |
-| disk | `Disk` |
+Name | Type |
+------ | ------ |
+`operation` | any |
+`disk` | Disk |
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="executeoperation"></a>
 
-### `<Const>` executeOperation
+### `Const` executeOperation
 
-▸ **executeOperation**(operation: *[Operation](interfaces/operation.md)*, disk: *`Disk`*): `Promise`<`void`>
+▸ **executeOperation**(`operation`: [Operation](interfaces/operation.md), `disk`: Disk): *Promise‹void›*
 
-*Defined in [source-destination/configured-source/configure.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configure.ts#L43)*
+*Defined in [lib/source-destination/configured-source/configure.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configure.ts#L43)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| operation | [Operation](interfaces/operation.md) |
-| disk | `Disk` |
+Name | Type |
+------ | ------ |
+`operation` | [Operation](interfaces/operation.md) |
+`disk` | Disk |
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="fstat"></a>
 
 ###  fstat
 
-▸ **fstat**(fd: *`number`*): `Promise`<`Stats`>
+▸ **fstat**(`fd`: number): *Promise‹Stats›*
 
-*Defined in [fs.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/fs.ts#L32)*
+*Defined in [lib/fs.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/fs.ts#L32)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| fd | `number` |
+Name | Type |
+------ | ------ |
+`fd` | number |
 
-**Returns:** `Promise`<`Stats`>
+**Returns:** *Promise‹Stats›*
 
 ___
-<a id="fsync"></a>
 
 ###  fsync
 
-▸ **fsync**(fd: *`number`*): `Promise`<`void`>
+▸ **fsync**(`fd`: number): *Promise‹void›*
 
-*Defined in [fs.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/fs.ts#L46)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| fd | `number` |
-
-**Returns:** `Promise`<`void`>
-
-___
-<a id="getdiskdevicetype"></a>
-
-### `<Const>` getDiskDeviceType
-
-▸ **getDiskDeviceType**(disk: *`Disk`*): `Promise`<`any`>
-
-*Defined in [source-destination/configured-source/configure.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configure.ts#L68)*
+*Defined in [lib/fs.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/fs.ts#L46)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| disk | `Disk` |
+Name | Type |
+------ | ------ |
+`fd` | number |
 
-**Returns:** `Promise`<`any`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="geteta"></a>
+
+### `Const` getDiskDeviceType
+
+▸ **getDiskDeviceType**(`disk`: Disk): *Promise‹any›*
+
+*Defined in [lib/source-destination/configured-source/configure.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configure.ts#L68)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`disk` | Disk |
+
+**Returns:** *Promise‹any›*
+
+___
 
 ###  getEta
 
-▸ **getEta**(current: *`number`*, total: *`number`*, speed: *`number`*): `number` \| `undefined`
+▸ **getEta**(`current`: number, `total`: number, `speed`: number): *number | undefined*
 
-*Defined in [multi-write.ts:72](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L72)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| current | `number` |
-| total | `number` |
-| speed | `number` |
-
-**Returns:** `number` \| `undefined`
-
-___
-<a id="getfilestreamfromzipstream"></a>
-
-### `<Const>` getFileStreamFromZipStream
-
-▸ **getFileStreamFromZipStream**(zipStream: *`ReadableStream`*, match: *`function`*): `Promise`<`ZipStreamEntry`>
-
-*Defined in [zip.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/zip.ts#L21)*
+*Defined in [lib/multi-write.ts:72](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L72)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| zipStream | `ReadableStream` |
-| match | `function` |
+Name | Type |
+------ | ------ |
+`current` | number |
+`total` | number |
+`speed` | number |
 
-**Returns:** `Promise`<`ZipStreamEntry`>
+**Returns:** *number | undefined*
 
 ___
-<a id="getpartitionindex"></a>
 
-### `<Const>` getPartitionIndex
+### `Const` getFileStreamFromZipStream
 
-▸ **getPartitionIndex**(partition: *`number` \| `object`*): `number`
+▸ **getFileStreamFromZipStream**(`zipStream`: ReadableStream, `match`: function): *Promise‹ZipStreamEntry›*
 
-*Defined in [source-destination/configured-source/configure.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configure.ts#L50)*
+*Defined in [lib/zip.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/zip.ts#L21)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| partition | `number` \| `object` |
+▪ **zipStream**: *ReadableStream*
 
-**Returns:** `number`
+▪ **match**: *function*
+
+▸ (`filename`: string): *boolean*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`filename` | string |
+
+**Returns:** *Promise‹ZipStreamEntry›*
 
 ___
-<a id="getrootstream"></a>
+
+### `Const` getPartitionIndex
+
+▸ **getPartitionIndex**(`partition`: number | object): *number*
+
+*Defined in [lib/source-destination/configured-source/configure.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configure.ts#L50)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`partition` | number &#124; object |
+
+**Returns:** *number*
+
+___
 
 ###  getRootStream
 
-▸ **getRootStream**(stream: *`ReadableStream`*): `ReadableStream`
+▸ **getRootStream**(`stream`: ReadableStream): *ReadableStream*
 
-*Defined in [source-destination/compressed-source.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L33)*
+*Defined in [lib/source-destination/compressed-source.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L33)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| stream | `ReadableStream` |
+Name | Type |
+------ | ------ |
+`stream` | ReadableStream |
 
-**Returns:** `ReadableStream`
+**Returns:** *ReadableStream*
 
 ___
-<a id="issourcetransform"></a>
 
 ###  isSourceTransform
 
-▸ **isSourceTransform**(stream: *`any`*): `boolean`
+▸ **isSourceTransform**(`stream`: any): *stream is SourceTransform*
 
-*Defined in [source-destination/compressed-source.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L29)*
+*Defined in [lib/source-destination/compressed-source.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L29)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| stream | `any` |
+Name | Type |
+------ | ------ |
+`stream` | any |
 
-**Returns:** `boolean`
+**Returns:** *stream is SourceTransform*
 
 ___
-<a id="istransienterror"></a>
 
 ###  isTransientError
 
-▸ **isTransientError**(error: *`ErrnoException`*): `boolean`
+▸ **isTransientError**(`error`: ErrnoException): *boolean*
 
-*Defined in [errors.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/errors.ts#L65)*
+*Defined in [lib/errors.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/errors.ts#L65)*
 
-*__summary__*: Determine whether an error is considered a transient occurrence, and the operation should be retried Errors considered potentially temporary are:
-
-*   Mac OS: ENXIO, EBUSY
-*   Windows: ENOENT, UNKNOWN
-*   Linux: EIO, EBUSY
+**`summary`** Determine whether an error is considered a
+transient occurrence, and the operation should be retried
+Errors considered potentially temporary are:
+  - Mac OS: ENXIO, EBUSY
+  - Windows: ENOENT, UNKNOWN
+  - Linux: EIO, EBUSY
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| error | `ErrnoException` |
+Name | Type |
+------ | ------ |
+`error` | ErrnoException |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="isntnull"></a>
 
 ###  isntNull
 
-▸ **isntNull**(x: *`any`*): `boolean`
+▸ **isntNull**(`x`: any): *boolean*
 
-*Defined in [source-destination/multi-destination.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L31)*
+*Defined in [lib/source-destination/multi-destination.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L31)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| x | `any` |
+Name | Type |
+------ | ------ |
+`x` | any |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="lookslikecomputemodule"></a>
 
 ###  looksLikeComputeModule
 
-▸ **looksLikeComputeModule**(description: *`string`*): `boolean`
+▸ **looksLikeComputeModule**(`description`: string): *boolean*
 
-*Defined in [scanner/adapters/block-device.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/block-device.ts#L38)*
+*Defined in [lib/scanner/adapters/block-device.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/block-device.ts#L38)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| description | `string` |
+Name | Type |
+------ | ------ |
+`description` | string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="makeclassemitprogressevents"></a>
 
 ###  makeClassEmitProgressEvents
 
-▸ **makeClassEmitProgressEvents**<`T`>(Cls: *`T`*, attribute: *`string`*, positionAttribute: *`string`*, interval: *`number`*): `(Anonymous class)` & `T`
+▸ **makeClassEmitProgressEvents**<**T**>(`Cls`: T, `attribute`: string, `positionAttribute`: string, `interval`: number): *(Anonymous class) & T*
 
-*Defined in [source-destination/progress.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/progress.ts#L33)*
+*Defined in [lib/source-destination/progress.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/progress.ts#L33)*
 
 **Type parameters:**
 
-#### T :  [Constructor](#constructor)<`EventEmitter`>
+▪ **T**: *[Constructor](README.md#constructor)‹EventEmitter›*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | `T` |
-| attribute | `string` |
-| positionAttribute | `string` |
-| interval | `number` |
+Name | Type |
+------ | ------ |
+`Cls` | T |
+`attribute` | string |
+`positionAttribute` | string |
+`interval` | number |
 
-**Returns:** `(Anonymous class)` & `T`
+**Returns:** *(Anonymous class) & T*
 
 ___
-<a id="matchsupportedextensions"></a>
 
 ###  matchSupportedExtensions
 
-▸ **matchSupportedExtensions**(filename: *`string`*): `boolean`
+▸ **matchSupportedExtensions**(`filename`: string): *boolean*
 
-*Defined in [source-destination/zip.ts:61](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L61)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| filename | `string` |
-
-**Returns:** `boolean`
-
-___
-<a id="nmwificonfig"></a>
-
-### `<Const>` nmWifiConfig
-
-▸ **nmWifiConfig**(index: *`number`*, options: *[WifiConfig](interfaces/wificonfig.md)*): `string`
-
-*Defined in [source-destination/configured-source/operations/configure.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/operations/configure.ts#L41)*
+*Defined in [lib/source-destination/zip.ts:61](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L61)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| index | `number` |
-| options | [WifiConfig](interfaces/wificonfig.md) |
+Name | Type |
+------ | ------ |
+`filename` | string |
 
-**Returns:** `string`
+**Returns:** *boolean*
 
 ___
-<a id="open"></a>
+
+### `Const` nmWifiConfig
+
+▸ **nmWifiConfig**(`index`: number, `options`: [WifiConfig](interfaces/wificonfig.md)): *string*
+
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/operations/configure.ts#L41)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`index` | number |
+`options` | [WifiConfig](interfaces/wificonfig.md) |
+
+**Returns:** *string*
+
+___
 
 ###  open
 
-▸ **open**(path: *`string` \| `Buffer`*, flags: *`string` \| `number`*, mode?: *`number`*): `Promise`<`number`>
+▸ **open**(`path`: string | Buffer, `flags`: string | number, `mode`: number): *Promise‹number›*
 
-*Defined in [fs.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/fs.ts#L58)*
-
-**Parameters:**
-
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| path | `string` \| `Buffer` | - |
-| flags | `string` \| `number` | - |
-| `Default value` mode | `number` | 438 |
-
-**Returns:** `Promise`<`number`>
-
-___
-<a id="pad"></a>
-
-### `<Const>` pad
-
-▸ **pad**(num: *`number`*): `string`
-
-*Defined in [source-destination/configured-source/operations/configure.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/operations/configure.ts#L110)*
+*Defined in [lib/fs.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/fs.ts#L58)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| num | `number` |
+Name | Type | Default |
+------ | ------ | ------ |
+`path` | string &#124; Buffer | - |
+`flags` | string &#124; number | - |
+`mode` | number | 438 |
 
-**Returns:** `string`
+**Returns:** *Promise‹number›*
 
 ___
-<a id="piperegularsourcetodestination"></a>
+
+### `Const` pad
+
+▸ **pad**(`num`: number): *string*
+
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/operations/configure.ts#L110)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`num` | number |
+
+**Returns:** *string*
+
+___
 
 ###  pipeRegularSourceToDestination
 
-▸ **pipeRegularSourceToDestination**(source: *[SourceDestination](classes/sourcedestination.md)*, sourceMetadata: *[Metadata](interfaces/metadata.md)*, destination: *[MultiDestination](classes/multidestination.md)*, verify: *`boolean`*, updateState: *`function`*, onFail: *`function`*, onProgress: *`function`*, _onRootStreamProgress: *`function`*): `Promise`<`void`>
+▸ **pipeRegularSourceToDestination**(`source`: [SourceDestination](classes/sourcedestination.md), `sourceMetadata`: [Metadata](interfaces/metadata.md), `destination`: [MultiDestination](classes/multidestination.md), `verify`: boolean, `updateState`: function, `onFail`: function, `onProgress`: function, `_onRootStreamProgress`: function): *Promise‹void›*
 
-*Defined in [multi-write.ts:218](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L218)*
+*Defined in [lib/multi-write.ts:218](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L218)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| source | [SourceDestination](classes/sourcedestination.md) |
-| sourceMetadata | [Metadata](interfaces/metadata.md) |
-| destination | [MultiDestination](classes/multidestination.md) |
-| verify | `boolean` |
-| updateState | `function` |
-| onFail | `function` |
-| onProgress | `function` |
-| _onRootStreamProgress | `function` |
+▪ **source**: *[SourceDestination](classes/sourcedestination.md)*
 
-**Returns:** `Promise`<`void`>
+▪ **sourceMetadata**: *[Metadata](interfaces/metadata.md)*
+
+▪ **destination**: *[MultiDestination](classes/multidestination.md)*
+
+▪ **verify**: *boolean*
+
+▪ **updateState**: *function*
+
+▸ (`state?`: [WriteStep](README.md#writestep)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`state?` | [WriteStep](README.md#writestep) |
+
+▪ **onFail**: *function*
+
+▸ (`error`: [MultiDestinationError](classes/multidestinationerror.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`error` | [MultiDestinationError](classes/multidestinationerror.md) |
+
+▪ **onProgress**: *function*
+
+▸ (`progress`: [ProgressEvent](interfaces/progressevent.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`progress` | [ProgressEvent](interfaces/progressevent.md) |
+
+▪ **_onRootStreamProgress**: *function*
+
+▸ (`progress`: [ProgressEvent](interfaces/progressevent.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`progress` | [ProgressEvent](interfaces/progressevent.md) |
+
+**Returns:** *Promise‹void›*
 
 ___
-<a id="pipesourcetodestinations"></a>
 
 ###  pipeSourceToDestinations
 
-▸ **pipeSourceToDestinations**(source: *[SourceDestination](classes/sourcedestination.md)*, destinations: *[SourceDestination](classes/sourcedestination.md)[]*, onFail: *[OnFailFunction](#onfailfunction)*, onProgress: *[OnProgressFunction](#onprogressfunction)*, verify?: *`boolean`*): `Promise`<[PipeSourceToDestinationsResult](interfaces/pipesourcetodestinationsresult.md)>
+▸ **pipeSourceToDestinations**(`source`: [SourceDestination](classes/sourcedestination.md), `destinations`: [SourceDestination](classes/sourcedestination.md)[], `onFail`: [OnFailFunction](README.md#onfailfunction), `onProgress`: [OnProgressFunction](README.md#onprogressfunction), `verify`: boolean): *Promise‹[PipeSourceToDestinationsResult](interfaces/pipesourcetodestinationsresult.md)›*
 
-*Defined in [multi-write.ts:82](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L82)*
+*Defined in [lib/multi-write.ts:82](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L82)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| source | [SourceDestination](classes/sourcedestination.md) | - |
-| destinations | [SourceDestination](classes/sourcedestination.md)[] | - |
-| onFail | [OnFailFunction](#onfailfunction) | - |
-| onProgress | [OnProgressFunction](#onprogressfunction) | - |
-| `Default value` verify | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`source` | [SourceDestination](classes/sourcedestination.md) | - |
+`destinations` | [SourceDestination](classes/sourcedestination.md)[] | - |
+`onFail` | [OnFailFunction](README.md#onfailfunction) | - |
+`onProgress` | [OnProgressFunction](README.md#onprogressfunction) | - |
+`verify` | boolean | false |
 
-**Returns:** `Promise`<[PipeSourceToDestinationsResult](interfaces/pipesourcetodestinationsresult.md)>
+**Returns:** *Promise‹[PipeSourceToDestinationsResult](interfaces/pipesourcetodestinationsresult.md)›*
 
 ___
-<a id="pipesparsesourcetodestination"></a>
 
 ###  pipeSparseSourceToDestination
 
-▸ **pipeSparseSourceToDestination**(source: *[SourceDestination](classes/sourcedestination.md)*, destination: *[SourceDestination](classes/sourcedestination.md)*, verify: *`boolean`*, updateState: *`function`*, onFail: *`function`*, onProgress: *`function`*, _onRootStreamProgress: *`function`*): `Promise`<`void`>
+▸ **pipeSparseSourceToDestination**(`source`: [SourceDestination](classes/sourcedestination.md), `destination`: [SourceDestination](classes/sourcedestination.md), `verify`: boolean, `updateState`: function, `onFail`: function, `onProgress`: function, `_onRootStreamProgress`: function): *Promise‹void›*
 
-*Defined in [multi-write.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L306)*
+*Defined in [lib/multi-write.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L306)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| source | [SourceDestination](classes/sourcedestination.md) |
-| destination | [SourceDestination](classes/sourcedestination.md) |
-| verify | `boolean` |
-| updateState | `function` |
-| onFail | `function` |
-| onProgress | `function` |
-| _onRootStreamProgress | `function` |
+▪ **source**: *[SourceDestination](classes/sourcedestination.md)*
 
-**Returns:** `Promise`<`void`>
+▪ **destination**: *[SourceDestination](classes/sourcedestination.md)*
+
+▪ **verify**: *boolean*
+
+▪ **updateState**: *function*
+
+▸ (`state?`: [WriteStep](README.md#writestep)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`state?` | [WriteStep](README.md#writestep) |
+
+▪ **onFail**: *function*
+
+▸ (`error`: [MultiDestinationError](classes/multidestinationerror.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`error` | [MultiDestinationError](classes/multidestinationerror.md) |
+
+▪ **onProgress**: *function*
+
+▸ (`progress`: [ProgressEvent](interfaces/progressevent.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`progress` | [ProgressEvent](interfaces/progressevent.md) |
+
+▪ **_onRootStreamProgress**: *function*
+
+▸ (`progress`: [ProgressEvent](interfaces/progressevent.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`progress` | [ProgressEvent](interfaces/progressevent.md) |
+
+**Returns:** *Promise‹void›*
 
 ___
-<a id="randomfilepath"></a>
 
-### `<Const>` randomFilePath
+### `Const` randomFilePath
 
-▸ **randomFilePath**(): `string`
+▸ **randomFilePath**(): *string*
 
-*Defined in [tmp.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/tmp.ts#L28)*
+*Defined in [lib/tmp.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/tmp.ts#L28)*
 
-**Returns:** `string`
+**Returns:** *string*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(fd: *`number`*, buf: *`Buffer`*, offset: *`number`*, length: *`number`*, position: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`fd`: number, `buf`: Buffer, `offset`: number, `length`: number, `position`: number): *Promise‹ReadResult›*
 
-*Defined in [fs.ts:76](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/fs.ts#L76)*
+*Defined in [lib/fs.ts:76](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/fs.ts#L76)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| fd | `number` |
-| buf | `Buffer` |
-| offset | `number` |
-| length | `number` |
-| position | `number` |
+Name | Type |
+------ | ------ |
+`fd` | number |
+`buf` | Buffer |
+`offset` | number |
+`length` | number |
+`position` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="readfile"></a>
 
 ###  readFile
 
-▸ **readFile**(path: *`string`*, options?: *`object` \| `undefined`*): `Promise`<`string` \| `Buffer`>
+▸ **readFile**(`path`: string, `options`: object | undefined): *Promise‹string | Buffer›*
 
-*Defined in [fs.ts:103](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/fs.ts#L103)*
+*Defined in [lib/fs.ts:103](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/fs.ts#L103)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| path | `string` | - |
-| `Default value` options | `object` \| `undefined` |  {encoding: null,flag: &#x27;r&#x27;,} |
+Name | Type | Default |
+------ | ------ | ------ |
+`path` | string | - |
+`options` | object &#124; undefined | {
+		encoding: null,
+		flag: 'r',
+	} |
 
-**Returns:** `Promise`<`string` \| `Buffer`>
+**Returns:** *Promise‹string | Buffer›*
 
 ___
-<a id="require"></a>
 
 ###  require
 
-▸ **require**(moduleName: *`string`*): `any`
+▸ **require**(`moduleName`: string): *any*
 
-*Defined in [scanner/adapters/usbboot.ts:17](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/usbboot.ts#L17)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| moduleName | `string` |
-
-**Returns:** `any`
-
-___
-<a id="rundiskpart"></a>
-
-### `<Const>` runDiskpart
-
-▸ **runDiskpart**(commands: *`string`[]*): `Promise`<`void`>
-
-*Defined in [diskpart.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/diskpart.ts#L63)*
+*Defined in [lib/scanner/adapters/usbboot.ts:17](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/usbboot.ts#L17)*
 
 **Parameters:**
 
-| Name | Type | Description |
-| ------ | ------ | ------ |
-| commands | `string`[] |  list of commands to run |
+Name | Type |
+------ | ------ |
+`moduleName` | string |
 
-**Returns:** `Promise`<`void`>
+**Returns:** *any*
 
 ___
-<a id="runverifier"></a>
+
+### `Const` runDiskpart
+
+▸ **runDiskpart**(`commands`: string[]): *Promise‹void›*
+
+*Defined in [lib/diskpart.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/diskpart.ts#L63)*
+
+**`summary`** Run a diskpart script
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`commands` | string[] | list of commands to run  |
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  runVerifier
 
-▸ **runVerifier**(verifier: *[Verifier](classes/verifier.md)*, onFail: *`function`*, onProgress: *`function`*): `Promise`<`void`>
+▸ **runVerifier**(`verifier`: [Verifier](classes/verifier.md), `onFail`: function, `onProgress`: function): *Promise‹void›*
 
-*Defined in [multi-write.ts:338](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L338)*
+*Defined in [lib/multi-write.ts:338](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L338)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| verifier | [Verifier](classes/verifier.md) |
-| onFail | `function` |
-| onProgress | `function` |
+▪ **verifier**: *[Verifier](classes/verifier.md)*
 
-**Returns:** `Promise`<`void`>
+▪ **onFail**: *function*
+
+▸ (`error`: [MultiDestinationError](classes/multidestinationerror.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`error` | [MultiDestinationError](classes/multidestinationerror.md) |
+
+▪ **onProgress**: *function*
+
+▸ (`progress`: [ProgressEvent](interfaces/progressevent.md)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`progress` | [ProgressEvent](interfaces/progressevent.md) |
+
+**Returns:** *Promise‹void›*
 
 ___
-<a id="sparsestreamtobuffer"></a>
 
 ###  sparseStreamToBuffer
 
-▸ **sparseStreamToBuffer**(stream: *`ReadableStream`*): `Promise`<`Buffer`>
+▸ **sparseStreamToBuffer**(`stream`: ReadableStream): *Promise‹Buffer›*
 
-*Defined in [utils.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/utils.ts#L36)*
+*Defined in [lib/utils.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/utils.ts#L36)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| stream | `ReadableStream` |
+Name | Type |
+------ | ------ |
+`stream` | ReadableStream |
 
-**Returns:** `Promise`<`Buffer`>
+**Returns:** *Promise‹Buffer›*
 
 ___
-<a id="stat"></a>
 
 ###  stat
 
-▸ **stat**(path: *`string` \| `Buffer`*): `Promise`<`Stats`>
+▸ **stat**(`path`: string | Buffer): *Promise‹Stats›*
 
-*Defined in [fs.ts:126](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/fs.ts#L126)*
+*Defined in [lib/fs.ts:126](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/fs.ts#L126)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| path | `string` \| `Buffer` |
+Name | Type |
+------ | ------ |
+`path` | string &#124; Buffer |
 
-**Returns:** `Promise`<`Stats`>
+**Returns:** *Promise‹Stats›*
 
 ___
-<a id="streamtobuffer"></a>
 
 ###  streamToBuffer
 
-▸ **streamToBuffer**(stream: *`ReadableStream`*): `Promise`<`Buffer`>
+▸ **streamToBuffer**(`stream`: ReadableStream): *Promise‹Buffer›*
 
-*Defined in [utils.ts:19](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/utils.ts#L19)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| stream | `ReadableStream` |
-
-**Returns:** `Promise`<`Buffer`>
-
-___
-<a id="tmpfile"></a>
-
-### `<Const>` tmpFile
-
-▸ **tmpFile**(keepOpen?: *`boolean`*): `Promise`<[TmpFileResult](interfaces/tmpfileresult.md)>
-
-*Defined in [tmp.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/tmp.ts#L37)*
+*Defined in [lib/utils.ts:19](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/utils.ts#L19)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` keepOpen | `boolean` | true |
+Name | Type |
+------ | ------ |
+`stream` | ReadableStream |
 
-**Returns:** `Promise`<[TmpFileResult](interfaces/tmpfileresult.md)>
+**Returns:** *Promise‹Buffer›*
 
 ___
-<a id="tmpfiledisposer"></a>
 
-### `<Const>` tmpFileDisposer
+### `Const` tmpFile
 
-▸ **tmpFileDisposer**(keepOpen?: *`boolean`*): `Disposer`<[TmpFileResult](interfaces/tmpfileresult.md)>
+▸ **tmpFile**(`keepOpen`: boolean): *Promise‹[TmpFileResult](interfaces/tmpfileresult.md)›*
 
-*Defined in [tmp.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/tmp.ts#L65)*
+*Defined in [lib/tmp.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/tmp.ts#L37)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` keepOpen | `boolean` | true |
+Name | Type | Default |
+------ | ------ | ------ |
+`keepOpen` | boolean | true |
 
-**Returns:** `Disposer`<[TmpFileResult](interfaces/tmpfileresult.md)>
+**Returns:** *Promise‹[TmpFileResult](interfaces/tmpfileresult.md)›*
 
 ___
-<a id="unlink"></a>
+
+### `Const` tmpFileDisposer
+
+▸ **tmpFileDisposer**(`keepOpen`: boolean): *Disposer‹[TmpFileResult](interfaces/tmpfileresult.md)›*
+
+*Defined in [lib/tmp.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/tmp.ts#L65)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`keepOpen` | boolean | true |
+
+**Returns:** *Disposer‹[TmpFileResult](interfaces/tmpfileresult.md)›*
+
+___
 
 ###  unlink
 
-▸ **unlink**(path: *`string` \| `Buffer`*): `Promise`<`void`>
+▸ **unlink**(`path`: string | Buffer): *Promise‹void›*
 
-*Defined in [fs.ts:156](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/fs.ts#L156)*
+*Defined in [lib/fs.ts:156](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/fs.ts#L156)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| path | `string` \| `Buffer` |
+Name | Type |
+------ | ------ |
+`path` | string &#124; Buffer |
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="verifyorgeneratechecksum"></a>
 
 ###  verifyOrGenerateChecksum
 
-▸ **verifyOrGenerateChecksum**(hasher: *[AnyHasher](#anyhasher) \| `undefined`*, blocks: *[BlocksWithChecksum](interfaces/blockswithchecksum.md)*, verify: *`boolean`*, generateChecksums: *`boolean`*): `void`
+▸ **verifyOrGenerateChecksum**(`hasher`: [AnyHasher](README.md#anyhasher) | undefined, `blocks`: [BlocksWithChecksum](interfaces/blockswithchecksum.md), `verify`: boolean, `generateChecksums`: boolean): *void*
 
-*Defined in [sparse-stream/shared.ts:112](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L112)*
+*Defined in [lib/sparse-stream/shared.ts:112](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L112)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| hasher | [AnyHasher](#anyhasher) \| `undefined` |
-| blocks | [BlocksWithChecksum](interfaces/blockswithchecksum.md) |
-| verify | `boolean` |
-| generateChecksums | `boolean` |
+Name | Type |
+------ | ------ |
+`hasher` | [AnyHasher](README.md#anyhasher) &#124; undefined |
+`blocks` | [BlocksWithChecksum](interfaces/blockswithchecksum.md) |
+`verify` | boolean |
+`generateChecksums` | boolean |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(fd: *`number`*, buf: *`Buffer`*, offset: *`number`*, length: *`number`*, position: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`fd`: number, `buf`: Buffer, `offset`: number, `length`: number, `position`: number): *Promise‹WriteResult›*
 
-*Defined in [fs.ts:168](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/fs.ts#L168)*
+*Defined in [lib/fs.ts:168](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/fs.ts#L168)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| fd | `number` |
-| buf | `Buffer` |
-| offset | `number` |
-| length | `number` |
-| position | `number` |
+Name | Type |
+------ | ------ |
+`fd` | number |
+`buf` | Buffer |
+`offset` | number |
+`length` | number |
+`position` | number |
 
-**Returns:** `Promise`<`WriteResult`>
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="writefile"></a>
 
 ###  writeFile
 
-▸ **writeFile**(path: *`string`*, data: *`string` \| `Buffer`*, options?: *`object`*): `Promise`<`void`>
+▸ **writeFile**(`path`: string, `data`: string | Buffer, `options`: object): *Promise‹void›*
 
-*Defined in [fs.ts:140](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/fs.ts#L140)*
+*Defined in [lib/fs.ts:140](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/fs.ts#L140)*
 
 **Parameters:**
 
-**path: `string`**
+▪ **path**: *string*
 
-**data: `string` \| `Buffer`**
+▪ **data**: *string | Buffer*
 
-**`Default value` options: `object`**
+▪`Default value`  **options**: *object*= { encoding: 'utf8', mode: 0o666, flag: 'w' }
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| encoding | `string` | &quot;utf8&quot; |
-| flag | `string` | &quot;w&quot; |
-| mode | `number` | 438 |
+Name | Type | Default |
+------ | ------ | ------ |
+`encoding` | string | "utf8" |
+`flag` | string | "w" |
+`mode` | number | 438 |
 
-**Returns:** `Promise`<`void`>
-
-___
+**Returns:** *Promise‹void›*
 
 ## Object literals
 
-<a id="actions"></a>
+### `Const` ACTIONS
 
-### `<Const>` ACTIONS
+### ▪ **ACTIONS**: *object*
 
-**ACTIONS**: *`object`*
+*Defined in [lib/source-destination/configured-source/configure.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configure.ts#L38)*
 
-*Defined in [source-destination/configured-source/configure.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configure.ts#L38)*
+###  configure
 
-<a id="actions.configure"></a>
+• **configure**: *execute* = configureAction
 
-####  configure
+*Defined in [lib/source-destination/configured-source/configure.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configure.ts#L39)*
 
-**● configure**: *[execute]()* =  configureAction
+###  copy
 
-*Defined in [source-destination/configured-source/configure.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configure.ts#L39)*
+• **copy**: *execute* = copyAction
 
-___
-<a id="actions.copy"></a>
-
-####  copy
-
-**● copy**: *[execute]()* =  copyAction
-
-*Defined in [source-destination/configured-source/configure.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configure.ts#L40)*
-
-___
-
-___
-
+*Defined in [lib/source-destination/configured-source/configure.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configure.ts#L40)*

--- a/doc/classes/adapter.md
+++ b/doc/classes/adapter.md
@@ -1,24 +1,24 @@
-[etcher-sdk](../README.md) > [Adapter](../classes/adapter.md)
+[etcher-sdk](../README.md) › [Adapter](adapter.md)
 
 # Class: Adapter
 
 ## Hierarchy
 
- `EventEmitter`
+* EventEmitter
 
-**↳ Adapter**
+  ↳ **Adapter**
 
-↳  [BlockDeviceAdapter](blockdeviceadapter.md)
+  ↳ [BlockDeviceAdapter](blockdeviceadapter.md)
 
-↳  [UsbbootDeviceAdapter](usbbootdeviceadapter.md)
+  ↳ [UsbbootDeviceAdapter](usbbootdeviceadapter.md)
 
-↳  [DriverlessDeviceAdapter$](driverlessdeviceadapter_.md)
+  ↳ [DriverlessDeviceAdapter$](driverlessdeviceadapter_.md)
 
 ## Index
 
 ### Properties
 
-* [defaultMaxListeners](adapter.md#defaultmaxlisteners)
+* [defaultMaxListeners](adapter.md#static-defaultmaxlisteners)
 
 ### Methods
 
@@ -35,336 +35,310 @@
 * [removeAllListeners](adapter.md#removealllisteners)
 * [removeListener](adapter.md#removelistener)
 * [setMaxListeners](adapter.md#setmaxlisteners)
-* [start](adapter.md#start)
-* [stop](adapter.md#stop)
-* [listenerCount](adapter.md#listenercount-1)
-
----
+* [start](adapter.md#abstract-start)
+* [stop](adapter.md#abstract-stop)
+* [listenerCount](adapter.md#static-listenercount)
 
 ## Properties
 
-<a id="defaultmaxlisteners"></a>
+### `Static` defaultMaxListeners
 
-### `<Static>` defaultMaxListeners
+▪ **defaultMaxListeners**: *number*
 
-**● defaultMaxListeners**: *`number`*
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
 
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
-
-___
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="addlistener"></a>
-
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
-
-**Returns:** `this`
-
-___
-<a id="start"></a>
-
-### `<Abstract>` start
-
-▸ **start**(): `void`
-
-*Defined in [scanner/adapters/adapter.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/adapter.ts#L34)*
-
-**Returns:** `void`
-
-___
-<a id="stop"></a>
-
-### `<Abstract>` stop
-
-▸ **stop**(): `void`
-
-*Defined in [scanner/adapters/adapter.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/adapter.ts#L35)*
-
-**Returns:** `void`
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `number`
+**Returns:** *this*
 
 ___
 
+### `Abstract` start
+
+▸ **start**(): *void*
+
+*Defined in [lib/scanner/adapters/adapter.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/adapter.ts#L34)*
+
+**Returns:** *void*
+
+___
+
+### `Abstract` stop
+
+▸ **stop**(): *void*
+
+*Defined in [lib/scanner/adapters/adapter.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/adapter.ts#L35)*
+
+**Returns:** *void*
+
+___
+
+### `Static` listenerCount
+
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
+
+Defined in node_modules/@types/node/base.d.ts:680
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
+
+**Returns:** *number*

--- a/doc/classes/balenas3source.md
+++ b/doc/classes/balenas3source.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [BalenaS3Source](../classes/balenas3source.md)
+[etcher-sdk](../README.md) › [BalenaS3Source](balenas3source.md)
 
 # Class: BalenaS3Source
 
 ## Hierarchy
 
-↳  [SourceDestination](sourcedestination.md)
+  ↳ [SourceDestination](sourcedestination.md)
 
-**↳ BalenaS3Source**
+  ↳ **BalenaS3Source**
 
 ## Index
 
@@ -20,20 +20,20 @@
 * [deviceType](balenas3source.md#devicetype)
 * [host](balenas3source.md#host)
 * [name](balenas3source.md#name)
-* [names](balenas3source.md#names)
-* [rawSource](balenas3source.md#rawsource)
-* [ready](balenas3source.md#ready)
+* [names](balenas3source.md#private-names)
+* [rawSource](balenas3source.md#private-rawsource)
+* [ready](balenas3source.md#private-ready)
 * [version](balenas3source.md#version)
-* [zipSource](balenas3source.md#zipsource)
-* [defaultMaxListeners](balenas3source.md#defaultmaxlisteners)
-* [imageExtensions](balenas3source.md#imageextensions)
-* [mimetype](balenas3source.md#mimetype)
+* [zipSource](balenas3source.md#private-zipsource)
+* [defaultMaxListeners](balenas3source.md#static-defaultmaxlisteners)
+* [imageExtensions](balenas3source.md#static-imageextensions)
+* [mimetype](balenas3source.md#static-optional-mimetype)
 
 ### Methods
 
-* [_close](balenas3source.md#_close)
-* [_getMetadata](balenas3source.md#_getmetadata)
-* [_open](balenas3source.md#_open)
+* [_close](balenas3source.md#protected-_close)
+* [_getMetadata](balenas3source.md#protected-_getmetadata)
+* [_open](balenas3source.md#protected-_open)
 * [addListener](balenas3source.md#addlistener)
 * [canCreateReadStream](balenas3source.md#cancreatereadstream)
 * [canCreateSparseReadStream](balenas3source.md#cancreatesparsereadstream)
@@ -53,15 +53,15 @@
 * [getInnerSource](balenas3source.md#getinnersource)
 * [getMaxListeners](balenas3source.md#getmaxlisteners)
 * [getMetadata](balenas3source.md#getmetadata)
-* [getName](balenas3source.md#getname)
+* [getName](balenas3source.md#private-getname)
 * [getPartitionTable](balenas3source.md#getpartitiontable)
-* [getUrl](balenas3source.md#geturl)
+* [getUrl](balenas3source.md#private-geturl)
 * [listenerCount](balenas3source.md#listenercount)
 * [listeners](balenas3source.md#listeners)
 * [on](balenas3source.md#on)
 * [once](balenas3source.md#once)
 * [open](balenas3source.md#open)
-* [prepare](balenas3source.md#prepare)
+* [prepare](balenas3source.md#private-prepare)
 * [prependListener](balenas3source.md#prependlistener)
 * [prependOnceListener](balenas3source.md#prependoncelistener)
 * [read](balenas3source.md#read)
@@ -69,133 +69,115 @@
 * [removeListener](balenas3source.md#removelistener)
 * [setMaxListeners](balenas3source.md#setmaxlisteners)
 * [write](balenas3source.md#write)
-* [listenerCount](balenas3source.md#listenercount-1)
-* [register](balenas3source.md#register)
-
----
+* [listenerCount](balenas3source.md#static-listenercount)
+* [register](balenas3source.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new BalenaS3Source**(bucket: *`string`*, deviceType: *`string`*, version: *`string`*, host?: *`string`*): [BalenaS3Source](balenas3source.md)
+\+ **new BalenaS3Source**(`bucket`: string, `deviceType`: string, `version`: string, `host`: string): *[BalenaS3Source](balenas3source.md)*
 
-*Defined in [source-destination/balena-s3-source.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L32)*
+*Defined in [lib/source-destination/balena-s3-source.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L32)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| bucket | `string` | - |
-| deviceType | `string` | - |
-| version | `string` | - |
-| `Default value` host | `string` | &quot;s3.amazonaws.com&quot; |
+Name | Type | Default |
+------ | ------ | ------ |
+`bucket` | string | - |
+`deviceType` | string | - |
+`version` | string | - |
+`host` | string | "s3.amazonaws.com" |
 
-**Returns:** [BalenaS3Source](balenas3source.md)
-
-___
+**Returns:** *[BalenaS3Source](balenas3source.md)*
 
 ## Properties
 
-<a id="bucket"></a>
-
 ###  bucket
 
-**● bucket**: *`string`*
+• **bucket**: *string*
 
-*Defined in [source-destination/balena-s3-source.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L35)*
+*Defined in [lib/source-destination/balena-s3-source.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L35)*
 
 ___
-<a id="devicetype"></a>
 
 ###  deviceType
 
-**● deviceType**: *`string`*
+• **deviceType**: *string*
 
-*Defined in [source-destination/balena-s3-source.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L36)*
+*Defined in [lib/source-destination/balena-s3-source.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L36)*
 
 ___
-<a id="host"></a>
 
 ###  host
 
-**● host**: *`string`*
+• **host**: *string*
 
-*Defined in [source-destination/balena-s3-source.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L38)*
+*Defined in [lib/source-destination/balena-s3-source.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L38)*
 
 ___
-<a id="name"></a>
 
 ###  name
 
-**● name**: *[Name](../#name)*
+• **name**: *[Name](../README.md#name)*
 
-*Defined in [source-destination/balena-s3-source.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L32)*
-
-___
-<a id="names"></a>
-
-### `<Private>` names
-
-**● names**: *[Name](../#name)[]* =  ['balena', 'resin']
-
-*Defined in [source-destination/balena-s3-source.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L31)*
+*Defined in [lib/source-destination/balena-s3-source.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L32)*
 
 ___
-<a id="rawsource"></a>
 
-### `<Private>` rawSource
+### `Private` names
 
-**● rawSource**: *[Http](http.md)*
+• **names**: *[Name](../README.md#name)[]* = ['balena', 'resin']
 
-*Defined in [source-destination/balena-s3-source.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L28)*
-
-___
-<a id="ready"></a>
-
-### `<Private>` ready
-
-**● ready**: *`Promise`<`void`>*
-
-*Defined in [source-destination/balena-s3-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L30)*
+*Defined in [lib/source-destination/balena-s3-source.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L31)*
 
 ___
-<a id="version"></a>
+
+### `Private` rawSource
+
+• **rawSource**: *[Http](http.md)*
+
+*Defined in [lib/source-destination/balena-s3-source.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L28)*
+
+___
+
+### `Private` ready
+
+• **ready**: *Promise‹void›*
+
+*Defined in [lib/source-destination/balena-s3-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L30)*
+
+___
 
 ###  version
 
-**● version**: *`string`*
+• **version**: *string*
 
-*Defined in [source-destination/balena-s3-source.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L37)*
-
-___
-<a id="zipsource"></a>
-
-### `<Private>` zipSource
-
-**● zipSource**: *[ZipSource](zipsource.md)*
-
-*Defined in [source-destination/balena-s3-source.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L29)*
+*Defined in [lib/source-destination/balena-s3-source.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L37)*
 
 ___
-<a id="defaultmaxlisteners"></a>
 
-### `<Static>` defaultMaxListeners
+### `Private` zipSource
 
-**● defaultMaxListeners**: *`number`*
+• **zipSource**: *[ZipSource](zipsource.md)*
 
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/balena-s3-source.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L29)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Static` defaultMaxListeners
 
-**● imageExtensions**: *`string`[]* =  [
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -208,692 +190,645 @@ ___
 		'wic',
 	]
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
-
-___
-<a id="mimetype"></a>
-
-### `<Static>``<Optional>` mimetype
-
-**● mimetype**: *`undefined` \| `string`*
-
-*Inherited from [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
-
-*Defined in [source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L244)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
+
+### `Static` `Optional` mimetype
+
+▪ **mimetype**? : *undefined | string*
+
+*Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
+
+*Defined in [lib/source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L244)*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#_close)*
+*Defined in [lib/source-destination/balena-s3-source.ts:117](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L117)*
 
-*Defined in [source-destination/balena-s3-source.ts:117](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L117)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Overrides [SourceDestination](sourcedestination.md).[_getMetadata](sourcedestination.md#_getmetadata)*
+*Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [source-destination/balena-s3-source.ts:107](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L107)*
+*Defined in [lib/source-destination/balena-s3-source.ts:107](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L107)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#_open)*
-
-*Defined in [source-destination/balena-s3-source.ts:112](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L112)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
+
+*Defined in [lib/source-destination/balena-s3-source.ts:112](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L112)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/balena-s3-source.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L71)*
+*Defined in [lib/source-destination/balena-s3-source.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L71)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L268)*
+*Defined in [lib/source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L268)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseWriteStream](sourcedestination.md#cancreatesparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L276)*
+*Defined in [lib/source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L276)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateWriteStream](sourcedestination.md#cancreatewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L272)*
+*Defined in [lib/source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L272)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Overrides [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/balena-s3-source.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L75)*
+*Defined in [lib/source-destination/balena-s3-source.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L75)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canWrite](sourcedestination.md#canwrite)*
+*Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L260)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(...args: *`any`[]*): `Promise`<`ReadableStream`>
+▸ **createReadStream**(...`args`: any[]): *Promise‹ReadableStream›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/balena-s3-source.ts:100](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L100)*
+*Defined in [lib/source-destination/balena-s3-source.ts:100](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L100)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`...args` | any[] |
 
-**Returns:** `Promise`<`ReadableStream`>
+**Returns:** *Promise‹ReadableStream›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(_generateChecksums?: *`boolean`*): `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+▸ **createSparseReadStream**(`_generateChecksums`: boolean): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L317)*
+*Defined in [lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L317)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _generateChecksums | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`_generateChecksums` | boolean | false |
 
-**Returns:** `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseWriteStream](sourcedestination.md#createsparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L331)*
+*Defined in [lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L331)*
 
-**Returns:** `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+**Returns:** *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
 ___
-<a id="createverifier"></a>
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createWriteStream](sourcedestination.md#createwritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L327)*
+*Defined in [lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L327)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="getname"></a>
-
-### `<Private>` getName
-
-▸ **getName**(): `Promise`<[Name](../#name)>
-
-*Defined in [source-destination/balena-s3-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L57)*
-
-**Returns:** `Promise`<[Name](../#name)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
+
+### `Private` getName
+
+▸ **getName**(): *Promise‹[Name](../README.md#name)›*
+
+*Defined in [lib/source-destination/balena-s3-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L57)*
+
+**Returns:** *Promise‹[Name](../README.md#name)›*
+
+___
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="geturl"></a>
 
-### `<Private>` getUrl
+### `Private` getUrl
 
-▸ **getUrl**(path: *`string`*): `string`
+▸ **getUrl**(`path`: string): *string*
 
-*Defined in [source-destination/balena-s3-source.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L79)*
+*Defined in [lib/source-destination/balena-s3-source.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L79)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| path | `string` |
+Name | Type |
+------ | ------ |
+`path` | string |
 
-**Returns:** `string`
+**Returns:** *string*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
-
-___
-<a id="prepare"></a>
-
-### `<Private>` prepare
-
-▸ **prepare**(): `Promise`<`void`>
-
-*Defined in [source-destination/balena-s3-source.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L48)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
+
+### `Private` prepare
+
+▸ **prepare**(): *Promise‹void›*
+
+*Defined in [lib/source-destination/balena-s3-source.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L48)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(buffer: *`Buffer`*, bufferOffset: *`number`*, length: *`number`*, sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`buffer`: Buffer, `bufferOffset`: number, `length`: number, `sourceOffset`: number): *Promise‹ReadResult›*
 
-*Overrides [SourceDestination](sourcedestination.md).[read](sourcedestination.md#read)*
+*Overrides [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [source-destination/balena-s3-source.ts:85](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/balena-s3-source.ts#L85)*
+*Defined in [lib/source-destination/balena-s3-source.ts:85](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/balena-s3-source.ts#L85)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| bufferOffset | `number` |
-| length | `number` |
-| sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
+`bufferOffset` | number |
+`length` | number |
+`sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[write](sourcedestination.md#write)*
+*Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L300)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L300)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/classes/blockdevice.md
+++ b/doc/classes/blockdevice.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [BlockDevice](../classes/blockdevice.md)
+[etcher-sdk](../README.md) › [BlockDevice](blockdevice.md)
 
 # Class: BlockDevice
 
 ## Hierarchy
 
-↳  [File](file.md)
+  ↳ [File](file.md)
 
-**↳ BlockDevice**
+  ↳ **BlockDevice**
 
 ## Implements
 
@@ -21,14 +21,14 @@
 ### Properties
 
 * [blockSize](blockdevice.md#blocksize)
-* [drive](blockdevice.md#drive)
+* [drive](blockdevice.md#private-drive)
 * [emitsProgress](blockdevice.md#emitsprogress)
-* [fd](blockdevice.md#fd)
-* [unmountOnSuccess](blockdevice.md#unmountonsuccess)
-* [OpenFlags](blockdevice.md#openflags)
-* [defaultMaxListeners](blockdevice.md#defaultmaxlisteners)
-* [imageExtensions](blockdevice.md#imageextensions)
-* [mimetype](blockdevice.md#mimetype)
+* [fd](blockdevice.md#protected-fd)
+* [unmountOnSuccess](blockdevice.md#private-unmountonsuccess)
+* [OpenFlags](blockdevice.md#static-openflags)
+* [defaultMaxListeners](blockdevice.md#static-defaultmaxlisteners)
+* [imageExtensions](blockdevice.md#static-imageextensions)
+* [mimetype](blockdevice.md#static-optional-mimetype)
 
 ### Accessors
 
@@ -42,14 +42,14 @@
 
 ### Methods
 
-* [_close](blockdevice.md#_close)
-* [_getMetadata](blockdevice.md#_getmetadata)
-* [_open](blockdevice.md#_open)
+* [_close](blockdevice.md#protected-_close)
+* [_getMetadata](blockdevice.md#protected-_getmetadata)
+* [_open](blockdevice.md#protected-_open)
 * [addListener](blockdevice.md#addlistener)
-* [alignOffsetAfter](blockdevice.md#alignoffsetafter)
-* [alignOffsetBefore](blockdevice.md#alignoffsetbefore)
-* [alignedRead](blockdevice.md#alignedread)
-* [alignedWrite](blockdevice.md#alignedwrite)
+* [alignOffsetAfter](blockdevice.md#private-alignoffsetafter)
+* [alignOffsetBefore](blockdevice.md#private-alignoffsetbefore)
+* [alignedRead](blockdevice.md#private-alignedread)
+* [alignedWrite](blockdevice.md#private-alignedwrite)
 * [canCreateReadStream](blockdevice.md#cancreatereadstream)
 * [canCreateSparseReadStream](blockdevice.md#cancreatesparsereadstream)
 * [canCreateSparseWriteStream](blockdevice.md#cancreatesparsewritestream)
@@ -71,7 +71,7 @@
 * [getPartitionTable](blockdevice.md#getpartitiontable)
 * [listenerCount](blockdevice.md#listenercount)
 * [listeners](blockdevice.md#listeners)
-* [offsetIsAligned](blockdevice.md#offsetisaligned)
+* [offsetIsAligned](blockdevice.md#private-offsetisaligned)
 * [on](blockdevice.md#on)
 * [once](blockdevice.md#once)
 * [open](blockdevice.md#open)
@@ -82,116 +82,101 @@
 * [removeListener](blockdevice.md#removelistener)
 * [setMaxListeners](blockdevice.md#setmaxlisteners)
 * [write](blockdevice.md#write)
-* [listenerCount](blockdevice.md#listenercount-1)
-* [register](blockdevice.md#register)
-
----
+* [listenerCount](blockdevice.md#static-listenercount)
+* [register](blockdevice.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new BlockDevice**(drive: *[DrivelistDrive](../interfaces/drivelistdrive.md)*, unmountOnSuccess?: *`boolean`*): [BlockDevice](blockdevice.md)
+\+ **new BlockDevice**(`drive`: [DrivelistDrive](../interfaces/drivelistdrive.md), `unmountOnSuccess`: boolean): *[BlockDevice](blockdevice.md)*
 
 *Overrides [File](file.md).[constructor](file.md#constructor)*
 
-*Defined in [source-destination/block-device.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L48)*
+*Defined in [lib/source-destination/block-device.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L48)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| drive | [DrivelistDrive](../interfaces/drivelistdrive.md) | - |
-| `Default value` unmountOnSuccess | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`drive` | [DrivelistDrive](../interfaces/drivelistdrive.md) | - |
+`unmountOnSuccess` | boolean | false |
 
-**Returns:** [BlockDevice](blockdevice.md)
-
-___
+**Returns:** *[BlockDevice](blockdevice.md)*
 
 ## Properties
 
-<a id="blocksize"></a>
-
 ###  blockSize
 
-**● blockSize**: *`number`* = 512
+• **blockSize**: *number* = 512
 
 *Inherited from [File](file.md).[blockSize](file.md#blocksize)*
 
-*Defined in [source-destination/file.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L58)*
+*Defined in [lib/source-destination/file.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L58)*
 
 ___
-<a id="drive"></a>
 
-### `<Private>` drive
+### `Private` drive
 
-**● drive**: *[DrivelistDrive](../interfaces/drivelistdrive.md)*
+• **drive**: *[DrivelistDrive](../interfaces/drivelistdrive.md)*
 
-*Defined in [source-destination/block-device.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L50)*
+*Defined in [lib/source-destination/block-device.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L50)*
 
 ___
-<a id="emitsprogress"></a>
 
 ###  emitsProgress
 
-**● emitsProgress**: *`boolean`* = false
+• **emitsProgress**: *boolean* = false
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[emitsProgress](../interfaces/adaptersourcedestination.md#emitsprogress)*
 
-*Defined in [source-destination/block-device.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L48)*
+*Defined in [lib/source-destination/block-device.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L48)*
 
 ___
-<a id="fd"></a>
 
-### `<Protected>` fd
+### `Protected` fd
 
-**● fd**: *`number`*
+• **fd**: *number*
 
-*Inherited from [File](file.md).[fd](file.md#fd)*
+*Inherited from [File](file.md).[fd](file.md#protected-fd)*
 
-*Defined in [source-destination/file.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L57)*
-
-___
-<a id="unmountonsuccess"></a>
-
-### `<Private>` unmountOnSuccess
-
-**● unmountOnSuccess**: *`boolean`*
-
-*Defined in [source-destination/block-device.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L50)*
+*Defined in [lib/source-destination/file.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L57)*
 
 ___
-<a id="openflags"></a>
 
-### `<Static>` OpenFlags
+### `Private` unmountOnSuccess
 
-**● OpenFlags**: *[OpenFlags](../enums/openflags.md)* =  OpenFlags
+• **unmountOnSuccess**: *boolean*
 
-*Inherited from [File](file.md).[OpenFlags](file.md#openflags)*
-
-*Defined in [source-destination/file.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L56)*
+*Defined in [lib/source-destination/block-device.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L50)*
 
 ___
-<a id="defaultmaxlisteners"></a>
 
-### `<Static>` defaultMaxListeners
+### `Static` OpenFlags
 
-**● defaultMaxListeners**: *`number`*
+▪ **OpenFlags**: *[OpenFlags](../enums/openflags.md)* = OpenFlags
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[defaultMaxListeners](../interfaces/adaptersourcedestination.md#defaultmaxlisteners)*
+*Inherited from [File](file.md).[OpenFlags](file.md#static-openflags)*
 
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/file.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L56)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Static` defaultMaxListeners
 
-**● imageExtensions**: *`string`[]* =  [
+▪ **defaultMaxListeners**: *number*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[defaultMaxListeners](../interfaces/adaptersourcedestination.md#static-defaultmaxlisteners)*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -204,910 +189,851 @@ ___
 		'wic',
 	]
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[imageExtensions](../interfaces/adaptersourcedestination.md#imageextensions)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[imageExtensions](../interfaces/adaptersourcedestination.md#static-imageextensions)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
-
-___
-<a id="mimetype"></a>
-
-### `<Static>``<Optional>` mimetype
-
-**● mimetype**: *`undefined` \| `string`*
-
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[mimetype](../interfaces/adaptersourcedestination.md#mimetype)*
-
-*Inherited from [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
-
-*Defined in [source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L244)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
+
+### `Static` `Optional` mimetype
+
+▪ **mimetype**? : *undefined | string*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[mimetype](../interfaces/adaptersourcedestination.md#static-optional-mimetype)*
+
+*Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
+
+*Defined in [lib/source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L244)*
 
 ## Accessors
 
-<a id="description"></a>
-
 ###  description
 
-**get description**(): `string`
+• **get description**(): *string*
 
-*Defined in [source-destination/block-device.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L71)*
+*Defined in [lib/source-destination/block-device.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L71)*
 
-**Returns:** `string`
+**Returns:** *string*
 
 ___
-<a id="device"></a>
 
 ###  device
 
-**get device**(): `string`
+• **get device**(): *string*
 
-*Defined in [source-destination/block-device.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L63)*
+*Defined in [lib/source-destination/block-device.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L63)*
 
-**Returns:** `string`
+**Returns:** *string*
 
 ___
-<a id="devicepath"></a>
 
 ###  devicePath
 
-**get devicePath**(): `string` \| `null`
+• **get devicePath**(): *string | null*
 
-*Defined in [source-destination/block-device.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L67)*
+*Defined in [lib/source-destination/block-device.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L67)*
 
-**Returns:** `string` \| `null`
+**Returns:** *string | null*
 
 ___
-<a id="issystem"></a>
 
 ###  isSystem
 
-**get isSystem**(): `boolean`
+• **get isSystem**(): *boolean*
 
-*Defined in [source-destination/block-device.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L55)*
+*Defined in [lib/source-destination/block-device.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L55)*
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="mountpoints"></a>
 
 ###  mountpoints
 
-**get mountpoints**(): `Array`<`object`>
+• **get mountpoints**(): *Array‹object›*
 
-*Defined in [source-destination/block-device.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L75)*
+*Defined in [lib/source-destination/block-device.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L75)*
 
-**Returns:** `Array`<`object`>
+**Returns:** *Array‹object›*
 
 ___
-<a id="raw"></a>
 
 ###  raw
 
-**get raw**(): `string`
+• **get raw**(): *string*
 
-*Defined in [source-destination/block-device.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L59)*
+*Defined in [lib/source-destination/block-device.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L59)*
 
-**Returns:** `string`
+**Returns:** *string*
 
 ___
-<a id="size"></a>
 
 ###  size
 
-**get size**(): `number` \| `null`
+• **get size**(): *number | null*
 
-*Defined in [source-destination/block-device.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L79)*
+*Defined in [lib/source-destination/block-device.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L79)*
 
-**Returns:** `number` \| `null`
-
-___
+**Returns:** *number | null*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[_close](../interfaces/adaptersourcedestination.md#_close)*
+*Overrides [File](file.md).[_close](file.md#protected-_close)*
 
-*Overrides [File](file.md).[_close](file.md#_close)*
+*Defined in [lib/source-destination/block-device.ts:127](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L127)*
 
-*Defined in [source-destination/block-device.ts:127](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L127)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[_getMetadata](../interfaces/adaptersourcedestination.md#_getmetadata)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Overrides [File](file.md).[_getMetadata](file.md#_getmetadata)*
+*Overrides [File](file.md).[_getMetadata](file.md#protected-_getmetadata)*
 
-*Defined in [source-destination/block-device.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L83)*
+*Defined in [lib/source-destination/block-device.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L83)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[_open](../interfaces/adaptersourcedestination.md#_open)*
-
-*Overrides [File](file.md).[_open](file.md#_open)*
-
-*Defined in [source-destination/block-device.ts:119](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L119)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
+*Overrides [File](file.md).[_open](file.md#protected-_open)*
+
+*Defined in [lib/source-destination/block-device.ts:119](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L119)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[addListener](../interfaces/adaptersourcedestination.md#addlistener)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
-
-**Returns:** `this`
-
-___
-<a id="alignoffsetafter"></a>
-
-### `<Private>` alignOffsetAfter
-
-▸ **alignOffsetAfter**(offset: *`number`*): `number`
-
-*Defined in [source-destination/block-device.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L147)*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| offset | `number` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `number`
+**Returns:** *this*
 
 ___
-<a id="alignoffsetbefore"></a>
 
-### `<Private>` alignOffsetBefore
+### `Private` alignOffsetAfter
 
-▸ **alignOffsetBefore**(offset: *`number`*): `number`
+▸ **alignOffsetAfter**(`offset`: number): *number*
 
-*Defined in [source-destination/block-device.ts:143](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L143)*
+*Defined in [lib/source-destination/block-device.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L147)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| offset | `number` |
+Name | Type |
+------ | ------ |
+`offset` | number |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="alignedread"></a>
 
-### `<Private>` alignedRead
+### `Private` alignOffsetBefore
 
-▸ **alignedRead**(buffer: *`Buffer`*, bufferOffset: *`number`*, length: *`number`*, sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **alignOffsetBefore**(`offset`: number): *number*
 
-*Defined in [source-destination/block-device.ts:151](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L151)*
+*Defined in [lib/source-destination/block-device.ts:143](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L143)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| bufferOffset | `number` |
-| length | `number` |
-| sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`offset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *number*
 
 ___
-<a id="alignedwrite"></a>
 
-### `<Private>` alignedWrite
+### `Private` alignedRead
 
-▸ **alignedWrite**(buffer: *`Buffer`*, bufferOffset: *`number`*, length: *`number`*, fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **alignedRead**(`buffer`: Buffer, `bufferOffset`: number, `length`: number, `sourceOffset`: number): *Promise‹ReadResult›*
 
-*Defined in [source-destination/block-device.ts:187](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L187)*
+*Defined in [lib/source-destination/block-device.ts:151](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L151)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| bufferOffset | `number` |
-| length | `number` |
-| fileOffset | `number` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
+`bufferOffset` | number |
+`length` | number |
+`sourceOffset` | number |
 
-**Returns:** `Promise`<`WriteResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="cancreatereadstream"></a>
+
+### `Private` alignedWrite
+
+▸ **alignedWrite**(`buffer`: Buffer, `bufferOffset`: number, `length`: number, `fileOffset`: number): *Promise‹WriteResult›*
+
+*Defined in [lib/source-destination/block-device.ts:187](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L187)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
+`bufferOffset` | number |
+`length` | number |
+`fileOffset` | number |
+
+**Returns:** *Promise‹WriteResult›*
+
+___
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canCreateReadStream](../interfaces/adaptersourcedestination.md#cancreatereadstream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Inherited from [File](file.md).[canCreateReadStream](file.md#cancreatereadstream)*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/file.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L87)*
+*Defined in [lib/source-destination/file.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L87)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canCreateSparseReadStream](../interfaces/adaptersourcedestination.md#cancreatesparsereadstream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L268)*
+*Defined in [lib/source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L268)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canCreateSparseWriteStream](../interfaces/adaptersourcedestination.md#cancreatesparsewritestream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Overrides [File](file.md).[canCreateSparseWriteStream](file.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/block-device.ts:97](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L97)*
+*Defined in [lib/source-destination/block-device.ts:97](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L97)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canCreateWriteStream](../interfaces/adaptersourcedestination.md#cancreatewritestream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Overrides [File](file.md).[canCreateWriteStream](file.md#cancreatewritestream)*
 
-*Defined in [source-destination/block-device.ts:93](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L93)*
+*Defined in [lib/source-destination/block-device.ts:93](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L93)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canRead](../interfaces/adaptersourcedestination.md#canread)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Inherited from [File](file.md).[canRead](file.md#canread)*
 
-*Overrides [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Overrides [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/file.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L79)*
+*Defined in [lib/source-destination/file.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L79)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canWrite](../interfaces/adaptersourcedestination.md#canwrite)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Overrides [File](file.md).[canWrite](file.md#canwrite)*
 
-*Defined in [source-destination/block-device.ts:89](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L89)*
+*Defined in [lib/source-destination/block-device.ts:89](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L89)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[close](../interfaces/adaptersourcedestination.md#close)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(emitProgress?: *`boolean`*, start?: *`number`*, end?: *`undefined` \| `number`*): `Promise`<`ReadableStream`>
+▸ **createReadStream**(`emitProgress`: boolean, `start`: number, `end?`: undefined | number): *Promise‹ReadableStream›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[createReadStream](../interfaces/adaptersourcedestination.md#createreadstream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Inherited from [File](file.md).[createReadStream](file.md#createreadstream)*
 
-*Overrides [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/file.ts:124](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L124)*
+*Defined in [lib/source-destination/file.ts:124](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L124)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` emitProgress | `boolean` | false |
-| `Default value` start | `number` | 0 |
-| `Optional` end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`emitProgress` | boolean | false |
+`start` | number | 0 |
+`end?` | undefined &#124; number | - |
 
-**Returns:** `Promise`<`ReadableStream`>
+**Returns:** *Promise‹ReadableStream›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(_generateChecksums?: *`boolean`*): `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+▸ **createSparseReadStream**(`_generateChecksums`: boolean): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[createSparseReadStream](../interfaces/adaptersourcedestination.md#createsparsereadstream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L317)*
+*Defined in [lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L317)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _generateChecksums | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`_generateChecksums` | boolean | false |
 
-**Returns:** `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWriteStream](sparsewritestream.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWriteStream](sparsewritestream.md)›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[createSparseWriteStream](../interfaces/adaptersourcedestination.md#createsparsewritestream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Overrides [File](file.md).[createSparseWriteStream](file.md#createsparsewritestream)*
 
-*Defined in [source-destination/block-device.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L110)*
+*Defined in [lib/source-destination/block-device.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L110)*
 
-**Returns:** `Promise`<[SparseWriteStream](sparsewritestream.md)>
+**Returns:** *Promise‹[SparseWriteStream](sparsewritestream.md)›*
 
 ___
-<a id="createverifier"></a>
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[createVerifier](../interfaces/adaptersourcedestination.md#createverifier)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<[BlockWriteStream](blockwritestream.md)>
+▸ **createWriteStream**(): *Promise‹[BlockWriteStream](blockwritestream.md)›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[createWriteStream](../interfaces/adaptersourcedestination.md#createwritestream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Overrides [File](file.md).[createWriteStream](file.md#createwritestream)*
 
-*Defined in [source-destination/block-device.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L101)*
+*Defined in [lib/source-destination/block-device.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L101)*
 
-**Returns:** `Promise`<[BlockWriteStream](blockwritestream.md)>
+**Returns:** *Promise‹[BlockWriteStream](blockwritestream.md)›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[emit](../interfaces/adaptersourcedestination.md#emit)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[eventNames](../interfaces/adaptersourcedestination.md#eventnames)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[getBlocks](../interfaces/adaptersourcedestination.md#getblocks)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[getInnerSource](../interfaces/adaptersourcedestination.md#getinnersource)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[getMaxListeners](../interfaces/adaptersourcedestination.md#getmaxlisteners)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[getMetadata](../interfaces/adaptersourcedestination.md#getmetadata)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[getPartitionTable](../interfaces/adaptersourcedestination.md#getpartitiontable)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[listenerCount](../interfaces/adaptersourcedestination.md#listenercount)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[listeners](../interfaces/adaptersourcedestination.md#listeners)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-
-**Returns:** `Function`[]
-
-___
-<a id="offsetisaligned"></a>
-
-### `<Private>` offsetIsAligned
-
-▸ **offsetIsAligned**(offset: *`number`*): `boolean`
-
-*Defined in [source-destination/block-device.ts:139](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L139)*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| offset | `number` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `boolean`
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
+
+### `Private` offsetIsAligned
+
+▸ **offsetIsAligned**(`offset`: number): *boolean*
+
+*Defined in [lib/source-destination/block-device.ts:139](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L139)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`offset` | number |
+
+**Returns:** *boolean*
+
+___
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[on](../interfaces/adaptersourcedestination.md#on)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[once](../interfaces/adaptersourcedestination.md#once)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[open](../interfaces/adaptersourcedestination.md#open)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[prependListener](../interfaces/adaptersourcedestination.md#prependlistener)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[prependOnceListener](../interfaces/adaptersourcedestination.md#prependoncelistener)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(buffer: *`Buffer`*, bufferOffset: *`number`*, length: *`number`*, sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`buffer`: Buffer, `bufferOffset`: number, `length`: number, `sourceOffset`: number): *Promise‹ReadResult›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[read](../interfaces/adaptersourcedestination.md#read)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Overrides [File](file.md).[read](file.md#read)*
 
-*Defined in [source-destination/block-device.ts:171](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L171)*
+*Defined in [lib/source-destination/block-device.ts:171](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L171)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| bufferOffset | `number` |
-| length | `number` |
-| sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
+`bufferOffset` | number |
+`length` | number |
+`sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[removeAllListeners](../interfaces/adaptersourcedestination.md#removealllisteners)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[removeListener](../interfaces/adaptersourcedestination.md#removelistener)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[setMaxListeners](../interfaces/adaptersourcedestination.md#setmaxlisteners)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(buffer: *`Buffer`*, bufferOffset: *`number`*, length: *`number`*, fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`buffer`: Buffer, `bufferOffset`: number, `length`: number, `fileOffset`: number): *Promise‹WriteResult›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[write](../interfaces/adaptersourcedestination.md#write)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Overrides [File](file.md).[write](file.md#write)*
 
-*Defined in [source-destination/block-device.ts:203](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/block-device.ts#L203)*
+*Defined in [lib/source-destination/block-device.ts:203](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/block-device.ts#L203)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| bufferOffset | `number` |
-| length | `number` |
-| fileOffset | `number` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
+`bufferOffset` | number |
+`length` | number |
+`fileOffset` | number |
 
-**Returns:** `Promise`<`WriteResult`>
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="listenercount-1"></a>
 
-### `<Static>` listenerCount
+### `Static` listenerCount
 
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[listenerCount](../interfaces/adaptersourcedestination.md#listenercount-1)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` register
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **register**(`Cls`: typeof SourceSource): *void*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[register](../interfaces/adaptersourcedestination.md#register)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
 
-**Returns:** `void`
-
-___
-
+**Returns:** *void*

--- a/doc/classes/blockdeviceadapter.md
+++ b/doc/classes/blockdeviceadapter.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [BlockDeviceAdapter](../classes/blockdeviceadapter.md)
+[etcher-sdk](../README.md) › [BlockDeviceAdapter](blockdeviceadapter.md)
 
 # Class: BlockDeviceAdapter
 
 ## Hierarchy
 
-↳  [Adapter](adapter.md)
+  ↳ [Adapter](adapter.md)
 
-**↳ BlockDeviceAdapter**
+  ↳ **BlockDeviceAdapter**
 
 ## Index
 
@@ -16,11 +16,11 @@
 
 ### Properties
 
-* [drives](blockdeviceadapter.md#drives)
+* [drives](blockdeviceadapter.md#private-drives)
 * [includeSystemDrives](blockdeviceadapter.md#includesystemdrives)
-* [ready](blockdeviceadapter.md#ready)
-* [running](blockdeviceadapter.md#running)
-* [defaultMaxListeners](blockdeviceadapter.md#defaultmaxlisteners)
+* [ready](blockdeviceadapter.md#private-ready)
+* [running](blockdeviceadapter.md#private-running)
+* [defaultMaxListeners](blockdeviceadapter.md#static-defaultmaxlisteners)
 
 ### Methods
 
@@ -28,7 +28,7 @@
 * [emit](blockdeviceadapter.md#emit)
 * [eventNames](blockdeviceadapter.md#eventnames)
 * [getMaxListeners](blockdeviceadapter.md#getmaxlisteners)
-* [listDrives](blockdeviceadapter.md#listdrives)
+* [listDrives](blockdeviceadapter.md#private-listdrives)
 * [listenerCount](blockdeviceadapter.md#listenercount)
 * [listeners](blockdeviceadapter.md#listeners)
 * [on](blockdeviceadapter.md#on)
@@ -37,437 +37,399 @@
 * [prependOnceListener](blockdeviceadapter.md#prependoncelistener)
 * [removeAllListeners](blockdeviceadapter.md#removealllisteners)
 * [removeListener](blockdeviceadapter.md#removelistener)
-* [scan](blockdeviceadapter.md#scan)
-* [scanLoop](blockdeviceadapter.md#scanloop)
+* [scan](blockdeviceadapter.md#private-scan)
+* [scanLoop](blockdeviceadapter.md#private-scanloop)
 * [setMaxListeners](blockdeviceadapter.md#setmaxlisteners)
 * [start](blockdeviceadapter.md#start)
 * [stop](blockdeviceadapter.md#stop)
-* [listenerCount](blockdeviceadapter.md#listenercount-1)
-
----
+* [listenerCount](blockdeviceadapter.md#static-listenercount)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new BlockDeviceAdapter**(includeSystemDrives?: *`function`*): [BlockDeviceAdapter](blockdeviceadapter.md)
+\+ **new BlockDeviceAdapter**(`includeSystemDrives`: function): *[BlockDeviceAdapter](blockdeviceadapter.md)*
 
-*Defined in [scanner/adapters/block-device.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/block-device.ts#L60)*
+*Defined in [lib/scanner/adapters/block-device.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/block-device.ts#L60)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` includeSystemDrives | `function` |  () &#x3D;&gt; false |
+▪`Default value`  **includeSystemDrives**: *function*= () => false
 
-**Returns:** [BlockDeviceAdapter](blockdeviceadapter.md)
+▸ (): *boolean*
 
-___
+**Returns:** *[BlockDeviceAdapter](blockdeviceadapter.md)*
 
 ## Properties
 
-<a id="drives"></a>
+### `Private` drives
 
-### `<Private>` drives
+• **drives**: *Map‹string, [BlockDevice](blockdevice.md)›* = new Map()
 
-**● drives**: *`Map`<`string`, [BlockDevice](blockdevice.md)>* =  new Map()
-
-*Defined in [scanner/adapters/block-device.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/block-device.ts#L58)*
+*Defined in [lib/scanner/adapters/block-device.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/block-device.ts#L58)*
 
 ___
-<a id="includesystemdrives"></a>
 
 ###  includeSystemDrives
 
-**● includeSystemDrives**: *`function`*
+• **includeSystemDrives**: *function*
 
-*Defined in [scanner/adapters/block-device.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/block-device.ts#L62)*
+*Defined in [lib/scanner/adapters/block-device.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/block-device.ts#L62)*
 
-#### Type declaration
-▸(): `boolean`
+#### Type declaration:
 
-**Returns:** `boolean`
-
-___
-<a id="ready"></a>
-
-### `<Private>` ready
-
-**● ready**: *`boolean`* = false
-
-*Defined in [scanner/adapters/block-device.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/block-device.ts#L60)*
+▸ (): *boolean*
 
 ___
-<a id="running"></a>
 
-### `<Private>` running
+### `Private` ready
 
-**● running**: *`boolean`* = false
+• **ready**: *boolean* = false
 
-*Defined in [scanner/adapters/block-device.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/block-device.ts#L59)*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/scanner/adapters/block-device.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/block-device.ts#L60)*
 
 ___
+
+### `Private` running
+
+• **running**: *boolean* = false
+
+*Defined in [lib/scanner/adapters/block-device.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/block-device.ts#L59)*
+
+___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="addlistener"></a>
-
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
-
-___
-<a id="listdrives"></a>
-
-### `<Private>` listDrives
-
-▸ **listDrives**(): `Promise`<`Map`<`string`, [DrivelistDrive](../interfaces/drivelistdrive.md)>>
-
-*Defined in [scanner/adapters/block-device.ts:107](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/block-device.ts#L107)*
-
-**Returns:** `Promise`<`Map`<`string`, [DrivelistDrive](../interfaces/drivelistdrive.md)>>
+**Returns:** *number*
 
 ___
-<a id="listenercount"></a>
+
+### `Private` listDrives
+
+▸ **listDrives**(): *Promise‹Map‹string, [DrivelistDrive](../interfaces/drivelistdrive.md)››*
+
+*Defined in [lib/scanner/adapters/block-device.ts:107](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/block-device.ts#L107)*
+
+**Returns:** *Promise‹Map‹string, [DrivelistDrive](../interfaces/drivelistdrive.md)››*
+
+___
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
-
-___
-<a id="scan"></a>
-
-### `<Private>` scan
-
-▸ **scan**(): `Promise`<`void`>
-
-*Defined in [scanner/adapters/block-device.ts:88](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/block-device.ts#L88)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *this*
 
 ___
-<a id="scanloop"></a>
 
-### `<Private>` scanLoop
+### `Private` scan
 
-▸ **scanLoop**(): `Promise`<`void`>
+▸ **scan**(): *Promise‹void›*
 
-*Defined in [scanner/adapters/block-device.ts:77](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/block-device.ts#L77)*
+*Defined in [lib/scanner/adapters/block-device.ts:88](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/block-device.ts#L88)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="setmaxlisteners"></a>
+
+### `Private` scanLoop
+
+▸ **scanLoop**(): *Promise‹void›*
+
+*Defined in [lib/scanner/adapters/block-device.ts:77](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/block-device.ts#L77)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="start"></a>
 
 ###  start
 
-▸ **start**(): `void`
+▸ **start**(): *void*
 
-*Overrides [Adapter](adapter.md).[start](adapter.md#start)*
+*Overrides [Adapter](adapter.md).[start](adapter.md#abstract-start)*
 
-*Defined in [scanner/adapters/block-device.ts:66](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/block-device.ts#L66)*
+*Defined in [lib/scanner/adapters/block-device.ts:66](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/block-device.ts#L66)*
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="stop"></a>
 
 ###  stop
 
-▸ **stop**(): `void`
+▸ **stop**(): *void*
 
-*Overrides [Adapter](adapter.md).[stop](adapter.md#stop)*
+*Overrides [Adapter](adapter.md).[stop](adapter.md#abstract-stop)*
 
-*Defined in [scanner/adapters/block-device.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/block-device.ts#L71)*
+*Defined in [lib/scanner/adapters/block-device.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/block-device.ts#L71)*
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="listenercount-1"></a>
 
-### `<Static>` listenerCount
+### `Static` listenerCount
 
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `number`
-
-___
-
+**Returns:** *number*

--- a/doc/classes/blockreadstream.md
+++ b/doc/classes/blockreadstream.md
@@ -1,16 +1,16 @@
-[etcher-sdk](../README.md) > [BlockReadStream](../classes/blockreadstream.md)
+[etcher-sdk](../README.md) › [BlockReadStream](blockreadstream.md)
 
 # Class: BlockReadStream
 
 ## Hierarchy
 
- `Readable`
+* Readable
 
-**↳ BlockReadStream**
+  ↳ **BlockReadStream**
 
 ## Implements
 
-* `ReadableStream`
+* ReadableStream
 
 ## Index
 
@@ -20,17 +20,17 @@
 
 ### Properties
 
-* [bytesRead](blockreadstream.md#bytesread)
-* [chunkSize](blockreadstream.md#chunksize)
-* [end](blockreadstream.md#end)
-* [maxRetries](blockreadstream.md#maxretries)
+* [bytesRead](blockreadstream.md#private-bytesread)
+* [chunkSize](blockreadstream.md#private-chunksize)
+* [end](blockreadstream.md#private-end)
+* [maxRetries](blockreadstream.md#private-maxretries)
 * [readable](blockreadstream.md#readable)
-* [source](blockreadstream.md#source)
-* [defaultMaxListeners](blockreadstream.md#defaultmaxlisteners)
+* [source](blockreadstream.md#private-source)
+* [defaultMaxListeners](blockreadstream.md#static-defaultmaxlisteners)
 
 ### Methods
 
-* [__read](blockreadstream.md#__read)
+* [__read](blockreadstream.md#private-__read)
 * [_read](blockreadstream.md#_read)
 * [addListener](blockreadstream.md#addlistener)
 * [emit](blockreadstream.md#emit)
@@ -52,1221 +52,1266 @@
 * [resume](blockreadstream.md#resume)
 * [setEncoding](blockreadstream.md#setencoding)
 * [setMaxListeners](blockreadstream.md#setmaxlisteners)
-* [tryRead](blockreadstream.md#tryread)
+* [tryRead](blockreadstream.md#private-tryread)
 * [unpipe](blockreadstream.md#unpipe)
 * [unshift](blockreadstream.md#unshift)
 * [wrap](blockreadstream.md#wrap)
-* [listenerCount](blockreadstream.md#listenercount-1)
-
----
+* [listenerCount](blockreadstream.md#static-listenercount)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new BlockReadStream**(source: *[File](file.md)*, bytesRead?: *`number`*, end?: *`number`*, chunkSize?: *`number`*, maxRetries?: *`number`*): [BlockReadStream](blockreadstream.md)
+\+ **new BlockReadStream**(`source`: [File](file.md), `bytesRead`: number, `end`: number, `chunkSize`: number, `maxRetries`: number): *[BlockReadStream](blockreadstream.md)*
 
-*Overrides Readable.__constructor*
+*Overrides void*
 
-*Defined in [block-read-stream.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-read-stream.ts#L31)*
+*Defined in [lib/block-read-stream.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-read-stream.ts#L31)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| source | [File](file.md) | - |
-| `Default value` bytesRead | `number` | 0 |
-| `Default value` end | `number` |  Infinity |
-| `Default value` chunkSize | `number` |  CHUNK_SIZE |
-| `Default value` maxRetries | `number` | 5 |
+Name | Type | Default |
+------ | ------ | ------ |
+`source` | [File](file.md) | - |
+`bytesRead` | number | 0 |
+`end` | number | Infinity |
+`chunkSize` | number | CHUNK_SIZE |
+`maxRetries` | number | 5 |
 
-**Returns:** [BlockReadStream](blockreadstream.md)
-
-___
+**Returns:** *[BlockReadStream](blockreadstream.md)*
 
 ## Properties
 
-<a id="bytesread"></a>
+### `Private` bytesRead
 
-### `<Private>` bytesRead
+• **bytesRead**: *number*
 
-**● bytesRead**: *`number`*
-
-*Defined in [block-read-stream.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-read-stream.ts#L35)*
+*Defined in [lib/block-read-stream.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-read-stream.ts#L35)*
 
 ___
-<a id="chunksize"></a>
 
-### `<Private>` chunkSize
+### `Private` chunkSize
 
-**● chunkSize**: *`number`*
+• **chunkSize**: *number*
 
-*Defined in [block-read-stream.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-read-stream.ts#L31)*
-
-___
-<a id="end"></a>
-
-### `<Private>` end
-
-**● end**: *`number`*
-
-*Defined in [block-read-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-read-stream.ts#L36)*
+*Defined in [lib/block-read-stream.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-read-stream.ts#L31)*
 
 ___
-<a id="maxretries"></a>
 
-### `<Private>` maxRetries
+### `Private` end
 
-**● maxRetries**: *`number`*
+• **end**: *number*
 
-*Defined in [block-read-stream.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-read-stream.ts#L38)*
+*Defined in [lib/block-read-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-read-stream.ts#L36)*
 
 ___
-<a id="readable"></a>
+
+### `Private` maxRetries
+
+• **maxRetries**: *number*
+
+*Defined in [lib/block-read-stream.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-read-stream.ts#L38)*
+
+___
 
 ###  readable
 
-**● readable**: *`boolean`*
+• **readable**: *boolean*
 
-*Inherited from Readable.readable*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[readable](sparsefilterstream.md#readable)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3688*
-
-___
-<a id="source"></a>
-
-### `<Private>` source
-
-**● source**: *[File](file.md)*
-
-*Defined in [block-read-stream.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-read-stream.ts#L34)*
+Defined in node_modules/@types/node/base.d.ts:3688
 
 ___
-<a id="defaultmaxlisteners"></a>
 
-### `<Static>` defaultMaxListeners
+### `Private` source
 
-**● defaultMaxListeners**: *`number`*
+• **source**: *[File](file.md)*
 
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/block-read-stream.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-read-stream.ts#L34)*
 
 ___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="__read"></a>
+### `Private` __read
 
-### `<Private>` __read
+▸ **__read**(): *Promise‹void›*
 
-▸ **__read**(): `Promise`<`void`>
+*Defined in [lib/block-read-stream.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-read-stream.ts#L68)*
 
-*Defined in [block-read-stream.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-read-stream.ts#L68)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_read"></a>
 
 ###  _read
 
-▸ **_read**(): `void`
+▸ **_read**(): *void*
 
-*Overrides Readable._read*
+*Overrides [SparseFilterStream](sparsefilterstream.md).[_read](sparsefilterstream.md#_read)*
 
-*Defined in [block-read-stream.ts:93](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-read-stream.ts#L93)*
+*Defined in [lib/block-read-stream.ts:93](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-read-stream.ts#L93)*
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="addlistener"></a>
 
 ###  addListener
 
-▸ **addListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string, `listener`: Function): *this*
 
-▸ **addListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-▸ **addListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-▸ **addListener**(event: *"end"*, listener: *`function`*): `this`
+Defined in node_modules/@types/node/base.d.ts:3711
 
-▸ **addListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **addListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3711*
-
-Event emitter The defined events on documents including:
-
-1.  close
-2.  data
-3.  end
-4.  readable
-5.  error
+Event emitter
+The defined events on documents including:
+  1. close
+  2. data
+  3. end
+  4. readable
+  5. error
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.addListener*
+▸ **addListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.addListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3712*
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3713*
+Defined in node_modules/@types/node/base.d.ts:3712
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.addListener*
+▸ (): *void*
 
-*Overrides EventEmitter.addListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3714*
+▸ **addListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3715*
+Defined in node_modules/@types/node/base.d.ts:3713
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3716*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **addListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3714
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3715
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3716
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-▸ **emit**(event: *"close"*): `boolean`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-▸ **emit**(event: *"data"*, chunk: *`Buffer` \| `string`*): `boolean`
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-▸ **emit**(event: *"end"*): `boolean`
-
-▸ **emit**(event: *"readable"*): `boolean`
-
-▸ **emit**(event: *"error"*, err: *`Error`*): `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3718*
+Defined in node_modules/@types/node/base.d.ts:3718
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "close"): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3719*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-
-**Returns:** `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3720*
+Defined in node_modules/@types/node/base.d.ts:3719
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| chunk | `Buffer` \| `string` |
+Name | Type |
+------ | ------ |
+`event` | "close" |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "data", `chunk`: Buffer | string): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3721*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-
-**Returns:** `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3722*
+Defined in node_modules/@types/node/base.d.ts:3720
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
+Name | Type |
+------ | ------ |
+`event` | "data" |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "end"): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3723*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3721
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| err | `Error` |
+Name | Type |
+------ | ------ |
+`event` | "end" |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "readable"): *boolean*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3722
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "readable" |
+
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "error", `err`: [Error](notcapable.md#static-error)): *boolean*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3723
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "error" |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+Defined in node_modules/@types/node/base.d.ts:694
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
-
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+Defined in node_modules/@types/node/base.d.ts:691
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
-
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="ispaused"></a>
 
 ###  isPaused
 
-▸ **isPaused**(): `boolean`
+▸ **isPaused**(): *boolean*
 
-*Inherited from Readable.isPaused*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[isPaused](sparsefilterstream.md#ispaused)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3695*
+Defined in node_modules/@types/node/base.d.ts:3695
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string, `listener`: Function): *this*
 
-▸ **on**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-▸ **on**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-▸ **on**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3725*
+Defined in node_modules/@types/node/base.d.ts:3725
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.on*
+▸ **on**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.on*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3726*
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3727*
+Defined in node_modules/@types/node/base.d.ts:3726
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.on*
+▸ (): *void*
 
-*Overrides EventEmitter.on*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3728*
+▸ **on**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Returns:** `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3729*
+Defined in node_modules/@types/node/base.d.ts:3727
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3730*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **on**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3728
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **on**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3729
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **on**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3730
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string, `listener`: Function): *this*
 
-▸ **once**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-▸ **once**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-▸ **once**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3732*
+Defined in node_modules/@types/node/base.d.ts:3732
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.once*
+▸ **once**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.once*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3733*
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3734*
+Defined in node_modules/@types/node/base.d.ts:3733
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.once*
+▸ (): *void*
 
-*Overrides EventEmitter.once*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3735*
+▸ **once**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Returns:** `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3736*
+Defined in node_modules/@types/node/base.d.ts:3734
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3737*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **once**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3735
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **once**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3736
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **once**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3737
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="pause"></a>
 
 ###  pause
 
-▸ **pause**(): `this`
+▸ **pause**(): *this*
 
-*Inherited from Readable.pause*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[pause](sparsefilterstream.md#pause)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3693*
+Defined in node_modules/@types/node/base.d.ts:3693
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="pipe"></a>
 
 ###  pipe
 
-▸ **pipe**<`T`>(destination: *`T`*, options?: *`undefined` \| `object`*): `T`
+▸ **pipe**<**T**>(`destination`: T, `options?`: undefined | object): *T*
 
-*Inherited from Readable.pipe*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[pipe](sparsefilterstream.md#pipe)*
 
-*Overrides internal.pipe*
+*Overrides [CountingWritable](countingwritable.md).[pipe](countingwritable.md#pipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3696*
+Defined in node_modules/@types/node/base.d.ts:3696
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| destination | `T` |
-| `Optional` options | `undefined` \| `object` |
+Name | Type |
+------ | ------ |
+`destination` | T |
+`options?` | undefined &#124; object |
 
-**Returns:** `T`
+**Returns:** *T*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-▸ **prependListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-▸ **prependListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3739*
+Defined in node_modules/@types/node/base.d.ts:3739
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.prependListener*
+▸ **prependListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3740*
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3741*
+Defined in node_modules/@types/node/base.d.ts:3740
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3742*
+▸ **prependListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3743*
+Defined in node_modules/@types/node/base.d.ts:3741
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3744*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3742
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3743
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3744
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependOnceListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3746*
+Defined in node_modules/@types/node/base.d.ts:3746
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.prependOnceListener*
+▸ **prependOnceListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependOnceListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3747*
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3748*
+Defined in node_modules/@types/node/base.d.ts:3747
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependOnceListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependOnceListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3749*
+▸ **prependOnceListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3750*
+Defined in node_modules/@types/node/base.d.ts:3748
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3751*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3749
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3750
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3751
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="push"></a>
 
 ###  push
 
-▸ **push**(chunk: *`any`*, encoding?: *`undefined` \| `string`*): `boolean`
+▸ **push**(`chunk`: any, `encoding?`: undefined | string): *boolean*
 
-*Inherited from Readable.push*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[push](sparsefilterstream.md#push)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3700*
+Defined in node_modules/@types/node/base.d.ts:3700
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(size?: *`undefined` \| `number`*): `any`
+▸ **read**(`size?`: undefined | number): *any*
 
-*Inherited from Readable.read*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[read](sparsefilterstream.md#read)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3691*
+Defined in node_modules/@types/node/base.d.ts:3691
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`size?` | undefined &#124; number |
 
-**Returns:** `any`
+**Returns:** *any*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string, `listener`: Function): *this*
 
-▸ **removeListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-▸ **removeListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-▸ **removeListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3753*
+Defined in node_modules/@types/node/base.d.ts:3753
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.removeListener*
+▸ **removeListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.removeListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3754*
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3755*
+Defined in node_modules/@types/node/base.d.ts:3754
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.removeListener*
+▸ (): *void*
 
-*Overrides EventEmitter.removeListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3756*
+▸ **removeListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3757*
+Defined in node_modules/@types/node/base.d.ts:3755
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3758*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3756
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3757
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3758
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="resume"></a>
 
 ###  resume
 
-▸ **resume**(): `this`
+▸ **resume**(): *this*
 
-*Inherited from Readable.resume*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[resume](sparsefilterstream.md#resume)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3694*
+Defined in node_modules/@types/node/base.d.ts:3694
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setencoding"></a>
 
 ###  setEncoding
 
-▸ **setEncoding**(encoding: *`string`*): `void`
+▸ **setEncoding**(`encoding`: string): *void*
 
-*Inherited from Readable.setEncoding*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[setEncoding](sparsefilterstream.md#setencoding)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3692*
+Defined in node_modules/@types/node/base.d.ts:3692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| encoding | `string` |
+Name | Type |
+------ | ------ |
+`encoding` | string |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="tryread"></a>
 
-### `<Private>` tryRead
+### `Private` tryRead
 
-▸ **tryRead**(buffer: *`Buffer`*): `Promise`<`ReadResult`>
+▸ **tryRead**(`buffer`: Buffer): *Promise‹ReadResult›*
 
-*Defined in [block-read-stream.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-read-stream.ts#L47)*
+*Defined in [lib/block-read-stream.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-read-stream.ts#L47)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="unpipe"></a>
 
 ###  unpipe
 
-▸ **unpipe**<`T`>(destination?: *[T]()*): `void`
+▸ **unpipe**<**T**>(`destination?`: T): *void*
 
-*Inherited from Readable.unpipe*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[unpipe](sparsefilterstream.md#unpipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3697*
+Defined in node_modules/@types/node/base.d.ts:3697
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` destination | [T]() |
+Name | Type |
+------ | ------ |
+`destination?` | T |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="unshift"></a>
 
 ###  unshift
 
-▸ **unshift**(chunk: *`any`*): `void`
+▸ **unshift**(`chunk`: any): *void*
 
-*Inherited from Readable.unshift*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[unshift](sparsefilterstream.md#unshift)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3698*
+Defined in node_modules/@types/node/base.d.ts:3698
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="wrap"></a>
 
 ###  wrap
 
-▸ **wrap**(oldStream: *`ReadableStream`*): `Readable`
+▸ **wrap**(`oldStream`: ReadableStream): *Readable*
 
-*Inherited from Readable.wrap*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[wrap](sparsefilterstream.md#wrap)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3699*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| oldStream | `ReadableStream` |
-
-**Returns:** `Readable`
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:3699
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`oldStream` | ReadableStream |
 
-**Returns:** `number`
+**Returns:** *Readable*
 
 ___
 
+### `Static` listenerCount
+
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
+
+Defined in node_modules/@types/node/base.d.ts:680
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
+
+**Returns:** *number*

--- a/doc/classes/blocksverificationerror.md
+++ b/doc/classes/blocksverificationerror.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [BlocksVerificationError](../classes/blocksverificationerror.md)
+[etcher-sdk](../README.md) › [BlocksVerificationError](blocksverificationerror.md)
 
 # Class: BlocksVerificationError
 
 ## Hierarchy
 
-↳  [VerificationError](verificationerror.md)
+  ↳ [VerificationError](verificationerror.md)
 
-**↳ BlocksVerificationError**
+  ↳ **BlocksVerificationError**
 
 ## Index
 
@@ -21,95 +21,77 @@
 * [code](blocksverificationerror.md#code)
 * [message](blocksverificationerror.md#message)
 * [name](blocksverificationerror.md#name)
-* [stack](blocksverificationerror.md#stack)
-
----
+* [stack](blocksverificationerror.md#optional-stack)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new BlocksVerificationError**(blocks: *[BlocksWithChecksum](../interfaces/blockswithchecksum.md)*, checksum: *`string`*): [BlocksVerificationError](blocksverificationerror.md)
+\+ **new BlocksVerificationError**(`blocks`: [BlocksWithChecksum](../interfaces/blockswithchecksum.md), `checksum`: string): *[BlocksVerificationError](blocksverificationerror.md)*
 
-*Defined in [errors.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/errors.ts#L48)*
+*Defined in [lib/errors.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/errors.ts#L48)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| blocks | [BlocksWithChecksum](../interfaces/blockswithchecksum.md) |
-| checksum | `string` |
+Name | Type |
+------ | ------ |
+`blocks` | [BlocksWithChecksum](../interfaces/blockswithchecksum.md) |
+`checksum` | string |
 
-**Returns:** [BlocksVerificationError](blocksverificationerror.md)
-
-___
+**Returns:** *[BlocksVerificationError](blocksverificationerror.md)*
 
 ## Properties
 
-<a id="blocks"></a>
-
 ###  blocks
 
-**● blocks**: *[BlocksWithChecksum](../interfaces/blockswithchecksum.md)*
+• **blocks**: *[BlocksWithChecksum](../interfaces/blockswithchecksum.md)*
 
-*Defined in [errors.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/errors.ts#L50)*
+*Defined in [lib/errors.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/errors.ts#L50)*
 
 ___
-<a id="checksum"></a>
 
 ###  checksum
 
-**● checksum**: *`string`*
+• **checksum**: *string*
 
-*Defined in [errors.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/errors.ts#L51)*
+*Defined in [lib/errors.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/errors.ts#L51)*
 
 ___
-<a id="code"></a>
 
 ###  code
 
-**● code**: *`string`* = "EVALIDATION"
+• **code**: *string* = "EVALIDATION"
 
 *Inherited from [VerificationError](verificationerror.md).[code](verificationerror.md#code)*
 
-*Defined in [errors.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/errors.ts#L24)*
+*Defined in [lib/errors.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/errors.ts#L24)*
 
 ___
-<a id="message"></a>
 
 ###  message
 
-**● message**: *`string`*
+• **message**: *string*
 
-*Inherited from Error.message*
+*Inherited from [NotCapable](notcapable.md).[message](notcapable.md#message)*
 
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:964*
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:974
 
 ___
-<a id="name"></a>
 
 ###  name
 
-**● name**: *`string`*
+• **name**: *string*
 
-*Inherited from Error.name*
+*Inherited from [NotCapable](notcapable.md).[name](notcapable.md#name)*
 
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:963*
-
-___
-<a id="stack"></a>
-
-### `<Optional>` stack
-
-**● stack**: *`undefined` \| `string`*
-
-*Inherited from Error.stack*
-
-*Overrides Error.stack*
-
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:965*
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:973
 
 ___
 
+### `Optional` stack
+
+• **stack**? : *undefined | string*
+
+*Inherited from [NotCapable](notcapable.md).[stack](notcapable.md#optional-stack)*
+
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:975

--- a/doc/classes/blocktransformstream.md
+++ b/doc/classes/blocktransformstream.md
@@ -1,17 +1,17 @@
-[etcher-sdk](../README.md) > [BlockTransformStream](../classes/blocktransformstream.md)
+[etcher-sdk](../README.md) › [BlockTransformStream](blocktransformstream.md)
 
 # Class: BlockTransformStream
 
 ## Hierarchy
 
- `Transform`
+* Transform
 
-**↳ BlockTransformStream**
+  ↳ **BlockTransformStream**
 
 ## Implements
 
-* `ReadableStream`
-* `Writable`
+* ReadableStream
+* Writable
 
 ## Index
 
@@ -21,14 +21,14 @@
 
 ### Properties
 
-* [_buffers](blocktransformstream.md#_buffers)
-* [_bytes](blocktransformstream.md#_bytes)
+* [_buffers](blocktransformstream.md#private-_buffers)
+* [_bytes](blocktransformstream.md#private-_bytes)
 * [bytesRead](blocktransformstream.md#bytesread)
 * [bytesWritten](blocktransformstream.md#byteswritten)
-* [chunkSize](blocktransformstream.md#chunksize)
+* [chunkSize](blocktransformstream.md#private-chunksize)
 * [readable](blocktransformstream.md#readable)
 * [writable](blocktransformstream.md#writable)
-* [defaultMaxListeners](blocktransformstream.md#defaultmaxlisteners)
+* [defaultMaxListeners](blocktransformstream.md#static-defaultmaxlisteners)
 
 ### Methods
 
@@ -62,1384 +62,1437 @@
 * [unshift](blocktransformstream.md#unshift)
 * [wrap](blocktransformstream.md#wrap)
 * [write](blocktransformstream.md#write)
-* [writeBuffers](blocktransformstream.md#writebuffers)
-* [listenerCount](blocktransformstream.md#listenercount-1)
-
----
+* [writeBuffers](blocktransformstream.md#private-writebuffers)
+* [listenerCount](blocktransformstream.md#static-listenercount)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new BlockTransformStream**(chunkSize: *`number`*): [BlockTransformStream](blocktransformstream.md)
+\+ **new BlockTransformStream**(`chunkSize`: number): *[BlockTransformStream](blocktransformstream.md)*
 
-*Overrides Transform.__constructor*
+*Overrides [SourceTransform](../interfaces/sourcetransform.md).[constructor](../interfaces/sourcetransform.md#constructor)*
 
-*Defined in [block-transform-stream.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-transform-stream.ts#L23)*
+*Defined in [lib/block-transform-stream.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-transform-stream.ts#L23)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunkSize | `number` |
+Name | Type |
+------ | ------ |
+`chunkSize` | number |
 
-**Returns:** [BlockTransformStream](blocktransformstream.md)
-
-___
+**Returns:** *[BlockTransformStream](blocktransformstream.md)*
 
 ## Properties
 
-<a id="_buffers"></a>
+### `Private` _buffers
 
-### `<Private>` _buffers
+• **_buffers**: *Buffer[]* = []
 
-**● _buffers**: *`Buffer`[]* =  []
-
-*Defined in [block-transform-stream.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-transform-stream.ts#L22)*
+*Defined in [lib/block-transform-stream.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-transform-stream.ts#L22)*
 
 ___
-<a id="_bytes"></a>
 
-### `<Private>` _bytes
+### `Private` _bytes
 
-**● _bytes**: *`number`* = 0
+• **_bytes**: *number* = 0
 
-*Defined in [block-transform-stream.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-transform-stream.ts#L23)*
+*Defined in [lib/block-transform-stream.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-transform-stream.ts#L23)*
 
 ___
-<a id="bytesread"></a>
 
 ###  bytesRead
 
-**● bytesRead**: *`number`* = 0
+• **bytesRead**: *number* = 0
 
-*Defined in [block-transform-stream.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-transform-stream.ts#L20)*
+*Defined in [lib/block-transform-stream.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-transform-stream.ts#L20)*
 
 ___
-<a id="byteswritten"></a>
 
 ###  bytesWritten
 
-**● bytesWritten**: *`number`* = 0
+• **bytesWritten**: *number* = 0
 
-*Defined in [block-transform-stream.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-transform-stream.ts#L21)*
-
-___
-<a id="chunksize"></a>
-
-### `<Private>` chunkSize
-
-**● chunkSize**: *`number`*
-
-*Defined in [block-transform-stream.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-transform-stream.ts#L25)*
+*Defined in [lib/block-transform-stream.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-transform-stream.ts#L21)*
 
 ___
-<a id="readable"></a>
+
+### `Private` chunkSize
+
+• **chunkSize**: *number*
+
+*Defined in [lib/block-transform-stream.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-transform-stream.ts#L25)*
+
+___
 
 ###  readable
 
-**● readable**: *`boolean`*
+• **readable**: *boolean*
 
-*Inherited from Readable.readable*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[readable](sparsefilterstream.md#readable)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3688*
+Defined in node_modules/@types/node/base.d.ts:3688
 
 ___
-<a id="writable"></a>
 
 ###  writable
 
-**● writable**: *`boolean`*
+• **writable**: *boolean*
 
-*Inherited from Duplex.writable*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[writable](sparsefilterstream.md#writable)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3855*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+Defined in node_modules/@types/node/base.d.ts:3855
 
 ___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="_flush"></a>
-
 ###  _flush
 
-▸ **_flush**(callback: *`function`*): `void`
+▸ **_flush**(`callback`: function): *void*
 
-*Defined in [block-transform-stream.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-transform-stream.ts#L71)*
+*Defined in [lib/block-transform-stream.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-transform-stream.ts#L71)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| callback | `function` |
+▪ **callback**: *function*
 
-**Returns:** `void`
+▸ (`error?`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`error?` | [Error](notcapable.md#static-error) |
+
+**Returns:** *void*
 
 ___
-<a id="_read"></a>
 
 ###  _read
 
-▸ **_read**(size: *`number`*): `void`
+▸ **_read**(`size`: number): *void*
 
-*Inherited from Readable._read*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[_read](sparsefilterstream.md#_read)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3690*
+Defined in node_modules/@types/node/base.d.ts:3690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| size | `number` |
+Name | Type |
+------ | ------ |
+`size` | number |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="_transform"></a>
 
 ###  _transform
 
-▸ **_transform**(chunk: *`Buffer`*, _encoding: *`string`*, callback: *`function`*): `void`
+▸ **_transform**(`chunk`: Buffer, `_encoding`: string, `callback`: function): *void*
 
-*Overrides Transform._transform*
+*Overrides [SourceTransform](../interfaces/sourcetransform.md).[_transform](../interfaces/sourcetransform.md#_transform)*
 
-*Defined in [block-transform-stream.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-transform-stream.ts#L50)*
+*Defined in [lib/block-transform-stream.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-transform-stream.ts#L50)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `Buffer` |
-| _encoding | `string` |
-| callback | `function` |
+▪ **chunk**: *Buffer*
 
-**Returns:** `void`
+▪ **_encoding**: *string*
+
+▪ **callback**: *function*
+
+▸ (`error?`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`error?` | [Error](notcapable.md#static-error) |
+
+**Returns:** *void*
 
 ___
-<a id="_write"></a>
 
 ###  _write
 
-▸ **_write**(chunk: *`any`*, encoding: *`string`*, callback: *`Function`*): `void`
+▸ **_write**(`chunk`: any, `encoding`: string, `callback`: Function): *void*
 
-*Inherited from Duplex._write*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[_write](sparsefilterstream.md#_write)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3857*
+Defined in node_modules/@types/node/base.d.ts:3857
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| encoding | `string` |
-| callback | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding` | string |
+`callback` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="addlistener"></a>
 
 ###  addListener
 
-▸ **addListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string, `listener`: Function): *this*
 
-▸ **addListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-▸ **addListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-▸ **addListener**(event: *"end"*, listener: *`function`*): `this`
+Defined in node_modules/@types/node/base.d.ts:3711
 
-▸ **addListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **addListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3711*
-
-Event emitter The defined events on documents including:
-
-1.  close
-2.  data
-3.  end
-4.  readable
-5.  error
+Event emitter
+The defined events on documents including:
+  1. close
+  2. data
+  3. end
+  4. readable
+  5. error
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.addListener*
+▸ **addListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.addListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3712*
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3713*
+Defined in node_modules/@types/node/base.d.ts:3712
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.addListener*
+▸ (): *void*
 
-*Overrides EventEmitter.addListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3714*
+▸ **addListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3715*
+Defined in node_modules/@types/node/base.d.ts:3713
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3716*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **addListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3714
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3715
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3716
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-▸ **emit**(event: *"close"*): `boolean`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-▸ **emit**(event: *"data"*, chunk: *`Buffer` \| `string`*): `boolean`
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-▸ **emit**(event: *"end"*): `boolean`
-
-▸ **emit**(event: *"readable"*): `boolean`
-
-▸ **emit**(event: *"error"*, err: *`Error`*): `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3718*
+Defined in node_modules/@types/node/base.d.ts:3718
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "close"): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3719*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-
-**Returns:** `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3720*
+Defined in node_modules/@types/node/base.d.ts:3719
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| chunk | `Buffer` \| `string` |
+Name | Type |
+------ | ------ |
+`event` | "close" |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "data", `chunk`: Buffer | string): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3721*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-
-**Returns:** `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3722*
+Defined in node_modules/@types/node/base.d.ts:3720
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
+Name | Type |
+------ | ------ |
+`event` | "data" |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "end"): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3723*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3721
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| err | `Error` |
+Name | Type |
+------ | ------ |
+`event` | "end" |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "readable"): *boolean*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3722
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "readable" |
+
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "error", `err`: [Error](notcapable.md#static-error)): *boolean*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3723
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "error" |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *boolean*
 
 ___
-<a id="end"></a>
 
 ###  end
 
-▸ **end**(cb?: *`Function`*): `void`
+▸ **end**(`cb?`: Function): *void*
 
-▸ **end**(chunk: *`any`*, cb?: *`Function`*): `void`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[end](sparsefilterstream.md#end)*
 
-▸ **end**(chunk: *`any`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `void`
-
-*Inherited from Duplex.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:3861*
+Defined in node_modules/@types/node/base.d.ts:3861
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
 
-*Inherited from Duplex.end*
+▸ **end**(`chunk`: any, `cb?`: Function): *void*
 
-*Defined in /node_modules/@types/node/base.d.ts:3862*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[end](sparsefilterstream.md#end)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` cb | `Function` |
-
-**Returns:** `void`
-
-*Inherited from Duplex.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:3863*
+Defined in node_modules/@types/node/base.d.ts:3862
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
+
+▸ **end**(`chunk`: any, `encoding?`: undefined | string, `cb?`: Function): *void*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[end](sparsefilterstream.md#end)*
+
+Defined in node_modules/@types/node/base.d.ts:3863
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
+
+**Returns:** *void*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+Defined in node_modules/@types/node/base.d.ts:694
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
-
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+Defined in node_modules/@types/node/base.d.ts:691
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
-
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="ispaused"></a>
 
 ###  isPaused
 
-▸ **isPaused**(): `boolean`
+▸ **isPaused**(): *boolean*
 
-*Inherited from Readable.isPaused*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[isPaused](sparsefilterstream.md#ispaused)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3695*
+Defined in node_modules/@types/node/base.d.ts:3695
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string, `listener`: Function): *this*
 
-▸ **on**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-▸ **on**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-▸ **on**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3725*
+Defined in node_modules/@types/node/base.d.ts:3725
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.on*
+▸ **on**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.on*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3726*
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3727*
+Defined in node_modules/@types/node/base.d.ts:3726
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.on*
+▸ (): *void*
 
-*Overrides EventEmitter.on*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3728*
+▸ **on**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Returns:** `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3729*
+Defined in node_modules/@types/node/base.d.ts:3727
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3730*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **on**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3728
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **on**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3729
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **on**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3730
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string, `listener`: Function): *this*
 
-▸ **once**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-▸ **once**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-▸ **once**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3732*
+Defined in node_modules/@types/node/base.d.ts:3732
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.once*
+▸ **once**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.once*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3733*
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3734*
+Defined in node_modules/@types/node/base.d.ts:3733
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.once*
+▸ (): *void*
 
-*Overrides EventEmitter.once*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3735*
+▸ **once**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Returns:** `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3736*
+Defined in node_modules/@types/node/base.d.ts:3734
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3737*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **once**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3735
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **once**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3736
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **once**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3737
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="pause"></a>
 
 ###  pause
 
-▸ **pause**(): `this`
+▸ **pause**(): *this*
 
-*Inherited from Readable.pause*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[pause](sparsefilterstream.md#pause)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3693*
+Defined in node_modules/@types/node/base.d.ts:3693
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="pipe"></a>
 
 ###  pipe
 
-▸ **pipe**<`T`>(destination: *`T`*, options?: *`undefined` \| `object`*): `T`
+▸ **pipe**<**T**>(`destination`: T, `options?`: undefined | object): *T*
 
-*Inherited from Readable.pipe*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[pipe](sparsefilterstream.md#pipe)*
 
-*Overrides internal.pipe*
+*Overrides [CountingWritable](countingwritable.md).[pipe](countingwritable.md#pipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3696*
+Defined in node_modules/@types/node/base.d.ts:3696
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| destination | `T` |
-| `Optional` options | `undefined` \| `object` |
+Name | Type |
+------ | ------ |
+`destination` | T |
+`options?` | undefined &#124; object |
 
-**Returns:** `T`
+**Returns:** *T*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-▸ **prependListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-▸ **prependListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3739*
+Defined in node_modules/@types/node/base.d.ts:3739
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.prependListener*
+▸ **prependListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3740*
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3741*
+Defined in node_modules/@types/node/base.d.ts:3740
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3742*
+▸ **prependListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3743*
+Defined in node_modules/@types/node/base.d.ts:3741
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3744*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3742
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3743
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3744
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependOnceListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3746*
+Defined in node_modules/@types/node/base.d.ts:3746
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.prependOnceListener*
+▸ **prependOnceListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependOnceListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3747*
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3748*
+Defined in node_modules/@types/node/base.d.ts:3747
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependOnceListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependOnceListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3749*
+▸ **prependOnceListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3750*
+Defined in node_modules/@types/node/base.d.ts:3748
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3751*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3749
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3750
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3751
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="push"></a>
 
 ###  push
 
-▸ **push**(chunk: *`any`*, encoding?: *`undefined` \| `string`*): `boolean`
+▸ **push**(`chunk`: any, `encoding?`: undefined | string): *boolean*
 
-*Inherited from Readable.push*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[push](sparsefilterstream.md#push)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3700*
+Defined in node_modules/@types/node/base.d.ts:3700
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(size?: *`undefined` \| `number`*): `any`
+▸ **read**(`size?`: undefined | number): *any*
 
-*Inherited from Readable.read*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[read](sparsefilterstream.md#read)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3691*
+Defined in node_modules/@types/node/base.d.ts:3691
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`size?` | undefined &#124; number |
 
-**Returns:** `any`
+**Returns:** *any*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string, `listener`: Function): *this*
 
-▸ **removeListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-▸ **removeListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-▸ **removeListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3753*
+Defined in node_modules/@types/node/base.d.ts:3753
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.removeListener*
+▸ **removeListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.removeListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3754*
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3755*
+Defined in node_modules/@types/node/base.d.ts:3754
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.removeListener*
+▸ (): *void*
 
-*Overrides EventEmitter.removeListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3756*
+▸ **removeListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3757*
+Defined in node_modules/@types/node/base.d.ts:3755
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3758*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3756
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3757
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3758
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="resume"></a>
 
 ###  resume
 
-▸ **resume**(): `this`
+▸ **resume**(): *this*
 
-*Inherited from Readable.resume*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[resume](sparsefilterstream.md#resume)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3694*
+Defined in node_modules/@types/node/base.d.ts:3694
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setdefaultencoding"></a>
 
 ###  setDefaultEncoding
 
-▸ **setDefaultEncoding**(encoding: *`string`*): `this`
+▸ **setDefaultEncoding**(`encoding`: string): *this*
 
-*Inherited from Duplex.setDefaultEncoding*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[setDefaultEncoding](sparsefilterstream.md#setdefaultencoding)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3860*
+Defined in node_modules/@types/node/base.d.ts:3860
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| encoding | `string` |
+Name | Type |
+------ | ------ |
+`encoding` | string |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setencoding"></a>
 
 ###  setEncoding
 
-▸ **setEncoding**(encoding: *`string`*): `void`
+▸ **setEncoding**(`encoding`: string): *void*
 
-*Inherited from Readable.setEncoding*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[setEncoding](sparsefilterstream.md#setencoding)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3692*
+Defined in node_modules/@types/node/base.d.ts:3692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| encoding | `string` |
+Name | Type |
+------ | ------ |
+`encoding` | string |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="unpipe"></a>
 
 ###  unpipe
 
-▸ **unpipe**<`T`>(destination?: *[T]()*): `void`
+▸ **unpipe**<**T**>(`destination?`: T): *void*
 
-*Inherited from Readable.unpipe*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[unpipe](sparsefilterstream.md#unpipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3697*
+Defined in node_modules/@types/node/base.d.ts:3697
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` destination | [T]() |
+Name | Type |
+------ | ------ |
+`destination?` | T |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="unshift"></a>
 
 ###  unshift
 
-▸ **unshift**(chunk: *`any`*): `void`
+▸ **unshift**(`chunk`: any): *void*
 
-*Inherited from Readable.unshift*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[unshift](sparsefilterstream.md#unshift)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3698*
+Defined in node_modules/@types/node/base.d.ts:3698
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="wrap"></a>
 
 ###  wrap
 
-▸ **wrap**(oldStream: *`ReadableStream`*): `Readable`
+▸ **wrap**(`oldStream`: ReadableStream): *Readable*
 
-*Inherited from Readable.wrap*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[wrap](sparsefilterstream.md#wrap)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3699*
+Defined in node_modules/@types/node/base.d.ts:3699
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| oldStream | `ReadableStream` |
+Name | Type |
+------ | ------ |
+`oldStream` | ReadableStream |
 
-**Returns:** `Readable`
+**Returns:** *Readable*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(chunk: *`any`*, cb?: *`Function`*): `boolean`
+▸ **write**(`chunk`: any, `cb?`: Function): *boolean*
 
-▸ **write**(chunk: *`any`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `boolean`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[write](sparsefilterstream.md#write)*
 
-*Inherited from Duplex.write*
-
-*Defined in /node_modules/@types/node/base.d.ts:3858*
+Defined in node_modules/@types/node/base.d.ts:3858
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`cb?` | Function |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Duplex.write*
+▸ **write**(`chunk`: any, `encoding?`: undefined | string, `cb?`: Function): *boolean*
 
-*Defined in /node_modules/@types/node/base.d.ts:3859*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[write](sparsefilterstream.md#write)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
-
-**Returns:** `boolean`
-
-___
-<a id="writebuffers"></a>
-
-### `<Private>` writeBuffers
-
-▸ **writeBuffers**(flush?: *`boolean`*): `void`
-
-*Defined in [block-transform-stream.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-transform-stream.ts#L29)*
+Defined in node_modules/@types/node/base.d.ts:3859
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` flush | `boolean` | false |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
 
-**Returns:** `void`
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
-
-**Returns:** `number`
+**Returns:** *boolean*
 
 ___
 
+### `Private` writeBuffers
+
+▸ **writeBuffers**(`flush`: boolean): *void*
+
+*Defined in [lib/block-transform-stream.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-transform-stream.ts#L29)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`flush` | boolean | false |
+
+**Returns:** *void*
+
+___
+
+### `Static` listenerCount
+
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
+
+Defined in node_modules/@types/node/base.d.ts:680
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
+
+**Returns:** *number*

--- a/doc/classes/blockwritestream.md
+++ b/doc/classes/blockwritestream.md
@@ -1,16 +1,16 @@
-[etcher-sdk](../README.md) > [BlockWriteStream](../classes/blockwritestream.md)
+[etcher-sdk](../README.md) › [BlockWriteStream](blockwritestream.md)
 
 # Class: BlockWriteStream
 
 ## Hierarchy
 
- `Writable`
+* Writable
 
-**↳ BlockWriteStream**
+  ↳ **BlockWriteStream**
 
 ## Implements
 
-* `WritableStream`
+* WritableStream
 
 ## Index
 
@@ -20,20 +20,20 @@
 
 ### Properties
 
-* [_buffers](blockwritestream.md#_buffers)
-* [_bytes](blockwritestream.md#_bytes)
-* [_firstBuffers](blockwritestream.md#_firstbuffers)
+* [_buffers](blockwritestream.md#private-_buffers)
+* [_bytes](blockwritestream.md#private-_bytes)
+* [_firstBuffers](blockwritestream.md#private-_firstbuffers)
 * [bytesWritten](blockwritestream.md#byteswritten)
-* [destination](blockwritestream.md#destination)
+* [destination](blockwritestream.md#private-destination)
 * [firstBytesToKeep](blockwritestream.md#firstbytestokeep)
-* [maxRetries](blockwritestream.md#maxretries)
+* [maxRetries](blockwritestream.md#private-maxretries)
 * [writable](blockwritestream.md#writable)
-* [defaultMaxListeners](blockwritestream.md#defaultmaxlisteners)
+* [defaultMaxListeners](blockwritestream.md#static-defaultmaxlisteners)
 
 ### Methods
 
-* [__final](blockwritestream.md#__final)
-* [__write](blockwritestream.md#__write)
+* [__final](blockwritestream.md#private-__final)
+* [__write](blockwritestream.md#private-__write)
 * [_final](blockwritestream.md#_final)
 * [_write](blockwritestream.md#_write)
 * [addListener](blockwritestream.md#addlistener)
@@ -54,1378 +54,1478 @@
 * [setDefaultEncoding](blockwritestream.md#setdefaultencoding)
 * [setMaxListeners](blockwritestream.md#setmaxlisteners)
 * [write](blockwritestream.md#write)
-* [writeBuffers](blockwritestream.md#writebuffers)
-* [writeChunk](blockwritestream.md#writechunk)
-* [listenerCount](blockwritestream.md#listenercount-1)
-
----
+* [writeBuffers](blockwritestream.md#private-writebuffers)
+* [writeChunk](blockwritestream.md#private-writechunk)
+* [listenerCount](blockwritestream.md#static-listenercount)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new BlockWriteStream**(destination: *[BlockDevice](blockdevice.md)*, firstBytesToKeep?: *`number`*, maxRetries?: *`number`*): [BlockWriteStream](blockwritestream.md)
+\+ **new BlockWriteStream**(`destination`: [BlockDevice](blockdevice.md), `firstBytesToKeep`: number, `maxRetries`: number): *[BlockWriteStream](blockwritestream.md)*
 
-*Overrides Writable.__constructor*
+*Overrides [CountingWritable](countingwritable.md).[constructor](countingwritable.md#constructor)*
 
-*Defined in [block-write-stream.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-write-stream.ts#L37)*
+*Defined in [lib/block-write-stream.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-write-stream.ts#L37)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| destination | [BlockDevice](blockdevice.md) | - |
-| `Default value` firstBytesToKeep | `number` | 0 |
-| `Default value` maxRetries | `number` | 5 |
+Name | Type | Default |
+------ | ------ | ------ |
+`destination` | [BlockDevice](blockdevice.md) | - |
+`firstBytesToKeep` | number | 0 |
+`maxRetries` | number | 5 |
 
-**Returns:** [BlockWriteStream](blockwritestream.md)
-
-___
+**Returns:** *[BlockWriteStream](blockwritestream.md)*
 
 ## Properties
 
-<a id="_buffers"></a>
+### `Private` _buffers
 
-### `<Private>` _buffers
+• **_buffers**: *Buffer[]* = []
 
-**● _buffers**: *`Buffer`[]* =  []
-
-*Defined in [block-write-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-write-stream.ts#L36)*
+*Defined in [lib/block-write-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-write-stream.ts#L36)*
 
 ___
-<a id="_bytes"></a>
 
-### `<Private>` _bytes
+### `Private` _bytes
 
-**● _bytes**: *`number`* = 0
+• **_bytes**: *number* = 0
 
-*Defined in [block-write-stream.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-write-stream.ts#L37)*
-
-___
-<a id="_firstbuffers"></a>
-
-### `<Private>` _firstBuffers
-
-**● _firstBuffers**: *`Buffer`[]* =  []
-
-*Defined in [block-write-stream.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-write-stream.ts#L35)*
+*Defined in [lib/block-write-stream.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-write-stream.ts#L37)*
 
 ___
-<a id="byteswritten"></a>
+
+### `Private` _firstBuffers
+
+• **_firstBuffers**: *Buffer[]* = []
+
+*Defined in [lib/block-write-stream.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-write-stream.ts#L35)*
+
+___
 
 ###  bytesWritten
 
-**● bytesWritten**: *`number`* = 0
+• **bytesWritten**: *number* = 0
 
-*Defined in [block-write-stream.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-write-stream.ts#L34)*
-
-___
-<a id="destination"></a>
-
-### `<Private>` destination
-
-**● destination**: *[BlockDevice](blockdevice.md)*
-
-*Defined in [block-write-stream.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-write-stream.ts#L40)*
+*Defined in [lib/block-write-stream.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-write-stream.ts#L34)*
 
 ___
-<a id="firstbytestokeep"></a>
+
+### `Private` destination
+
+• **destination**: *[BlockDevice](blockdevice.md)*
+
+*Defined in [lib/block-write-stream.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-write-stream.ts#L40)*
+
+___
 
 ###  firstBytesToKeep
 
-**● firstBytesToKeep**: *`number`*
+• **firstBytesToKeep**: *number*
 
-*Defined in [block-write-stream.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-write-stream.ts#L41)*
-
-___
-<a id="maxretries"></a>
-
-### `<Private>` maxRetries
-
-**● maxRetries**: *`number`*
-
-*Defined in [block-write-stream.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-write-stream.ts#L42)*
+*Defined in [lib/block-write-stream.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-write-stream.ts#L41)*
 
 ___
-<a id="writable"></a>
+
+### `Private` maxRetries
+
+• **maxRetries**: *number*
+
+*Defined in [lib/block-write-stream.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-write-stream.ts#L42)*
+
+___
 
 ###  writable
 
-**● writable**: *`boolean`*
+• **writable**: *boolean*
 
-*Inherited from Writable.writable*
+*Inherited from [CountingWritable](countingwritable.md).[writable](countingwritable.md#writable)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3770*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+Defined in node_modules/@types/node/base.d.ts:3770
 
 ___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="__final"></a>
+### `Private` __final
 
-### `<Private>` __final
+▸ **__final**(): *Promise‹void›*
 
-▸ **__final**(): `Promise`<`void`>
+*Defined in [lib/block-write-stream.ts:141](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-write-stream.ts#L141)*
 
-*Defined in [block-write-stream.ts:141](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-write-stream.ts#L141)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="__write"></a>
 
-### `<Private>` __write
+### `Private` __write
 
-▸ **__write**(buffer: *`Buffer`*): `Promise`<`void`>
+▸ **__write**(`buffer`: Buffer): *Promise‹void›*
 
-*Defined in [block-write-stream.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-write-stream.ts#L102)*
+*Defined in [lib/block-write-stream.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-write-stream.ts#L102)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_final"></a>
 
 ###  _final
 
-▸ **_final**(callback: *`function`*): `void`
+▸ **_final**(`callback`: function): *void*
 
-*Defined in [block-write-stream.ts:165](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-write-stream.ts#L165)*
+*Defined in [lib/block-write-stream.ts:165](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-write-stream.ts#L165)*
 
-*__summary__*: Write buffered data before a stream ends, called by stream internals
+**`summary`** Write buffered data before a stream ends, called by stream internals
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| callback | `function` |
+▪ **callback**: *function*
 
-**Returns:** `void`
+▸ (`error?`: [Error](notcapable.md#static-error) | void): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`error?` | [Error](notcapable.md#static-error) &#124; void |
+
+**Returns:** *void*
 
 ___
-<a id="_write"></a>
 
 ###  _write
 
-▸ **_write**(buffer: *`Buffer`*, _encoding: *`string`*, callback: *`function`*): `void`
+▸ **_write**(`buffer`: Buffer, `_encoding`: string, `callback`: function): *void*
 
-*Overrides Writable._write*
+*Overrides void*
 
-*Defined in [block-write-stream.ts:133](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-write-stream.ts#L133)*
+*Defined in [lib/block-write-stream.ts:133](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-write-stream.ts#L133)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| _encoding | `string` |
-| callback | `function` |
+▪ **buffer**: *Buffer*
 
-**Returns:** `void`
+▪ **_encoding**: *string*
+
+▪ **callback**: *function*
+
+▸ (`error`: [Error](notcapable.md#static-error) | undefined): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`error` | [Error](notcapable.md#static-error) &#124; undefined |
+
+**Returns:** *void*
 
 ___
-<a id="addlistener"></a>
 
 ###  addListener
 
-▸ **addListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string, `listener`: Function): *this*
 
-▸ **addListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
 
-▸ **addListener**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-▸ **addListener**(event: *"error"*, listener: *`function`*): `this`
+Defined in node_modules/@types/node/base.d.ts:3790
 
-▸ **addListener**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **addListener**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **addListener**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3790*
-
-Event emitter The defined events on documents including:
-
-1.  close
-2.  drain
-3.  error
-4.  finish
-5.  pipe
-6.  unpipe
+Event emitter
+The defined events on documents including:
+  1. close
+  2. drain
+  3. error
+  4. finish
+  5. pipe
+  6. unpipe
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.addListener*
+▸ **addListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.addListener*
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3791*
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3792*
+Defined in node_modules/@types/node/base.d.ts:3791
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.addListener*
+▸ (): *void*
 
-*Overrides EventEmitter.addListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3793*
+▸ **addListener**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3794*
+Defined in node_modules/@types/node/base.d.ts:3792
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.addListener*
+▸ (): *void*
 
-*Overrides EventEmitter.addListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3795*
+▸ **addListener**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3796*
+Defined in node_modules/@types/node/base.d.ts:3793
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3794
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3795
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3796
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="destroy"></a>
 
 ###  destroy
 
-▸ **destroy**(error?: *[Error](notcapable.md#error)*): `this`
+▸ **destroy**(`error?`: [Error](notcapable.md#static-error)): *this*
 
-*Inherited from Writable.destroy*
+*Inherited from [SparseWriteStream](sparsewritestream.md).[destroy](sparsewritestream.md#destroy)*
 
-*Defined in [/typings/readable-stream/index.d.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/typings/readable-stream/index.d.ts#L18)*
+*Defined in [typings/readable-stream/index.d.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/typings/readable-stream/index.d.ts#L18)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` error | [Error](notcapable.md#error) |
+Name | Type |
+------ | ------ |
+`error?` | [Error](notcapable.md#static-error) |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-▸ **emit**(event: *"close"*): `boolean`
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
 
-▸ **emit**(event: *"drain"*, chunk: *`Buffer` \| `string`*): `boolean`
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-▸ **emit**(event: *"error"*, err: *`Error`*): `boolean`
-
-▸ **emit**(event: *"finish"*): `boolean`
-
-▸ **emit**(event: *"pipe"*, src: *`Readable`*): `boolean`
-
-▸ **emit**(event: *"unpipe"*, src: *`Readable`*): `boolean`
-
-*Inherited from Writable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3798*
+Defined in node_modules/@types/node/base.d.ts:3798
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Writable.emit*
+▸ **emit**(`event`: "close"): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3799*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-
-**Returns:** `boolean`
-
-*Inherited from Writable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3800*
+Defined in node_modules/@types/node/base.d.ts:3799
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| chunk | `Buffer` \| `string` |
+Name | Type |
+------ | ------ |
+`event` | "close" |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Writable.emit*
+▸ **emit**(`event`: "drain", `chunk`: Buffer | string): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3801*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| err | `Error` |
-
-**Returns:** `boolean`
-
-*Inherited from Writable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3802*
+Defined in node_modules/@types/node/base.d.ts:3800
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
+Name | Type |
+------ | ------ |
+`event` | "drain" |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Writable.emit*
+▸ **emit**(`event`: "error", `err`: [Error](notcapable.md#static-error)): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3803*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| src | `Readable` |
-
-**Returns:** `boolean`
-
-*Inherited from Writable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3804*
+Defined in node_modules/@types/node/base.d.ts:3801
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| src | `Readable` |
+Name | Type |
+------ | ------ |
+`event` | "error" |
+`err` | [Error](notcapable.md#static-error) |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "finish"): *boolean*
+
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3802
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "finish" |
+
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "pipe", `src`: Readable): *boolean*
+
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3803
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "pipe" |
+`src` | Readable |
+
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "unpipe", `src`: Readable): *boolean*
+
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3804
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "unpipe" |
+`src` | Readable |
+
+**Returns:** *boolean*
 
 ___
-<a id="end"></a>
 
 ###  end
 
-▸ **end**(cb?: *`Function`*): `void`
+▸ **end**(`cb?`: Function): *void*
 
-▸ **end**(chunk: *`any`*, cb?: *`Function`*): `void`
+*Inherited from [CountingWritable](countingwritable.md).[end](countingwritable.md#end)*
 
-▸ **end**(chunk: *`any`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `void`
-
-*Inherited from Writable.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:3776*
+Defined in node_modules/@types/node/base.d.ts:3776
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
 
-*Inherited from Writable.end*
+▸ **end**(`chunk`: any, `cb?`: Function): *void*
 
-*Defined in /node_modules/@types/node/base.d.ts:3777*
+*Inherited from [CountingWritable](countingwritable.md).[end](countingwritable.md#end)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` cb | `Function` |
-
-**Returns:** `void`
-
-*Inherited from Writable.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:3778*
+Defined in node_modules/@types/node/base.d.ts:3777
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
+
+▸ **end**(`chunk`: any, `encoding?`: undefined | string, `cb?`: Function): *void*
+
+*Inherited from [CountingWritable](countingwritable.md).[end](countingwritable.md#end)*
+
+Defined in node_modules/@types/node/base.d.ts:3778
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
+
+**Returns:** *void*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+Defined in node_modules/@types/node/base.d.ts:694
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
-
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+Defined in node_modules/@types/node/base.d.ts:691
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
-
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string, `listener`: Function): *this*
 
-▸ **on**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
 
-▸ **on**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-▸ **on**(event: *"error"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3806*
+Defined in node_modules/@types/node/base.d.ts:3806
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.on*
+▸ **on**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.on*
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3807*
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3808*
+Defined in node_modules/@types/node/base.d.ts:3807
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.on*
+▸ (): *void*
 
-*Overrides EventEmitter.on*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3809*
+▸ **on**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Returns:** `this`
-
-*Inherited from Writable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3810*
+Defined in node_modules/@types/node/base.d.ts:3808
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.on*
+▸ (): *void*
 
-*Overrides EventEmitter.on*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3811*
+▸ **on**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Returns:** `this`
-
-*Inherited from Writable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3812*
+Defined in node_modules/@types/node/base.d.ts:3809
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **on**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3810
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **on**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3811
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **on**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3812
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string, `listener`: Function): *this*
 
-▸ **once**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
 
-▸ **once**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-▸ **once**(event: *"error"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3814*
+Defined in node_modules/@types/node/base.d.ts:3814
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.once*
+▸ **once**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.once*
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3815*
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3816*
+Defined in node_modules/@types/node/base.d.ts:3815
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.once*
+▸ (): *void*
 
-*Overrides EventEmitter.once*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3817*
+▸ **once**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Returns:** `this`
-
-*Inherited from Writable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3818*
+Defined in node_modules/@types/node/base.d.ts:3816
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.once*
+▸ (): *void*
 
-*Overrides EventEmitter.once*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3819*
+▸ **once**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Returns:** `this`
-
-*Inherited from Writable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3820*
+Defined in node_modules/@types/node/base.d.ts:3817
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **once**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3818
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **once**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3819
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **once**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3820
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="pipe"></a>
 
 ###  pipe
 
-▸ **pipe**<`T`>(destination: *`T`*, options?: *`undefined` \| `object`*): `T`
+▸ **pipe**<**T**>(`destination`: T, `options?`: undefined | object): *T*
 
-*Inherited from internal.pipe*
+*Inherited from [CountingWritable](countingwritable.md).[pipe](countingwritable.md#pipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3673*
+Defined in node_modules/@types/node/base.d.ts:3673
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| destination | `T` |
-| `Optional` options | `undefined` \| `object` |
+Name | Type |
+------ | ------ |
+`destination` | T |
+`options?` | undefined &#124; object |
 
-**Returns:** `T`
+**Returns:** *T*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
 
-▸ **prependListener**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-▸ **prependListener**(event: *"error"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3822*
+Defined in node_modules/@types/node/base.d.ts:3822
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.prependListener*
+▸ **prependListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependListener*
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3823*
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3824*
+Defined in node_modules/@types/node/base.d.ts:3823
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.prependListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3825*
+▸ **prependListener**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3826*
+Defined in node_modules/@types/node/base.d.ts:3824
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.prependListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3827*
+▸ **prependListener**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3828*
+Defined in node_modules/@types/node/base.d.ts:3825
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3826
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3827
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3828
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependOnceListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"error"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3830*
+Defined in node_modules/@types/node/base.d.ts:3830
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.prependOnceListener*
+▸ **prependOnceListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependOnceListener*
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3831*
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3832*
+Defined in node_modules/@types/node/base.d.ts:3831
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.prependOnceListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependOnceListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3833*
+▸ **prependOnceListener**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3834*
+Defined in node_modules/@types/node/base.d.ts:3832
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.prependOnceListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependOnceListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3835*
+▸ **prependOnceListener**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3836*
+Defined in node_modules/@types/node/base.d.ts:3833
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3834
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3835
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3836
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string, `listener`: Function): *this*
 
-▸ **removeListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
 
-▸ **removeListener**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-▸ **removeListener**(event: *"error"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3838*
+Defined in node_modules/@types/node/base.d.ts:3838
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.removeListener*
+▸ **removeListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.removeListener*
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3839*
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3840*
+Defined in node_modules/@types/node/base.d.ts:3839
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.removeListener*
+▸ (): *void*
 
-*Overrides EventEmitter.removeListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3841*
+▸ **removeListener**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3842*
+Defined in node_modules/@types/node/base.d.ts:3840
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.removeListener*
+▸ (): *void*
 
-*Overrides EventEmitter.removeListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3843*
+▸ **removeListener**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3844*
+Defined in node_modules/@types/node/base.d.ts:3841
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3842
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3843
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3844
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="setdefaultencoding"></a>
 
 ###  setDefaultEncoding
 
-▸ **setDefaultEncoding**(encoding: *`string`*): `this`
+▸ **setDefaultEncoding**(`encoding`: string): *this*
 
-*Inherited from Writable.setDefaultEncoding*
+*Inherited from [CountingWritable](countingwritable.md).[setDefaultEncoding](countingwritable.md#setdefaultencoding)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3775*
+Defined in node_modules/@types/node/base.d.ts:3775
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| encoding | `string` |
+Name | Type |
+------ | ------ |
+`encoding` | string |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(chunk: *`any`*, cb?: *`Function`*): `boolean`
+▸ **write**(`chunk`: any, `cb?`: Function): *boolean*
 
-▸ **write**(chunk: *`any`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `boolean`
+*Inherited from [CountingWritable](countingwritable.md).[write](countingwritable.md#write)*
 
-*Inherited from Writable.write*
-
-*Defined in /node_modules/@types/node/base.d.ts:3773*
+Defined in node_modules/@types/node/base.d.ts:3773
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`cb?` | Function |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Writable.write*
+▸ **write**(`chunk`: any, `encoding?`: undefined | string, `cb?`: Function): *boolean*
 
-*Defined in /node_modules/@types/node/base.d.ts:3774*
+*Inherited from [CountingWritable](countingwritable.md).[write](countingwritable.md#write)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
-
-**Returns:** `boolean`
-
-___
-<a id="writebuffers"></a>
-
-### `<Private>` writeBuffers
-
-▸ **writeBuffers**(): `Promise`<`void`>
-
-*Defined in [block-write-stream.ts:82](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-write-stream.ts#L82)*
-
-**Returns:** `Promise`<`void`>
-
-___
-<a id="writechunk"></a>
-
-### `<Private>` writeChunk
-
-▸ **writeChunk**(buffer: *`Buffer`*, position: *`number`*, flushing?: *`boolean`*): `Promise`<`void`>
-
-*Defined in [block-write-stream.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/block-write-stream.ts#L50)*
+Defined in node_modules/@types/node/base.d.ts:3774
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| buffer | `Buffer` | - |
-| position | `number` | - |
-| `Default value` flushing | `boolean` | false |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
 
-**Returns:** `Promise`<`void`>
+**Returns:** *boolean*
 
 ___
-<a id="listenercount-1"></a>
 
-### `<Static>` listenerCount
+### `Private` writeBuffers
 
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
+▸ **writeBuffers**(): *Promise‹void›*
 
-*Inherited from EventEmitter.listenerCount*
+*Defined in [lib/block-write-stream.ts:82](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-write-stream.ts#L82)*
 
-*Defined in /node_modules/@types/node/base.d.ts:680*
+**Returns:** *Promise‹void›*
+
+___
+
+### `Private` writeChunk
+
+▸ **writeChunk**(`buffer`: Buffer, `position`: number, `flushing`: boolean): *Promise‹void›*
+
+*Defined in [lib/block-write-stream.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/block-write-stream.ts#L50)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type | Default |
+------ | ------ | ------ |
+`buffer` | Buffer | - |
+`position` | number | - |
+`flushing` | boolean | false |
 
-**Returns:** `number`
+**Returns:** *Promise‹void›*
 
 ___
 
+### `Static` listenerCount
+
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
+
+Defined in node_modules/@types/node/base.d.ts:680
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
+
+**Returns:** *number*

--- a/doc/classes/bzip2source.md
+++ b/doc/classes/bzip2source.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [BZip2Source](../classes/bzip2source.md)
+[etcher-sdk](../README.md) › [BZip2Source](bzip2source.md)
 
 # Class: BZip2Source
 
 ## Hierarchy
 
-↳  [CompressedSource](compressedsource.md)
+  ↳ [CompressedSource](compressedsource.md)
 
-**↳ BZip2Source**
+  ↳ **BZip2Source**
 
 ## Index
 
@@ -16,18 +16,18 @@
 
 ### Properties
 
-* [isSizeEstimated](bzip2source.md#issizeestimated)
-* [source](bzip2source.md#source)
-* [defaultMaxListeners](bzip2source.md#defaultmaxlisteners)
-* [imageExtensions](bzip2source.md#imageextensions)
-* [mimetype](bzip2source.md#mimetype)
-* [requiresRandomReadableSource](bzip2source.md#requiresrandomreadablesource)
+* [isSizeEstimated](bzip2source.md#protected-issizeestimated)
+* [source](bzip2source.md#protected-source)
+* [defaultMaxListeners](bzip2source.md#static-defaultmaxlisteners)
+* [imageExtensions](bzip2source.md#static-imageextensions)
+* [mimetype](bzip2source.md#static-mimetype)
+* [requiresRandomReadableSource](bzip2source.md#static-requiresrandomreadablesource)
 
 ### Methods
 
-* [_close](bzip2source.md#_close)
-* [_getMetadata](bzip2source.md#_getmetadata)
-* [_open](bzip2source.md#_open)
+* [_close](bzip2source.md#protected-_close)
+* [_getMetadata](bzip2source.md#protected-_getmetadata)
+* [_open](bzip2source.md#protected-_open)
 * [addListener](bzip2source.md#addlistener)
 * [canCreateReadStream](bzip2source.md#cancreatereadstream)
 * [canCreateSparseReadStream](bzip2source.md#cancreatesparsereadstream)
@@ -39,7 +39,7 @@
 * [createReadStream](bzip2source.md#createreadstream)
 * [createSparseReadStream](bzip2source.md#createsparsereadstream)
 * [createSparseWriteStream](bzip2source.md#createsparsewritestream)
-* [createTransform](bzip2source.md#createtransform)
+* [createTransform](bzip2source.md#protected-createtransform)
 * [createVerifier](bzip2source.md#createverifier)
 * [createWriteStream](bzip2source.md#createwritestream)
 * [emit](bzip2source.md#emit)
@@ -49,7 +49,7 @@
 * [getMaxListeners](bzip2source.md#getmaxlisteners)
 * [getMetadata](bzip2source.md#getmetadata)
 * [getPartitionTable](bzip2source.md#getpartitiontable)
-* [getSize](bzip2source.md#getsize)
+* [getSize](bzip2source.md#protected-getsize)
 * [listenerCount](bzip2source.md#listenercount)
 * [listeners](bzip2source.md#listeners)
 * [on](bzip2source.md#on)
@@ -62,73 +62,62 @@
 * [removeListener](bzip2source.md#removelistener)
 * [setMaxListeners](bzip2source.md#setmaxlisteners)
 * [write](bzip2source.md#write)
-* [listenerCount](bzip2source.md#listenercount-1)
-* [register](bzip2source.md#register)
-
----
+* [listenerCount](bzip2source.md#static-listenercount)
+* [register](bzip2source.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new BZip2Source**(source: *[SourceDestination](sourcedestination.md)*): [BZip2Source](bzip2source.md)
+\+ **new BZip2Source**(`source`: [SourceDestination](sourcedestination.md)): *[BZip2Source](bzip2source.md)*
 
 *Inherited from [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
 
-*Defined in [source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L20)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| source | [SourceDestination](sourcedestination.md) |
+Name | Type |
+------ | ------ |
+`source` | [SourceDestination](sourcedestination.md) |
 
-**Returns:** [BZip2Source](bzip2source.md)
-
-___
+**Returns:** *[BZip2Source](bzip2source.md)*
 
 ## Properties
 
-<a id="issizeestimated"></a>
+### `Protected` isSizeEstimated
 
-### `<Protected>` isSizeEstimated
+• **isSizeEstimated**: *boolean* = false
 
-**● isSizeEstimated**: *`boolean`* = false
+*Inherited from [CompressedSource](compressedsource.md).[isSizeEstimated](compressedsource.md#protected-issizeestimated)*
 
-*Inherited from [CompressedSource](compressedsource.md).[isSizeEstimated](compressedsource.md#issizeestimated)*
-
-*Defined in [source-destination/compressed-source.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L44)*
+*Defined in [lib/source-destination/compressed-source.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L44)*
 
 ___
-<a id="source"></a>
 
-### `<Protected>` source
+### `Protected` source
 
-**● source**: *[SourceDestination](sourcedestination.md)*
+• **source**: *[SourceDestination](sourcedestination.md)*
 
-*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#source)*
+*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
 
-*Defined in [source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L22)*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L22)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Static` defaultMaxListeners
 
-**● imageExtensions**: *`string`[]* =  [
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -141,702 +130,655 @@ ___
 		'wic',
 	]
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
-
-___
-<a id="mimetype"></a>
-
-### `<Static>` mimetype
-
-**● mimetype**: *"application/x-bzip2"* = "application/x-bzip2"
-
-*Overrides [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
-
-*Defined in [source-destination/bzip2.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/bzip2.ts#L24)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
-<a id="requiresrandomreadablesource"></a>
 
-### `<Static>` requiresRandomReadableSource
+### `Static` mimetype
 
-**● requiresRandomReadableSource**: *`boolean`* = false
+▪ **mimetype**: *"application/x-bzip2"* = "application/x-bzip2"
 
-*Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#requiresrandomreadablesource)*
+*Overrides [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
 
-*Defined in [source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/bzip2.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/bzip2.ts#L24)*
 
 ___
+
+### `Static` requiresRandomReadableSource
+
+▪ **requiresRandomReadableSource**: *boolean* = false
+
+*Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
+
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L20)*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Inherited from [SourceSource](sourcesource.md).[_close](sourcesource.md#protected-_close)*
 
-*Inherited from [SourceSource](sourcesource.md).[_close](sourcesource.md#_close)*
+*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#_close)*
+*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L30)*
 
-*Defined in [source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L30)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [CompressedSource](compressedsource.md).[_getMetadata](compressedsource.md#_getmetadata)*
+*Inherited from [CompressedSource](compressedsource.md).[_getMetadata](compressedsource.md#protected-_getmetadata)*
 
-*Overrides [SourceDestination](sourcedestination.md).[_getMetadata](sourcedestination.md#_getmetadata)*
+*Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [source-destination/compressed-source.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L84)*
+*Defined in [lib/source-destination/compressed-source.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L84)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Inherited from [SourceSource](sourcesource.md).[_open](sourcesource.md#_open)*
-
-*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#_open)*
-
-*Defined in [source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L26)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Inherited from [SourceSource](sourcesource.md).[_open](sourcesource.md#protected-_open)*
+
+*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
+
+*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L26)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
 *Inherited from [CompressedSource](compressedsource.md).[canCreateReadStream](compressedsource.md#cancreatereadstream)*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/compressed-source.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L50)*
+*Defined in [lib/source-destination/compressed-source.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L50)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L268)*
+*Defined in [lib/source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L268)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseWriteStream](sourcedestination.md#cancreatesparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L276)*
+*Defined in [lib/source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L276)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateWriteStream](sourcedestination.md#cancreatewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L272)*
+*Defined in [lib/source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L272)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L256)*
+*Defined in [lib/source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L256)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canWrite](sourcedestination.md#canwrite)*
+*Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L260)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(emitProgress?: *`boolean`*, start?: *`number`*, end?: *`undefined` \| `number`*): `Promise`<[SourceTransform](../interfaces/sourcetransform.md)>
+▸ **createReadStream**(`emitProgress`: boolean, `start`: number, `end?`: undefined | number): *Promise‹[SourceTransform](../interfaces/sourcetransform.md)›*
 
 *Inherited from [CompressedSource](compressedsource.md).[createReadStream](compressedsource.md#createreadstream)*
 
-*Overrides [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/compressed-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L54)*
+*Defined in [lib/source-destination/compressed-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L54)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` emitProgress | `boolean` | false |
-| `Default value` start | `number` | 0 |
-| `Optional` end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`emitProgress` | boolean | false |
+`start` | number | 0 |
+`end?` | undefined &#124; number | - |
 
-**Returns:** `Promise`<[SourceTransform](../interfaces/sourcetransform.md)>
+**Returns:** *Promise‹[SourceTransform](../interfaces/sourcetransform.md)›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(_generateChecksums?: *`boolean`*): `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+▸ **createSparseReadStream**(`_generateChecksums`: boolean): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L317)*
+*Defined in [lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L317)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _generateChecksums | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`_generateChecksums` | boolean | false |
 
-**Returns:** `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseWriteStream](sourcedestination.md#createsparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L331)*
+*Defined in [lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L331)*
 
-**Returns:** `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
-
-___
-<a id="createtransform"></a>
-
-### `<Protected>` createTransform
-
-▸ **createTransform**(): `Transform`
-
-*Overrides [CompressedSource](compressedsource.md).[createTransform](compressedsource.md#createtransform)*
-
-*Defined in [source-destination/bzip2.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/bzip2.ts#L26)*
-
-**Returns:** `Transform`
+**Returns:** *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
 ___
-<a id="createverifier"></a>
+
+### `Protected` createTransform
+
+▸ **createTransform**(): *Transform*
+
+*Overrides [CompressedSource](compressedsource.md).[createTransform](compressedsource.md#protected-abstract-createtransform)*
+
+*Defined in [lib/source-destination/bzip2.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/bzip2.ts#L26)*
+
+**Returns:** *Transform*
+
+___
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createWriteStream](sourcedestination.md#createwritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L327)*
+*Defined in [lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L327)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
-
-___
-<a id="getsize"></a>
-
-### `<Protected>` getSize
-
-▸ **getSize**(): `Promise`<`number` \| `undefined`>
-
-*Inherited from [CompressedSource](compressedsource.md).[getSize](compressedsource.md#getsize)*
-
-*Defined in [source-destination/compressed-source.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L46)*
-
-**Returns:** `Promise`<`number` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="listenercount"></a>
+
+### `Protected` getSize
+
+▸ **getSize**(): *Promise‹number | undefined›*
+
+*Inherited from [CompressedSource](compressedsource.md).[getSize](compressedsource.md#protected-getsize)*
+
+*Defined in [lib/source-destination/compressed-source.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L46)*
+
+**Returns:** *Promise‹number | undefined›*
+
+___
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_sourceOffset`: number): *Promise‹ReadResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[read](sourcedestination.md#read)*
+*Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L291)*
+*Defined in [lib/source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L291)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[write](sourcedestination.md#write)*
+*Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L300)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L300)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/classes/checksumverificationerror.md
+++ b/doc/classes/checksumverificationerror.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [ChecksumVerificationError](../classes/checksumverificationerror.md)
+[etcher-sdk](../README.md) › [ChecksumVerificationError](checksumverificationerror.md)
 
 # Class: ChecksumVerificationError
 
 ## Hierarchy
 
-↳  [VerificationError](verificationerror.md)
+  ↳ [VerificationError](verificationerror.md)
 
-**↳ ChecksumVerificationError**
+  ↳ **ChecksumVerificationError**
 
 ## Index
 
@@ -21,96 +21,78 @@
 * [expectedChecksum](checksumverificationerror.md#expectedchecksum)
 * [message](checksumverificationerror.md#message)
 * [name](checksumverificationerror.md#name)
-* [stack](checksumverificationerror.md#stack)
-
----
+* [stack](checksumverificationerror.md#optional-stack)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new ChecksumVerificationError**(message: *`string`*, checksum: *`string`*, expectedChecksum: *`string`*): [ChecksumVerificationError](checksumverificationerror.md)
+\+ **new ChecksumVerificationError**(`message`: string, `checksum`: string, `expectedChecksum`: string): *[ChecksumVerificationError](checksumverificationerror.md)*
 
-*Defined in [errors.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/errors.ts#L27)*
+*Defined in [lib/errors.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/errors.ts#L27)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| message | `string` |
-| checksum | `string` |
-| expectedChecksum | `string` |
+Name | Type |
+------ | ------ |
+`message` | string |
+`checksum` | string |
+`expectedChecksum` | string |
 
-**Returns:** [ChecksumVerificationError](checksumverificationerror.md)
-
-___
+**Returns:** *[ChecksumVerificationError](checksumverificationerror.md)*
 
 ## Properties
 
-<a id="checksum"></a>
-
 ###  checksum
 
-**● checksum**: *`string`*
+• **checksum**: *string*
 
-*Defined in [errors.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/errors.ts#L30)*
+*Defined in [lib/errors.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/errors.ts#L30)*
 
 ___
-<a id="code"></a>
 
 ###  code
 
-**● code**: *`string`* = "EVALIDATION"
+• **code**: *string* = "EVALIDATION"
 
 *Inherited from [VerificationError](verificationerror.md).[code](verificationerror.md#code)*
 
-*Defined in [errors.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/errors.ts#L24)*
+*Defined in [lib/errors.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/errors.ts#L24)*
 
 ___
-<a id="expectedchecksum"></a>
 
 ###  expectedChecksum
 
-**● expectedChecksum**: *`string`*
+• **expectedChecksum**: *string*
 
-*Defined in [errors.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/errors.ts#L31)*
+*Defined in [lib/errors.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/errors.ts#L31)*
 
 ___
-<a id="message"></a>
 
 ###  message
 
-**● message**: *`string`*
+• **message**: *string*
 
-*Inherited from Error.message*
+*Inherited from [NotCapable](notcapable.md).[message](notcapable.md#message)*
 
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:964*
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:974
 
 ___
-<a id="name"></a>
 
 ###  name
 
-**● name**: *`string`*
+• **name**: *string*
 
-*Inherited from Error.name*
+*Inherited from [NotCapable](notcapable.md).[name](notcapable.md#name)*
 
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:963*
-
-___
-<a id="stack"></a>
-
-### `<Optional>` stack
-
-**● stack**: *`undefined` \| `string`*
-
-*Inherited from Error.stack*
-
-*Overrides Error.stack*
-
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:965*
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:973
 
 ___
 
+### `Optional` stack
+
+• **stack**? : *undefined | string*
+
+*Inherited from [NotCapable](notcapable.md).[stack](notcapable.md#optional-stack)*
+
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:975

--- a/doc/classes/compressedsource.md
+++ b/doc/classes/compressedsource.md
@@ -1,18 +1,18 @@
-[etcher-sdk](../README.md) > [CompressedSource](../classes/compressedsource.md)
+[etcher-sdk](../README.md) › [CompressedSource](compressedsource.md)
 
 # Class: CompressedSource
 
 ## Hierarchy
 
-↳  [SourceSource](sourcesource.md)
+  ↳ [SourceSource](sourcesource.md)
 
-**↳ CompressedSource**
+  ↳ **CompressedSource**
 
-↳  [BZip2Source](bzip2source.md)
+  ↳ [BZip2Source](bzip2source.md)
 
-↳  [GZipSource](gzipsource.md)
+  ↳ [GZipSource](gzipsource.md)
 
-↳  [XzSource](xzsource.md)
+  ↳ [XzSource](xzsource.md)
 
 ## Index
 
@@ -22,18 +22,18 @@
 
 ### Properties
 
-* [isSizeEstimated](compressedsource.md#issizeestimated)
-* [source](compressedsource.md#source)
-* [defaultMaxListeners](compressedsource.md#defaultmaxlisteners)
-* [imageExtensions](compressedsource.md#imageextensions)
-* [mimetype](compressedsource.md#mimetype)
-* [requiresRandomReadableSource](compressedsource.md#requiresrandomreadablesource)
+* [isSizeEstimated](compressedsource.md#protected-issizeestimated)
+* [source](compressedsource.md#protected-source)
+* [defaultMaxListeners](compressedsource.md#static-defaultmaxlisteners)
+* [imageExtensions](compressedsource.md#static-imageextensions)
+* [mimetype](compressedsource.md#static-optional-mimetype)
+* [requiresRandomReadableSource](compressedsource.md#static-requiresrandomreadablesource)
 
 ### Methods
 
-* [_close](compressedsource.md#_close)
-* [_getMetadata](compressedsource.md#_getmetadata)
-* [_open](compressedsource.md#_open)
+* [_close](compressedsource.md#protected-_close)
+* [_getMetadata](compressedsource.md#protected-_getmetadata)
+* [_open](compressedsource.md#protected-_open)
 * [addListener](compressedsource.md#addlistener)
 * [canCreateReadStream](compressedsource.md#cancreatereadstream)
 * [canCreateSparseReadStream](compressedsource.md#cancreatesparsereadstream)
@@ -45,7 +45,7 @@
 * [createReadStream](compressedsource.md#createreadstream)
 * [createSparseReadStream](compressedsource.md#createsparsereadstream)
 * [createSparseWriteStream](compressedsource.md#createsparsewritestream)
-* [createTransform](compressedsource.md#createtransform)
+* [createTransform](compressedsource.md#protected-abstract-createtransform)
 * [createVerifier](compressedsource.md#createverifier)
 * [createWriteStream](compressedsource.md#createwritestream)
 * [emit](compressedsource.md#emit)
@@ -55,7 +55,7 @@
 * [getMaxListeners](compressedsource.md#getmaxlisteners)
 * [getMetadata](compressedsource.md#getmetadata)
 * [getPartitionTable](compressedsource.md#getpartitiontable)
-* [getSize](compressedsource.md#getsize)
+* [getSize](compressedsource.md#protected-getsize)
 * [listenerCount](compressedsource.md#listenercount)
 * [listeners](compressedsource.md#listeners)
 * [on](compressedsource.md#on)
@@ -68,71 +68,60 @@
 * [removeListener](compressedsource.md#removelistener)
 * [setMaxListeners](compressedsource.md#setmaxlisteners)
 * [write](compressedsource.md#write)
-* [listenerCount](compressedsource.md#listenercount-1)
-* [register](compressedsource.md#register)
-
----
+* [listenerCount](compressedsource.md#static-listenercount)
+* [register](compressedsource.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new CompressedSource**(source: *[SourceDestination](sourcedestination.md)*): [CompressedSource](compressedsource.md)
+\+ **new CompressedSource**(`source`: [SourceDestination](sourcedestination.md)): *[CompressedSource](compressedsource.md)*
 
 *Inherited from [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
 
-*Defined in [source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L20)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| source | [SourceDestination](sourcedestination.md) |
+Name | Type |
+------ | ------ |
+`source` | [SourceDestination](sourcedestination.md) |
 
-**Returns:** [CompressedSource](compressedsource.md)
-
-___
+**Returns:** *[CompressedSource](compressedsource.md)*
 
 ## Properties
 
-<a id="issizeestimated"></a>
+### `Protected` isSizeEstimated
 
-### `<Protected>` isSizeEstimated
+• **isSizeEstimated**: *boolean* = false
 
-**● isSizeEstimated**: *`boolean`* = false
-
-*Defined in [source-destination/compressed-source.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L44)*
+*Defined in [lib/source-destination/compressed-source.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L44)*
 
 ___
-<a id="source"></a>
 
-### `<Protected>` source
+### `Protected` source
 
-**● source**: *[SourceDestination](sourcedestination.md)*
+• **source**: *[SourceDestination](sourcedestination.md)*
 
-*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#source)*
+*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
 
-*Defined in [source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L22)*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L22)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Static` defaultMaxListeners
 
-**● imageExtensions**: *`string`[]* =  [
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -145,692 +134,645 @@ ___
 		'wic',
 	]
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
-
-___
-<a id="mimetype"></a>
-
-### `<Static>``<Optional>` mimetype
-
-**● mimetype**: *`undefined` \| `string`*
-
-*Inherited from [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
-
-*Defined in [source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L244)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
-<a id="requiresrandomreadablesource"></a>
 
-### `<Static>` requiresRandomReadableSource
+### `Static` `Optional` mimetype
 
-**● requiresRandomReadableSource**: *`boolean`* = false
+▪ **mimetype**? : *undefined | string*
 
-*Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#requiresrandomreadablesource)*
+*Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
 
-*Defined in [source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L244)*
 
 ___
+
+### `Static` requiresRandomReadableSource
+
+▪ **requiresRandomReadableSource**: *boolean* = false
+
+*Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
+
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L20)*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Inherited from [SourceSource](sourcesource.md).[_close](sourcesource.md#protected-_close)*
 
-*Inherited from [SourceSource](sourcesource.md).[_close](sourcesource.md#_close)*
+*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#_close)*
+*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L30)*
 
-*Defined in [source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L30)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Overrides [SourceDestination](sourcedestination.md).[_getMetadata](sourcedestination.md#_getmetadata)*
+*Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [source-destination/compressed-source.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L84)*
+*Defined in [lib/source-destination/compressed-source.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L84)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Inherited from [SourceSource](sourcesource.md).[_open](sourcesource.md#_open)*
-
-*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#_open)*
-
-*Defined in [source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L26)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Inherited from [SourceSource](sourcesource.md).[_open](sourcesource.md#protected-_open)*
+
+*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
+
+*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L26)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/compressed-source.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L50)*
+*Defined in [lib/source-destination/compressed-source.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L50)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L268)*
+*Defined in [lib/source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L268)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseWriteStream](sourcedestination.md#cancreatesparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L276)*
+*Defined in [lib/source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L276)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateWriteStream](sourcedestination.md#cancreatewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L272)*
+*Defined in [lib/source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L272)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L256)*
+*Defined in [lib/source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L256)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canWrite](sourcedestination.md#canwrite)*
+*Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L260)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(emitProgress?: *`boolean`*, start?: *`number`*, end?: *`undefined` \| `number`*): `Promise`<[SourceTransform](../interfaces/sourcetransform.md)>
+▸ **createReadStream**(`emitProgress`: boolean, `start`: number, `end?`: undefined | number): *Promise‹[SourceTransform](../interfaces/sourcetransform.md)›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/compressed-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L54)*
+*Defined in [lib/source-destination/compressed-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L54)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` emitProgress | `boolean` | false |
-| `Default value` start | `number` | 0 |
-| `Optional` end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`emitProgress` | boolean | false |
+`start` | number | 0 |
+`end?` | undefined &#124; number | - |
 
-**Returns:** `Promise`<[SourceTransform](../interfaces/sourcetransform.md)>
+**Returns:** *Promise‹[SourceTransform](../interfaces/sourcetransform.md)›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(_generateChecksums?: *`boolean`*): `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+▸ **createSparseReadStream**(`_generateChecksums`: boolean): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L317)*
+*Defined in [lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L317)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _generateChecksums | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`_generateChecksums` | boolean | false |
 
-**Returns:** `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseWriteStream](sourcedestination.md#createsparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L331)*
+*Defined in [lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L331)*
 
-**Returns:** `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
-
-___
-<a id="createtransform"></a>
-
-### `<Protected>``<Abstract>` createTransform
-
-▸ **createTransform**(): `Transform`
-
-*Defined in [source-destination/compressed-source.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L43)*
-
-**Returns:** `Transform`
+**Returns:** *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
 ___
-<a id="createverifier"></a>
+
+### `Protected` `Abstract` createTransform
+
+▸ **createTransform**(): *Transform*
+
+*Defined in [lib/source-destination/compressed-source.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L43)*
+
+**Returns:** *Transform*
+
+___
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createWriteStream](sourcedestination.md#createwritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L327)*
+*Defined in [lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L327)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
-
-___
-<a id="getsize"></a>
-
-### `<Protected>` getSize
-
-▸ **getSize**(): `Promise`<`number` \| `undefined`>
-
-*Defined in [source-destination/compressed-source.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L46)*
-
-**Returns:** `Promise`<`number` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="listenercount"></a>
+
+### `Protected` getSize
+
+▸ **getSize**(): *Promise‹number | undefined›*
+
+*Defined in [lib/source-destination/compressed-source.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L46)*
+
+**Returns:** *Promise‹number | undefined›*
+
+___
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_sourceOffset`: number): *Promise‹ReadResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[read](sourcedestination.md#read)*
+*Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L291)*
+*Defined in [lib/source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L291)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[write](sourcedestination.md#write)*
+*Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L300)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L300)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/classes/configuredsource.md
+++ b/doc/classes/configuredsource.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [ConfiguredSource](../classes/configuredsource.md)
+[etcher-sdk](../README.md) › [ConfiguredSource](configuredsource.md)
 
 # Class: ConfiguredSource
 
 ## Hierarchy
 
-↳  [SourceSource](sourcesource.md)
+  ↳ [SourceSource](sourcesource.md)
 
-**↳ ConfiguredSource**
+  ↳ **ConfiguredSource**
 
 ## Index
 
@@ -16,24 +16,24 @@
 
 ### Properties
 
-* [checksumType](configuredsource.md#checksumtype)
-* [chunkSize](configuredsource.md#chunksize)
-* [config](configuredsource.md#config)
-* [configure](configuredsource.md#configure)
-* [createStreamFromDisk](configuredsource.md#createstreamfromdisk)
-* [disk](configuredsource.md#disk)
-* [shouldTrimPartitions](configuredsource.md#shouldtrimpartitions)
-* [source](configuredsource.md#source)
-* [defaultMaxListeners](configuredsource.md#defaultmaxlisteners)
-* [imageExtensions](configuredsource.md#imageextensions)
-* [mimetype](configuredsource.md#mimetype)
-* [requiresRandomReadableSource](configuredsource.md#requiresrandomreadablesource)
+* [checksumType](configuredsource.md#private-checksumtype)
+* [chunkSize](configuredsource.md#private-chunksize)
+* [config](configuredsource.md#private-optional-config)
+* [configure](configuredsource.md#private-optional-configure)
+* [createStreamFromDisk](configuredsource.md#private-createstreamfromdisk)
+* [disk](configuredsource.md#private-disk)
+* [shouldTrimPartitions](configuredsource.md#private-shouldtrimpartitions)
+* [source](configuredsource.md#protected-source)
+* [defaultMaxListeners](configuredsource.md#static-defaultmaxlisteners)
+* [imageExtensions](configuredsource.md#static-imageextensions)
+* [mimetype](configuredsource.md#static-optional-mimetype)
+* [requiresRandomReadableSource](configuredsource.md#static-requiresrandomreadablesource)
 
 ### Methods
 
-* [_close](configuredsource.md#_close)
-* [_getMetadata](configuredsource.md#_getmetadata)
-* [_open](configuredsource.md#_open)
+* [_close](configuredsource.md#protected-_close)
+* [_getMetadata](configuredsource.md#protected-_getmetadata)
+* [_open](configuredsource.md#protected-_open)
 * [addListener](configuredsource.md#addlistener)
 * [canCreateReadStream](configuredsource.md#cancreatereadstream)
 * [canCreateSparseReadStream](configuredsource.md#cancreatesparsereadstream)
@@ -44,15 +44,15 @@
 * [close](configuredsource.md#close)
 * [createReadStream](configuredsource.md#createreadstream)
 * [createSparseReadStream](configuredsource.md#createsparsereadstream)
-* [createSparseReadStreamFromDisk](configuredsource.md#createsparsereadstreamfromdisk)
-* [createSparseReadStreamFromStream](configuredsource.md#createsparsereadstreamfromstream)
+* [createSparseReadStreamFromDisk](configuredsource.md#private-createsparsereadstreamfromdisk)
+* [createSparseReadStreamFromStream](configuredsource.md#private-createsparsereadstreamfromstream)
 * [createSparseWriteStream](configuredsource.md#createsparsewritestream)
 * [createVerifier](configuredsource.md#createverifier)
 * [createWriteStream](configuredsource.md#createwritestream)
 * [emit](configuredsource.md#emit)
 * [eventNames](configuredsource.md#eventnames)
 * [getBlocks](configuredsource.md#getblocks)
-* [getBlocksWithChecksumType](configuredsource.md#getblockswithchecksumtype)
+* [getBlocksWithChecksumType](configuredsource.md#private-getblockswithchecksumtype)
 * [getInnerSource](configuredsource.md#getinnersource)
 * [getMaxListeners](configuredsource.md#getmaxlisteners)
 * [getMetadata](configuredsource.md#getmetadata)
@@ -68,133 +68,116 @@
 * [removeAllListeners](configuredsource.md#removealllisteners)
 * [removeListener](configuredsource.md#removelistener)
 * [setMaxListeners](configuredsource.md#setmaxlisteners)
-* [trimPartitions](configuredsource.md#trimpartitions)
+* [trimPartitions](configuredsource.md#private-trimpartitions)
 * [write](configuredsource.md#write)
-* [listenerCount](configuredsource.md#listenercount-1)
-* [register](configuredsource.md#register)
-
----
+* [listenerCount](configuredsource.md#static-listenercount)
+* [register](configuredsource.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new ConfiguredSource**(source: *[SourceDestination](sourcedestination.md)*, shouldTrimPartitions: *`boolean`*, createStreamFromDisk: *`boolean`*, configure?: *[ConfigureFunction](../#configurefunction) \| "legacy"*, config?: *`any`*, checksumType?: *[ChecksumType](../#checksumtype)*, chunkSize?: *`number`*): [ConfiguredSource](configuredsource.md)
+\+ **new ConfiguredSource**(`source`: [SourceDestination](sourcedestination.md), `shouldTrimPartitions`: boolean, `createStreamFromDisk`: boolean, `configure?`: [ConfigureFunction](../README.md#configurefunction) | "legacy", `config?`: any, `checksumType`: [ChecksumType](../README.md#checksumtype), `chunkSize`: number): *[ConfiguredSource](configuredsource.md)*
 
 *Overrides [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
 
-*Defined in [source-destination/configured-source/configured-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L87)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L87)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| source | [SourceDestination](sourcedestination.md) | - |
-| shouldTrimPartitions | `boolean` | - |
-| createStreamFromDisk | `boolean` | - |
-| `Optional` configure | [ConfigureFunction](../#configurefunction) \| "legacy" | - |
-| `Optional` config | `any` | - |
-| `Default value` checksumType | [ChecksumType](../#checksumtype) | &quot;xxhash64&quot; |
-| `Default value` chunkSize | `number` |  CHUNK_SIZE |
+Name | Type | Default |
+------ | ------ | ------ |
+`source` | [SourceDestination](sourcedestination.md) | - |
+`shouldTrimPartitions` | boolean | - |
+`createStreamFromDisk` | boolean | - |
+`configure?` | [ConfigureFunction](../README.md#configurefunction) &#124; "legacy" | - |
+`config?` | any | - |
+`checksumType` | [ChecksumType](../README.md#checksumtype) | "xxhash64" |
+`chunkSize` | number | CHUNK_SIZE |
 
-**Returns:** [ConfiguredSource](configuredsource.md)
-
-___
+**Returns:** *[ConfiguredSource](configuredsource.md)*
 
 ## Properties
 
-<a id="checksumtype"></a>
+### `Private` checksumType
 
-### `<Private>` checksumType
+• **checksumType**: *[ChecksumType](../README.md#checksumtype)*
 
-**● checksumType**: *[ChecksumType](../#checksumtype)*
-
-*Defined in [source-destination/configured-source/configured-source.ts:96](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L96)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:96](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L96)*
 
 ___
-<a id="chunksize"></a>
 
-### `<Private>` chunkSize
+### `Private` chunkSize
 
-**● chunkSize**: *`number`*
+• **chunkSize**: *number*
 
-*Defined in [source-destination/configured-source/configured-source.ts:97](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L97)*
-
-___
-<a id="config"></a>
-
-### `<Private>``<Optional>` config
-
-**● config**: *`any`*
-
-*Defined in [source-destination/configured-source/configured-source.ts:95](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L95)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:97](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L97)*
 
 ___
-<a id="configure"></a>
 
-### `<Private>``<Optional>` configure
+### `Private` `Optional` config
 
-**● configure**: *[ConfigureFunction](../#configurefunction)*
+• **config**? : *any*
 
-*Defined in [source-destination/configured-source/configured-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L87)*
-
-___
-<a id="createstreamfromdisk"></a>
-
-### `<Private>` createStreamFromDisk
-
-**● createStreamFromDisk**: *`boolean`*
-
-*Defined in [source-destination/configured-source/configured-source.ts:93](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L93)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:95](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L95)*
 
 ___
-<a id="disk"></a>
 
-### `<Private>` disk
+### `Private` `Optional` configure
 
-**● disk**: *[SourceDisk](sourcedisk.md)*
+• **configure**? : *[ConfigureFunction](../README.md#configurefunction)*
 
-*Defined in [source-destination/configured-source/configured-source.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L86)*
-
-___
-<a id="shouldtrimpartitions"></a>
-
-### `<Private>` shouldTrimPartitions
-
-**● shouldTrimPartitions**: *`boolean`*
-
-*Defined in [source-destination/configured-source/configured-source.ts:92](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L92)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L87)*
 
 ___
-<a id="source"></a>
 
-### `<Protected>` source
+### `Private` createStreamFromDisk
 
-**● source**: *[SourceDestination](sourcedestination.md)*
+• **createStreamFromDisk**: *boolean*
 
-*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#source)*
-
-*Defined in [source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L22)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:93](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L93)*
 
 ___
-<a id="defaultmaxlisteners"></a>
 
-### `<Static>` defaultMaxListeners
+### `Private` disk
 
-**● defaultMaxListeners**: *`number`*
+• **disk**: *[SourceDisk](sourcedisk.md)*
 
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L86)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Private` shouldTrimPartitions
 
-**● imageExtensions**: *`string`[]* =  [
+• **shouldTrimPartitions**: *boolean*
+
+*Defined in [lib/source-destination/configured-source/configured-source.ts:92](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L92)*
+
+___
+
+### `Protected` source
+
+• **source**: *[SourceDestination](sourcedestination.md)*
+
+*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
+
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L22)*
+
+___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -207,726 +190,677 @@ ___
 		'wic',
 	]
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
-
-___
-<a id="mimetype"></a>
-
-### `<Static>``<Optional>` mimetype
-
-**● mimetype**: *`undefined` \| `string`*
-
-*Inherited from [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
-
-*Defined in [source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L244)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
-<a id="requiresrandomreadablesource"></a>
 
-### `<Static>` requiresRandomReadableSource
+### `Static` `Optional` mimetype
 
-**● requiresRandomReadableSource**: *`boolean`* = false
+▪ **mimetype**? : *undefined | string*
 
-*Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#requiresrandomreadablesource)*
+*Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
 
-*Defined in [source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L244)*
 
 ___
+
+### `Static` requiresRandomReadableSource
+
+▪ **requiresRandomReadableSource**: *boolean* = false
+
+*Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
+
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L20)*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Overrides [SourceSource](sourcesource.md).[_close](sourcesource.md#protected-_close)*
 
-*Overrides [SourceSource](sourcesource.md).[_close](sourcesource.md#_close)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:252](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L252)*
 
-*Defined in [source-destination/configured-source/configured-source.ts:252](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L252)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Overrides [SourceDestination](sourcedestination.md).[_getMetadata](sourcedestination.md#_getmetadata)*
+*Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [source-destination/configured-source/configured-source.ts:196](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L196)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:196](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L196)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Overrides [SourceSource](sourcesource.md).[_open](sourcesource.md#_open)*
-
-*Defined in [source-destination/configured-source/configured-source.ts:241](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L241)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Overrides [SourceSource](sourcesource.md).[_open](sourcesource.md#protected-_open)*
+
+*Defined in [lib/source-destination/configured-source/configured-source.ts:241](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L241)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/configured-source/configured-source.ts:131](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L131)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:131](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L131)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/configured-source/configured-source.ts:135](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L135)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:135](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L135)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseWriteStream](sourcedestination.md#cancreatesparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L276)*
+*Defined in [lib/source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L276)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateWriteStream](sourcedestination.md#cancreatewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L272)*
+*Defined in [lib/source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L272)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Overrides [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/configured-source/configured-source.ts:127](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L127)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:127](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L127)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canWrite](sourcedestination.md#canwrite)*
+*Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L260)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(...args: *`any`[]*): `Promise`<`ReadableStream`>
+▸ **createReadStream**(...`args`: any[]): *Promise‹ReadableStream›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/configured-source/configured-source.ts:148](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L148)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:148](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L148)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`...args` | any[] |
 
-**Returns:** `Promise`<`ReadableStream`>
+**Returns:** *Promise‹ReadableStream›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(generateChecksums: *`boolean`*): `Promise`<[SparseReadStream](sparsereadstream.md) \| [SparseFilterStream](sparsefilterstream.md)>
+▸ **createSparseReadStream**(`generateChecksums`: boolean): *Promise‹[SparseReadStream](sparsereadstream.md) | [SparseFilterStream](sparsefilterstream.md)›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Overrides [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/configured-source/configured-source.ts:186](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L186)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| generateChecksums | `boolean` |
-
-**Returns:** `Promise`<[SparseReadStream](sparsereadstream.md) \| [SparseFilterStream](sparsefilterstream.md)>
-
-___
-<a id="createsparsereadstreamfromdisk"></a>
-
-### `<Private>` createSparseReadStreamFromDisk
-
-▸ **createSparseReadStreamFromDisk**(generateChecksums: *`boolean`*): `Promise`<[SparseReadStream](sparsereadstream.md)>
-
-*Defined in [source-destination/configured-source/configured-source.ts:160](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L160)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:186](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L186)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| generateChecksums | `boolean` |
+Name | Type |
+------ | ------ |
+`generateChecksums` | boolean |
 
-**Returns:** `Promise`<[SparseReadStream](sparsereadstream.md)>
+**Returns:** *Promise‹[SparseReadStream](sparsereadstream.md) | [SparseFilterStream](sparsefilterstream.md)›*
 
 ___
-<a id="createsparsereadstreamfromstream"></a>
 
-### `<Private>` createSparseReadStreamFromStream
+### `Private` createSparseReadStreamFromDisk
 
-▸ **createSparseReadStreamFromStream**(generateChecksums: *`boolean`*): `Promise`<[SparseFilterStream](sparsefilterstream.md)>
+▸ **createSparseReadStreamFromDisk**(`generateChecksums`: boolean): *Promise‹[SparseReadStream](sparsereadstream.md)›*
 
-*Defined in [source-destination/configured-source/configured-source.ts:172](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L172)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:160](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L160)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| generateChecksums | `boolean` |
+Name | Type |
+------ | ------ |
+`generateChecksums` | boolean |
 
-**Returns:** `Promise`<[SparseFilterStream](sparsefilterstream.md)>
+**Returns:** *Promise‹[SparseReadStream](sparsereadstream.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
+
+### `Private` createSparseReadStreamFromStream
+
+▸ **createSparseReadStreamFromStream**(`generateChecksums`: boolean): *Promise‹[SparseFilterStream](sparsefilterstream.md)›*
+
+*Defined in [lib/source-destination/configured-source/configured-source.ts:172](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L172)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`generateChecksums` | boolean |
+
+**Returns:** *Promise‹[SparseFilterStream](sparsefilterstream.md)›*
+
+___
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseWriteStream](sourcedestination.md#createsparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L331)*
+*Defined in [lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L331)*
 
-**Returns:** `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+**Returns:** *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
 ___
-<a id="createverifier"></a>
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createWriteStream](sourcedestination.md#createwritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L327)*
+*Defined in [lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L327)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Overrides [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Overrides [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/configured-source/configured-source.ts:108](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L108)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:108](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L108)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getblockswithchecksumtype"></a>
 
-### `<Private>` getBlocksWithChecksumType
+### `Private` getBlocksWithChecksumType
 
-▸ **getBlocksWithChecksumType**(generateChecksums: *`boolean`*): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocksWithChecksumType**(`generateChecksums`: boolean): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Defined in [source-destination/configured-source/configured-source.ts:114](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L114)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:114](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L114)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| generateChecksums | `boolean` |
+Name | Type |
+------ | ------ |
+`generateChecksums` | boolean |
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(buffer: *`Buffer`*, bufferOffset: *`number`*, length: *`number`*, sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`buffer`: Buffer, `bufferOffset`: number, `length`: number, `sourceOffset`: number): *Promise‹ReadResult›*
 
-*Overrides [SourceDestination](sourcedestination.md).[read](sourcedestination.md#read)*
+*Overrides [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [source-destination/configured-source/configured-source.ts:139](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L139)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:139](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L139)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| bufferOffset | `number` |
-| length | `number` |
-| sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
+`bufferOffset` | number |
+`length` | number |
+`sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
-
-___
-<a id="trimpartitions"></a>
-
-### `<Private>` trimPartitions
-
-▸ **trimPartitions**(): `Promise`<`void`>
-
-*Defined in [source-destination/configured-source/configured-source.ts:203](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L203)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *this*
 
 ___
-<a id="write"></a>
+
+### `Private` trimPartitions
+
+▸ **trimPartitions**(): *Promise‹void›*
+
+*Defined in [lib/source-destination/configured-source/configured-source.ts:203](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L203)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  write
 
-▸ **write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[write](sourcedestination.md#write)*
+*Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L300)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L300)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/classes/countinghashstream.md
+++ b/doc/classes/countinghashstream.md
@@ -1,17 +1,17 @@
-[etcher-sdk](../README.md) > [CountingHashStream](../classes/countinghashstream.md)
+[etcher-sdk](../README.md) › [CountingHashStream](countinghashstream.md)
 
 # Class: CountingHashStream
 
 ## Hierarchy
 
- `Stream`
+* Stream
 
-**↳ CountingHashStream**
+  ↳ **CountingHashStream**
 
 ## Implements
 
-* `ReadableStream`
-* `Writable`
+* ReadableStream
+* Writable
 
 ## Index
 
@@ -24,7 +24,7 @@
 * [bytesWritten](countinghashstream.md#byteswritten)
 * [readable](countinghashstream.md#readable)
 * [writable](countinghashstream.md#writable)
-* [defaultMaxListeners](countinghashstream.md#defaultmaxlisteners)
+* [defaultMaxListeners](countinghashstream.md#static-defaultmaxlisteners)
 
 ### Methods
 
@@ -57,1317 +57,1364 @@
 * [unshift](countinghashstream.md#unshift)
 * [wrap](countinghashstream.md#wrap)
 * [write](countinghashstream.md#write)
-* [listenerCount](countinghashstream.md#listenercount-1)
-
----
+* [listenerCount](countinghashstream.md#static-listenercount)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new CountingHashStream**(seed: *`number`*, bits?: *`undefined` \| `number`*, enc?: *`undefined` \| `string`*): [CountingHashStream](countinghashstream.md)
+\+ **new CountingHashStream**(`seed`: number, `bits?`: undefined | number, `enc?`: undefined | string): *[CountingHashStream](countinghashstream.md)*
 
-*Inherited from Stream.__constructor*
+*Inherited from [CountingHashStream](countinghashstream.md).[constructor](countinghashstream.md#constructor)*
 
-*Overrides Transform.__constructor*
+*Overrides [SourceTransform](../interfaces/sourcetransform.md).[constructor](../interfaces/sourcetransform.md#constructor)*
 
-*Defined in [/typings/xxhash/index.d.ts:12](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/typings/xxhash/index.d.ts#L12)*
+*Defined in [typings/xxhash/index.d.ts:12](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/typings/xxhash/index.d.ts#L12)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| seed | `number` |
-| `Optional` bits | `undefined` \| `number` |
-| `Optional` enc | `undefined` \| `string` |
+Name | Type |
+------ | ------ |
+`seed` | number |
+`bits?` | undefined &#124; number |
+`enc?` | undefined &#124; string |
 
-**Returns:** [CountingHashStream](countinghashstream.md)
-
-___
+**Returns:** *[CountingHashStream](countinghashstream.md)*
 
 ## Properties
 
-<a id="byteswritten"></a>
-
 ###  bytesWritten
 
-**● bytesWritten**: *`number`* = 0
+• **bytesWritten**: *number* = 0
 
-*Defined in [source-destination/source-destination.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L48)*
+*Defined in [lib/source-destination/source-destination.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L48)*
 
 ___
-<a id="readable"></a>
 
 ###  readable
 
-**● readable**: *`boolean`*
+• **readable**: *boolean*
 
-*Inherited from Readable.readable*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[readable](sparsefilterstream.md#readable)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3688*
+Defined in node_modules/@types/node/base.d.ts:3688
 
 ___
-<a id="writable"></a>
 
 ###  writable
 
-**● writable**: *`boolean`*
+• **writable**: *boolean*
 
-*Inherited from Duplex.writable*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[writable](sparsefilterstream.md#writable)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3855*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+Defined in node_modules/@types/node/base.d.ts:3855
 
 ___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="_read"></a>
-
 ###  _read
 
-▸ **_read**(size: *`number`*): `void`
+▸ **_read**(`size`: number): *void*
 
-*Inherited from Readable._read*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[_read](sparsefilterstream.md#_read)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3690*
+Defined in node_modules/@types/node/base.d.ts:3690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| size | `number` |
+Name | Type |
+------ | ------ |
+`size` | number |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="_transform"></a>
 
 ###  _transform
 
-▸ **_transform**(chunk: *`Buffer`*, encoding: *`string`*, callback: *`function`*): `void`
+▸ **_transform**(`chunk`: Buffer, `encoding`: string, `callback`: function): *void*
 
-*Overrides Transform._transform*
+*Overrides [SourceTransform](../interfaces/sourcetransform.md).[_transform](../interfaces/sourcetransform.md#_transform)*
 
-*Defined in [source-destination/source-destination.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L50)*
+*Defined in [lib/source-destination/source-destination.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L50)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `Buffer` |
-| encoding | `string` |
-| callback | `function` |
+▪ **chunk**: *Buffer*
 
-**Returns:** `void`
+▪ **encoding**: *string*
+
+▪ **callback**: *function*
+
+▸ (): *void*
+
+**Returns:** *void*
 
 ___
-<a id="_write"></a>
 
 ###  _write
 
-▸ **_write**(chunk: *`any`*, encoding: *`string`*, callback: *`Function`*): `void`
+▸ **_write**(`chunk`: any, `encoding`: string, `callback`: Function): *void*
 
-*Inherited from Duplex._write*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[_write](sparsefilterstream.md#_write)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3857*
+Defined in node_modules/@types/node/base.d.ts:3857
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| encoding | `string` |
-| callback | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding` | string |
+`callback` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="addlistener"></a>
 
 ###  addListener
 
-▸ **addListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string, `listener`: Function): *this*
 
-▸ **addListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-▸ **addListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-▸ **addListener**(event: *"end"*, listener: *`function`*): `this`
+Defined in node_modules/@types/node/base.d.ts:3711
 
-▸ **addListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **addListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3711*
-
-Event emitter The defined events on documents including:
-
-1.  close
-2.  data
-3.  end
-4.  readable
-5.  error
+Event emitter
+The defined events on documents including:
+  1. close
+  2. data
+  3. end
+  4. readable
+  5. error
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.addListener*
+▸ **addListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.addListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3712*
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3713*
+Defined in node_modules/@types/node/base.d.ts:3712
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.addListener*
+▸ (): *void*
 
-*Overrides EventEmitter.addListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3714*
+▸ **addListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3715*
+Defined in node_modules/@types/node/base.d.ts:3713
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3716*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **addListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3714
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3715
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3716
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-▸ **emit**(event: *"close"*): `boolean`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-▸ **emit**(event: *"data"*, chunk: *`Buffer` \| `string`*): `boolean`
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-▸ **emit**(event: *"end"*): `boolean`
-
-▸ **emit**(event: *"readable"*): `boolean`
-
-▸ **emit**(event: *"error"*, err: *`Error`*): `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3718*
+Defined in node_modules/@types/node/base.d.ts:3718
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "close"): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3719*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-
-**Returns:** `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3720*
+Defined in node_modules/@types/node/base.d.ts:3719
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| chunk | `Buffer` \| `string` |
+Name | Type |
+------ | ------ |
+`event` | "close" |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "data", `chunk`: Buffer | string): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3721*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-
-**Returns:** `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3722*
+Defined in node_modules/@types/node/base.d.ts:3720
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
+Name | Type |
+------ | ------ |
+`event` | "data" |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "end"): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3723*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3721
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| err | `Error` |
+Name | Type |
+------ | ------ |
+`event` | "end" |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "readable"): *boolean*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3722
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "readable" |
+
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "error", `err`: [Error](notcapable.md#static-error)): *boolean*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3723
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "error" |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *boolean*
 
 ___
-<a id="end"></a>
 
 ###  end
 
-▸ **end**(cb?: *`Function`*): `void`
+▸ **end**(`cb?`: Function): *void*
 
-▸ **end**(chunk: *`any`*, cb?: *`Function`*): `void`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[end](sparsefilterstream.md#end)*
 
-▸ **end**(chunk: *`any`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `void`
-
-*Inherited from Duplex.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:3861*
+Defined in node_modules/@types/node/base.d.ts:3861
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
 
-*Inherited from Duplex.end*
+▸ **end**(`chunk`: any, `cb?`: Function): *void*
 
-*Defined in /node_modules/@types/node/base.d.ts:3862*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[end](sparsefilterstream.md#end)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` cb | `Function` |
-
-**Returns:** `void`
-
-*Inherited from Duplex.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:3863*
+Defined in node_modules/@types/node/base.d.ts:3862
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
+
+▸ **end**(`chunk`: any, `encoding?`: undefined | string, `cb?`: Function): *void*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[end](sparsefilterstream.md#end)*
+
+Defined in node_modules/@types/node/base.d.ts:3863
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
+
+**Returns:** *void*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+Defined in node_modules/@types/node/base.d.ts:694
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
-
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+Defined in node_modules/@types/node/base.d.ts:691
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
-
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="ispaused"></a>
 
 ###  isPaused
 
-▸ **isPaused**(): `boolean`
+▸ **isPaused**(): *boolean*
 
-*Inherited from Readable.isPaused*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[isPaused](sparsefilterstream.md#ispaused)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3695*
+Defined in node_modules/@types/node/base.d.ts:3695
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string, `listener`: Function): *this*
 
-▸ **on**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-▸ **on**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-▸ **on**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3725*
+Defined in node_modules/@types/node/base.d.ts:3725
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.on*
+▸ **on**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.on*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3726*
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3727*
+Defined in node_modules/@types/node/base.d.ts:3726
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.on*
+▸ (): *void*
 
-*Overrides EventEmitter.on*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3728*
+▸ **on**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Returns:** `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3729*
+Defined in node_modules/@types/node/base.d.ts:3727
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3730*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **on**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3728
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **on**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3729
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **on**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3730
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string, `listener`: Function): *this*
 
-▸ **once**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-▸ **once**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-▸ **once**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3732*
+Defined in node_modules/@types/node/base.d.ts:3732
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.once*
+▸ **once**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.once*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3733*
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3734*
+Defined in node_modules/@types/node/base.d.ts:3733
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.once*
+▸ (): *void*
 
-*Overrides EventEmitter.once*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3735*
+▸ **once**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Returns:** `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3736*
+Defined in node_modules/@types/node/base.d.ts:3734
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3737*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **once**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3735
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **once**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3736
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **once**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3737
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="pause"></a>
 
 ###  pause
 
-▸ **pause**(): `this`
+▸ **pause**(): *this*
 
-*Inherited from Readable.pause*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[pause](sparsefilterstream.md#pause)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3693*
+Defined in node_modules/@types/node/base.d.ts:3693
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="pipe"></a>
 
 ###  pipe
 
-▸ **pipe**<`T`>(destination: *`T`*, options?: *`undefined` \| `object`*): `T`
+▸ **pipe**<**T**>(`destination`: T, `options?`: undefined | object): *T*
 
-*Inherited from Readable.pipe*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[pipe](sparsefilterstream.md#pipe)*
 
-*Overrides internal.pipe*
+*Overrides [CountingWritable](countingwritable.md).[pipe](countingwritable.md#pipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3696*
+Defined in node_modules/@types/node/base.d.ts:3696
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| destination | `T` |
-| `Optional` options | `undefined` \| `object` |
+Name | Type |
+------ | ------ |
+`destination` | T |
+`options?` | undefined &#124; object |
 
-**Returns:** `T`
+**Returns:** *T*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-▸ **prependListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-▸ **prependListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3739*
+Defined in node_modules/@types/node/base.d.ts:3739
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.prependListener*
+▸ **prependListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3740*
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3741*
+Defined in node_modules/@types/node/base.d.ts:3740
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3742*
+▸ **prependListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3743*
+Defined in node_modules/@types/node/base.d.ts:3741
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3744*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3742
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3743
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3744
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependOnceListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3746*
+Defined in node_modules/@types/node/base.d.ts:3746
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.prependOnceListener*
+▸ **prependOnceListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependOnceListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3747*
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3748*
+Defined in node_modules/@types/node/base.d.ts:3747
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependOnceListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependOnceListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3749*
+▸ **prependOnceListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3750*
+Defined in node_modules/@types/node/base.d.ts:3748
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3751*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3749
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3750
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3751
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="push"></a>
 
 ###  push
 
-▸ **push**(chunk: *`any`*, encoding?: *`undefined` \| `string`*): `boolean`
+▸ **push**(`chunk`: any, `encoding?`: undefined | string): *boolean*
 
-*Inherited from Readable.push*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[push](sparsefilterstream.md#push)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3700*
+Defined in node_modules/@types/node/base.d.ts:3700
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(size?: *`undefined` \| `number`*): `any`
+▸ **read**(`size?`: undefined | number): *any*
 
-*Inherited from Readable.read*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[read](sparsefilterstream.md#read)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3691*
+Defined in node_modules/@types/node/base.d.ts:3691
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`size?` | undefined &#124; number |
 
-**Returns:** `any`
+**Returns:** *any*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string, `listener`: Function): *this*
 
-▸ **removeListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-▸ **removeListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-▸ **removeListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3753*
+Defined in node_modules/@types/node/base.d.ts:3753
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.removeListener*
+▸ **removeListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.removeListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3754*
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3755*
+Defined in node_modules/@types/node/base.d.ts:3754
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.removeListener*
+▸ (): *void*
 
-*Overrides EventEmitter.removeListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3756*
+▸ **removeListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3757*
+Defined in node_modules/@types/node/base.d.ts:3755
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3758*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3756
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3757
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3758
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="resume"></a>
 
 ###  resume
 
-▸ **resume**(): `this`
+▸ **resume**(): *this*
 
-*Inherited from Readable.resume*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[resume](sparsefilterstream.md#resume)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3694*
+Defined in node_modules/@types/node/base.d.ts:3694
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setdefaultencoding"></a>
 
 ###  setDefaultEncoding
 
-▸ **setDefaultEncoding**(encoding: *`string`*): `this`
+▸ **setDefaultEncoding**(`encoding`: string): *this*
 
-*Inherited from Duplex.setDefaultEncoding*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[setDefaultEncoding](sparsefilterstream.md#setdefaultencoding)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3860*
+Defined in node_modules/@types/node/base.d.ts:3860
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| encoding | `string` |
+Name | Type |
+------ | ------ |
+`encoding` | string |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setencoding"></a>
 
 ###  setEncoding
 
-▸ **setEncoding**(encoding: *`string`*): `void`
+▸ **setEncoding**(`encoding`: string): *void*
 
-*Inherited from Readable.setEncoding*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[setEncoding](sparsefilterstream.md#setencoding)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3692*
+Defined in node_modules/@types/node/base.d.ts:3692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| encoding | `string` |
+Name | Type |
+------ | ------ |
+`encoding` | string |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="unpipe"></a>
 
 ###  unpipe
 
-▸ **unpipe**<`T`>(destination?: *[T]()*): `void`
+▸ **unpipe**<**T**>(`destination?`: T): *void*
 
-*Inherited from Readable.unpipe*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[unpipe](sparsefilterstream.md#unpipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3697*
+Defined in node_modules/@types/node/base.d.ts:3697
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` destination | [T]() |
+Name | Type |
+------ | ------ |
+`destination?` | T |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="unshift"></a>
 
 ###  unshift
 
-▸ **unshift**(chunk: *`any`*): `void`
+▸ **unshift**(`chunk`: any): *void*
 
-*Inherited from Readable.unshift*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[unshift](sparsefilterstream.md#unshift)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3698*
+Defined in node_modules/@types/node/base.d.ts:3698
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="wrap"></a>
 
 ###  wrap
 
-▸ **wrap**(oldStream: *`ReadableStream`*): `Readable`
+▸ **wrap**(`oldStream`: ReadableStream): *Readable*
 
-*Inherited from Readable.wrap*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[wrap](sparsefilterstream.md#wrap)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3699*
+Defined in node_modules/@types/node/base.d.ts:3699
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| oldStream | `ReadableStream` |
+Name | Type |
+------ | ------ |
+`oldStream` | ReadableStream |
 
-**Returns:** `Readable`
+**Returns:** *Readable*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(chunk: *`any`*, cb?: *`Function`*): `boolean`
+▸ **write**(`chunk`: any, `cb?`: Function): *boolean*
 
-▸ **write**(chunk: *`any`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `boolean`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[write](sparsefilterstream.md#write)*
 
-*Inherited from Duplex.write*
-
-*Defined in /node_modules/@types/node/base.d.ts:3858*
+Defined in node_modules/@types/node/base.d.ts:3858
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`cb?` | Function |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Duplex.write*
+▸ **write**(`chunk`: any, `encoding?`: undefined | string, `cb?`: Function): *boolean*
 
-*Defined in /node_modules/@types/node/base.d.ts:3859*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[write](sparsefilterstream.md#write)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
-
-**Returns:** `boolean`
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:3859
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
 
-**Returns:** `number`
+**Returns:** *boolean*
 
 ___
 
+### `Static` listenerCount
+
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
+
+Defined in node_modules/@types/node/base.d.ts:680
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
+
+**Returns:** *number*

--- a/doc/classes/countingwritable.md
+++ b/doc/classes/countingwritable.md
@@ -1,16 +1,16 @@
-[etcher-sdk](../README.md) > [CountingWritable](../classes/countingwritable.md)
+[etcher-sdk](../README.md) › [CountingWritable](countingwritable.md)
 
 # Class: CountingWritable
 
 ## Hierarchy
 
- `Writable`
+* Writable
 
-**↳ CountingWritable**
+  ↳ **CountingWritable**
 
 ## Implements
 
-* `WritableStream`
+* WritableStream
 
 ## Index
 
@@ -23,7 +23,7 @@
 * [bytesWritten](countingwritable.md#byteswritten)
 * [position](countingwritable.md#position)
 * [writable](countingwritable.md#writable)
-* [defaultMaxListeners](countingwritable.md#defaultmaxlisteners)
+* [defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)
 
 ### Methods
 
@@ -45,1233 +45,1338 @@
 * [setDefaultEncoding](countingwritable.md#setdefaultencoding)
 * [setMaxListeners](countingwritable.md#setmaxlisteners)
 * [write](countingwritable.md#write)
-* [listenerCount](countingwritable.md#listenercount-1)
-
----
+* [listenerCount](countingwritable.md#static-listenercount)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new CountingWritable**(opts?: *`WritableOptions`*): [CountingWritable](countingwritable.md)
+\+ **new CountingWritable**(`opts?`: WritableOptions): *[CountingWritable](countingwritable.md)*
 
-*Inherited from Writable.__constructor*
+*Inherited from [CountingWritable](countingwritable.md).[constructor](countingwritable.md#constructor)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3770*
+Defined in node_modules/@types/node/base.d.ts:3770
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` opts | `WritableOptions` |
+Name | Type |
+------ | ------ |
+`opts?` | WritableOptions |
 
-**Returns:** [CountingWritable](countingwritable.md)
-
-___
+**Returns:** *[CountingWritable](countingwritable.md)*
 
 ## Properties
 
-<a id="byteswritten"></a>
-
 ###  bytesWritten
 
-**● bytesWritten**: *`number`* = 0
+• **bytesWritten**: *number* = 0
 
-*Defined in [source-destination/progress.ts:92](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/progress.ts#L92)*
+*Defined in [lib/source-destination/progress.ts:92](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/progress.ts#L92)*
 
 ___
-<a id="position"></a>
 
 ###  position
 
-**● position**: *`number` \| `undefined`*
+• **position**: *number | undefined*
 
-*Defined in [source-destination/progress.ts:93](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/progress.ts#L93)*
+*Defined in [lib/source-destination/progress.ts:93](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/progress.ts#L93)*
 
 ___
-<a id="writable"></a>
 
 ###  writable
 
-**● writable**: *`boolean`*
+• **writable**: *boolean*
 
-*Inherited from Writable.writable*
+*Inherited from [CountingWritable](countingwritable.md).[writable](countingwritable.md#writable)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3770*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+Defined in node_modules/@types/node/base.d.ts:3770
 
 ___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="_write"></a>
-
 ###  _write
 
-▸ **_write**(chunk: *`Buffer` \| `Chunk`*, _enc: *`string`*, callback: *`function`*): `void`
+▸ **_write**(`chunk`: Buffer | Chunk, `_enc`: string, `callback`: function): *void*
 
-*Overrides Writable._write*
+*Overrides void*
 
-*Defined in [source-destination/progress.ts:95](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/progress.ts#L95)*
+*Defined in [lib/source-destination/progress.ts:95](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/progress.ts#L95)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `Buffer` \| `Chunk` |
-| _enc | `string` |
-| callback | `function` |
+▪ **chunk**: *Buffer | Chunk*
 
-**Returns:** `void`
+▪ **_enc**: *string*
+
+▪ **callback**: *function*
+
+▸ (`err?`: [Error](notcapable.md#static-error) | undefined): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err?` | [Error](notcapable.md#static-error) &#124; undefined |
+
+**Returns:** *void*
 
 ___
-<a id="addlistener"></a>
 
 ###  addListener
 
-▸ **addListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string, `listener`: Function): *this*
 
-▸ **addListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
 
-▸ **addListener**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-▸ **addListener**(event: *"error"*, listener: *`function`*): `this`
+Defined in node_modules/@types/node/base.d.ts:3790
 
-▸ **addListener**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **addListener**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **addListener**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3790*
-
-Event emitter The defined events on documents including:
-
-1.  close
-2.  drain
-3.  error
-4.  finish
-5.  pipe
-6.  unpipe
+Event emitter
+The defined events on documents including:
+  1. close
+  2. drain
+  3. error
+  4. finish
+  5. pipe
+  6. unpipe
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.addListener*
+▸ **addListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.addListener*
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3791*
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3792*
+Defined in node_modules/@types/node/base.d.ts:3791
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.addListener*
+▸ (): *void*
 
-*Overrides EventEmitter.addListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3793*
+▸ **addListener**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3794*
+Defined in node_modules/@types/node/base.d.ts:3792
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.addListener*
+▸ (): *void*
 
-*Overrides EventEmitter.addListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3795*
+▸ **addListener**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3796*
+Defined in node_modules/@types/node/base.d.ts:3793
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3794
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3795
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3796
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-▸ **emit**(event: *"close"*): `boolean`
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
 
-▸ **emit**(event: *"drain"*, chunk: *`Buffer` \| `string`*): `boolean`
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-▸ **emit**(event: *"error"*, err: *`Error`*): `boolean`
-
-▸ **emit**(event: *"finish"*): `boolean`
-
-▸ **emit**(event: *"pipe"*, src: *`Readable`*): `boolean`
-
-▸ **emit**(event: *"unpipe"*, src: *`Readable`*): `boolean`
-
-*Inherited from Writable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3798*
+Defined in node_modules/@types/node/base.d.ts:3798
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Writable.emit*
+▸ **emit**(`event`: "close"): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3799*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-
-**Returns:** `boolean`
-
-*Inherited from Writable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3800*
+Defined in node_modules/@types/node/base.d.ts:3799
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| chunk | `Buffer` \| `string` |
+Name | Type |
+------ | ------ |
+`event` | "close" |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Writable.emit*
+▸ **emit**(`event`: "drain", `chunk`: Buffer | string): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3801*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| err | `Error` |
-
-**Returns:** `boolean`
-
-*Inherited from Writable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3802*
+Defined in node_modules/@types/node/base.d.ts:3800
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
+Name | Type |
+------ | ------ |
+`event` | "drain" |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Writable.emit*
+▸ **emit**(`event`: "error", `err`: [Error](notcapable.md#static-error)): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3803*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| src | `Readable` |
-
-**Returns:** `boolean`
-
-*Inherited from Writable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3804*
+Defined in node_modules/@types/node/base.d.ts:3801
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| src | `Readable` |
+Name | Type |
+------ | ------ |
+`event` | "error" |
+`err` | [Error](notcapable.md#static-error) |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "finish"): *boolean*
+
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3802
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "finish" |
+
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "pipe", `src`: Readable): *boolean*
+
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3803
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "pipe" |
+`src` | Readable |
+
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "unpipe", `src`: Readable): *boolean*
+
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3804
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "unpipe" |
+`src` | Readable |
+
+**Returns:** *boolean*
 
 ___
-<a id="end"></a>
 
 ###  end
 
-▸ **end**(cb?: *`Function`*): `void`
+▸ **end**(`cb?`: Function): *void*
 
-▸ **end**(chunk: *`any`*, cb?: *`Function`*): `void`
+*Inherited from [CountingWritable](countingwritable.md).[end](countingwritable.md#end)*
 
-▸ **end**(chunk: *`any`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `void`
-
-*Inherited from Writable.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:3776*
+Defined in node_modules/@types/node/base.d.ts:3776
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
 
-*Inherited from Writable.end*
+▸ **end**(`chunk`: any, `cb?`: Function): *void*
 
-*Defined in /node_modules/@types/node/base.d.ts:3777*
+*Inherited from [CountingWritable](countingwritable.md).[end](countingwritable.md#end)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` cb | `Function` |
-
-**Returns:** `void`
-
-*Inherited from Writable.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:3778*
+Defined in node_modules/@types/node/base.d.ts:3777
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
+
+▸ **end**(`chunk`: any, `encoding?`: undefined | string, `cb?`: Function): *void*
+
+*Inherited from [CountingWritable](countingwritable.md).[end](countingwritable.md#end)*
+
+Defined in node_modules/@types/node/base.d.ts:3778
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
+
+**Returns:** *void*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+Defined in node_modules/@types/node/base.d.ts:694
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
-
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+Defined in node_modules/@types/node/base.d.ts:691
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
-
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string, `listener`: Function): *this*
 
-▸ **on**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
 
-▸ **on**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-▸ **on**(event: *"error"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3806*
+Defined in node_modules/@types/node/base.d.ts:3806
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.on*
+▸ **on**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.on*
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3807*
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3808*
+Defined in node_modules/@types/node/base.d.ts:3807
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.on*
+▸ (): *void*
 
-*Overrides EventEmitter.on*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3809*
+▸ **on**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Returns:** `this`
-
-*Inherited from Writable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3810*
+Defined in node_modules/@types/node/base.d.ts:3808
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.on*
+▸ (): *void*
 
-*Overrides EventEmitter.on*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3811*
+▸ **on**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Returns:** `this`
-
-*Inherited from Writable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3812*
+Defined in node_modules/@types/node/base.d.ts:3809
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **on**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3810
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **on**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3811
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **on**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3812
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string, `listener`: Function): *this*
 
-▸ **once**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
 
-▸ **once**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-▸ **once**(event: *"error"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3814*
+Defined in node_modules/@types/node/base.d.ts:3814
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.once*
+▸ **once**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.once*
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3815*
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3816*
+Defined in node_modules/@types/node/base.d.ts:3815
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.once*
+▸ (): *void*
 
-*Overrides EventEmitter.once*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3817*
+▸ **once**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Returns:** `this`
-
-*Inherited from Writable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3818*
+Defined in node_modules/@types/node/base.d.ts:3816
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.once*
+▸ (): *void*
 
-*Overrides EventEmitter.once*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3819*
+▸ **once**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Returns:** `this`
-
-*Inherited from Writable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3820*
+Defined in node_modules/@types/node/base.d.ts:3817
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **once**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3818
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **once**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3819
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **once**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3820
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="pipe"></a>
 
 ###  pipe
 
-▸ **pipe**<`T`>(destination: *`T`*, options?: *`undefined` \| `object`*): `T`
+▸ **pipe**<**T**>(`destination`: T, `options?`: undefined | object): *T*
 
-*Inherited from internal.pipe*
+*Inherited from [CountingWritable](countingwritable.md).[pipe](countingwritable.md#pipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3673*
+Defined in node_modules/@types/node/base.d.ts:3673
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| destination | `T` |
-| `Optional` options | `undefined` \| `object` |
+Name | Type |
+------ | ------ |
+`destination` | T |
+`options?` | undefined &#124; object |
 
-**Returns:** `T`
+**Returns:** *T*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
 
-▸ **prependListener**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-▸ **prependListener**(event: *"error"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3822*
+Defined in node_modules/@types/node/base.d.ts:3822
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.prependListener*
+▸ **prependListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependListener*
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3823*
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3824*
+Defined in node_modules/@types/node/base.d.ts:3823
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.prependListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3825*
+▸ **prependListener**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3826*
+Defined in node_modules/@types/node/base.d.ts:3824
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.prependListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3827*
+▸ **prependListener**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3828*
+Defined in node_modules/@types/node/base.d.ts:3825
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3826
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3827
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3828
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependOnceListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"error"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3830*
+Defined in node_modules/@types/node/base.d.ts:3830
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.prependOnceListener*
+▸ **prependOnceListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependOnceListener*
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3831*
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3832*
+Defined in node_modules/@types/node/base.d.ts:3831
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.prependOnceListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependOnceListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3833*
+▸ **prependOnceListener**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3834*
+Defined in node_modules/@types/node/base.d.ts:3832
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.prependOnceListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependOnceListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3835*
+▸ **prependOnceListener**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3836*
+Defined in node_modules/@types/node/base.d.ts:3833
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3834
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3835
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3836
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string, `listener`: Function): *this*
 
-▸ **removeListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
 
-▸ **removeListener**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-▸ **removeListener**(event: *"error"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3838*
+Defined in node_modules/@types/node/base.d.ts:3838
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.removeListener*
+▸ **removeListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.removeListener*
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3839*
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3840*
+Defined in node_modules/@types/node/base.d.ts:3839
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.removeListener*
+▸ (): *void*
 
-*Overrides EventEmitter.removeListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3841*
+▸ **removeListener**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3842*
+Defined in node_modules/@types/node/base.d.ts:3840
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.removeListener*
+▸ (): *void*
 
-*Overrides EventEmitter.removeListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3843*
+▸ **removeListener**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3844*
+Defined in node_modules/@types/node/base.d.ts:3841
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3842
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3843
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3844
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="setdefaultencoding"></a>
 
 ###  setDefaultEncoding
 
-▸ **setDefaultEncoding**(encoding: *`string`*): `this`
+▸ **setDefaultEncoding**(`encoding`: string): *this*
 
-*Inherited from Writable.setDefaultEncoding*
+*Inherited from [CountingWritable](countingwritable.md).[setDefaultEncoding](countingwritable.md#setdefaultencoding)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3775*
+Defined in node_modules/@types/node/base.d.ts:3775
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| encoding | `string` |
+Name | Type |
+------ | ------ |
+`encoding` | string |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(chunk: *`any`*, cb?: *`Function`*): `boolean`
+▸ **write**(`chunk`: any, `cb?`: Function): *boolean*
 
-▸ **write**(chunk: *`any`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `boolean`
+*Inherited from [CountingWritable](countingwritable.md).[write](countingwritable.md#write)*
 
-*Inherited from Writable.write*
-
-*Defined in /node_modules/@types/node/base.d.ts:3773*
+Defined in node_modules/@types/node/base.d.ts:3773
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`cb?` | Function |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Writable.write*
+▸ **write**(`chunk`: any, `encoding?`: undefined | string, `cb?`: Function): *boolean*
 
-*Defined in /node_modules/@types/node/base.d.ts:3774*
+*Inherited from [CountingWritable](countingwritable.md).[write](countingwritable.md#write)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
-
-**Returns:** `boolean`
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:3774
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
 
-**Returns:** `number`
+**Returns:** *boolean*
 
 ___
 
+### `Static` listenerCount
+
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
+
+Defined in node_modules/@types/node/base.d.ts:680
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
+
+**Returns:** *number*

--- a/doc/classes/crc32hasher.md
+++ b/doc/classes/crc32hasher.md
@@ -1,70 +1,58 @@
-[etcher-sdk](../README.md) > [CRC32Hasher](../classes/crc32hasher.md)
+[etcher-sdk](../README.md) › [CRC32Hasher](crc32hasher.md)
 
 # Class: CRC32Hasher
 
 ## Hierarchy
 
-**CRC32Hasher**
+* **CRC32Hasher**
 
 ## Index
 
 ### Properties
 
-* [value](crc32hasher.md#value)
+* [value](crc32hasher.md#private-value)
 
 ### Methods
 
 * [digest](crc32hasher.md#digest)
 * [update](crc32hasher.md#update)
 
----
-
 ## Properties
 
-<a id="value"></a>
+### `Private` value
 
-### `<Private>` value
+• **value**: *number*
 
-**● value**: *`number`*
-
-*Defined in [sparse-stream/shared.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L55)*
-
-___
+*Defined in [lib/sparse-stream/shared.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L55)*
 
 ## Methods
 
-<a id="digest"></a>
-
 ###  digest
 
-▸ **digest**(_encoding: *"hex"*): `string`
+▸ **digest**(`_encoding`: "hex"): *string*
 
-*Defined in [sparse-stream/shared.ts:61](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L61)*
+*Defined in [lib/sparse-stream/shared.ts:61](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L61)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _encoding | "hex" |
+Name | Type |
+------ | ------ |
+`_encoding` | "hex" |
 
-**Returns:** `string`
+**Returns:** *string*
 
 ___
-<a id="update"></a>
 
 ###  update
 
-▸ **update**(data: *`Buffer`*): `void`
+▸ **update**(`data`: Buffer): *void*
 
-*Defined in [sparse-stream/shared.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L57)*
+*Defined in [lib/sparse-stream/shared.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L57)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| data | `Buffer` |
+Name | Type |
+------ | ------ |
+`data` | Buffer |
 
-**Returns:** `void`
-
-___
-
+**Returns:** *void*

--- a/doc/classes/dmgsource.md
+++ b/doc/classes/dmgsource.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [DmgSource](../classes/dmgsource.md)
+[etcher-sdk](../README.md) › [DmgSource](dmgsource.md)
 
 # Class: DmgSource
 
 ## Hierarchy
 
-↳  [SourceSource](sourcesource.md)
+  ↳ [SourceSource](sourcesource.md)
 
-**↳ DmgSource**
+  ↳ **DmgSource**
 
 ## Index
 
@@ -16,19 +16,19 @@
 
 ### Properties
 
-* [image](dmgsource.md#image)
-* [source](dmgsource.md#source)
-* [defaultMaxListeners](dmgsource.md#defaultmaxlisteners)
-* [imageExtensions](dmgsource.md#imageextensions)
-* [mappedBlockTypes](dmgsource.md#mappedblocktypes)
-* [mimetype](dmgsource.md#mimetype)
-* [requiresRandomReadableSource](dmgsource.md#requiresrandomreadablesource)
+* [image](dmgsource.md#private-image)
+* [source](dmgsource.md#protected-source)
+* [defaultMaxListeners](dmgsource.md#static-defaultmaxlisteners)
+* [imageExtensions](dmgsource.md#static-imageextensions)
+* [mappedBlockTypes](dmgsource.md#static-private-mappedblocktypes)
+* [mimetype](dmgsource.md#static-mimetype)
+* [requiresRandomReadableSource](dmgsource.md#static-requiresrandomreadablesource)
 
 ### Methods
 
-* [_close](dmgsource.md#_close)
-* [_getMetadata](dmgsource.md#_getmetadata)
-* [_open](dmgsource.md#_open)
+* [_close](dmgsource.md#protected-_close)
+* [_getMetadata](dmgsource.md#protected-_getmetadata)
+* [_open](dmgsource.md#protected-_open)
 * [addListener](dmgsource.md#addlistener)
 * [canCreateReadStream](dmgsource.md#cancreatereadstream)
 * [canCreateSparseReadStream](dmgsource.md#cancreatesparsereadstream)
@@ -61,71 +61,60 @@
 * [removeListener](dmgsource.md#removelistener)
 * [setMaxListeners](dmgsource.md#setmaxlisteners)
 * [write](dmgsource.md#write)
-* [listenerCount](dmgsource.md#listenercount-1)
-* [register](dmgsource.md#register)
-
----
+* [listenerCount](dmgsource.md#static-listenercount)
+* [register](dmgsource.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new DmgSource**(source: *[SourceDestination](sourcedestination.md)*): [DmgSource](dmgsource.md)
+\+ **new DmgSource**(`source`: [SourceDestination](sourcedestination.md)): *[DmgSource](dmgsource.md)*
 
 *Overrides [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
 
-*Defined in [source-destination/dmg.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/dmg.ts#L44)*
+*Defined in [lib/source-destination/dmg.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/dmg.ts#L44)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| source | [SourceDestination](sourcedestination.md) |
+Name | Type |
+------ | ------ |
+`source` | [SourceDestination](sourcedestination.md) |
 
-**Returns:** [DmgSource](dmgsource.md)
-
-___
+**Returns:** *[DmgSource](dmgsource.md)*
 
 ## Properties
 
-<a id="image"></a>
+### `Private` image
 
-### `<Private>` image
+• **image**: *UDIFImage*
 
-**● image**: *`UDIFImage`*
-
-*Defined in [source-destination/dmg.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/dmg.ts#L44)*
+*Defined in [lib/source-destination/dmg.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/dmg.ts#L44)*
 
 ___
-<a id="source"></a>
 
-### `<Protected>` source
+### `Protected` source
 
-**● source**: *[SourceDestination](sourcedestination.md)*
+• **source**: *[SourceDestination](sourcedestination.md)*
 
-*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#source)*
+*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
 
-*Defined in [source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L22)*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L22)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Static` defaultMaxListeners
 
-**● imageExtensions**: *`string`[]* =  [
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -138,16 +127,15 @@ ___
 		'wic',
 	]
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
-<a id="mappedblocktypes"></a>
 
-### `<Static>``<Private>` mappedBlockTypes
+### `Static` `Private` mappedBlockTypes
 
-**● mappedBlockTypes**: *`number`[]* =  [
+▪ **mappedBlockTypes**: *number[]* = [
 		BLOCK.RAW,
 		BLOCK.UDCO,
 		BLOCK.UDZO,
@@ -155,664 +143,619 @@ ___
 		BLOCK.LZFSE,
 	]
 
-*Defined in [source-destination/dmg.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/dmg.ts#L35)*
+*Defined in [lib/source-destination/dmg.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/dmg.ts#L35)*
 
 ___
-<a id="mimetype"></a>
 
-### `<Static>` mimetype
+### `Static` mimetype
 
-**● mimetype**: *"application/x-apple-diskimage"* = "application/x-apple-diskimage"
+▪ **mimetype**: *"application/x-apple-diskimage"* = "application/x-apple-diskimage"
 
-*Overrides [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
+*Overrides [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
 
-*Defined in [source-destination/dmg.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/dmg.ts#L43)*
-
-___
-<a id="requiresrandomreadablesource"></a>
-
-### `<Static>` requiresRandomReadableSource
-
-**● requiresRandomReadableSource**: *`boolean`* = true
-
-*Overrides [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#requiresrandomreadablesource)*
-
-*Defined in [source-destination/dmg.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/dmg.ts#L42)*
+*Defined in [lib/source-destination/dmg.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/dmg.ts#L43)*
 
 ___
+
+### `Static` requiresRandomReadableSource
+
+▪ **requiresRandomReadableSource**: *boolean* = true
+
+*Overrides [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
+
+*Defined in [lib/source-destination/dmg.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/dmg.ts#L42)*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Overrides [SourceSource](sourcesource.md).[_close](sourcesource.md#protected-_close)*
 
-*Overrides [SourceSource](sourcesource.md).[_close](sourcesource.md#_close)*
+*Defined in [lib/source-destination/dmg.ts:136](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/dmg.ts#L136)*
 
-*Defined in [source-destination/dmg.ts:136](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/dmg.ts#L136)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Overrides [SourceDestination](sourcedestination.md).[_getMetadata](sourcedestination.md#_getmetadata)*
+*Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [source-destination/dmg.ts:123](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/dmg.ts#L123)*
+*Defined in [lib/source-destination/dmg.ts:123](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/dmg.ts#L123)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Overrides [SourceSource](sourcesource.md).[_open](sourcesource.md#_open)*
-
-*Defined in [source-destination/dmg.ts:131](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/dmg.ts#L131)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Overrides [SourceSource](sourcesource.md).[_open](sourcesource.md#protected-_open)*
+
+*Defined in [lib/source-destination/dmg.ts:131](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/dmg.ts#L131)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/dmg.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/dmg.ts#L51)*
+*Defined in [lib/source-destination/dmg.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/dmg.ts#L51)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/dmg.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/dmg.ts#L55)*
+*Defined in [lib/source-destination/dmg.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/dmg.ts#L55)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseWriteStream](sourcedestination.md#cancreatesparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L276)*
+*Defined in [lib/source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L276)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateWriteStream](sourcedestination.md#cancreatewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L272)*
+*Defined in [lib/source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L272)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L256)*
+*Defined in [lib/source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L256)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canWrite](sourcedestination.md#canwrite)*
+*Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L260)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(_emitProgress?: *`boolean`*, start?: *`number`*, end?: *`undefined` \| `number`*): `Promise`<`ReadableStream`>
+▸ **createReadStream**(`_emitProgress`: boolean, `start`: number, `end?`: undefined | number): *Promise‹ReadableStream›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/dmg.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/dmg.ts#L59)*
+*Defined in [lib/source-destination/dmg.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/dmg.ts#L59)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _emitProgress | `boolean` | false |
-| `Default value` start | `number` | 0 |
-| `Optional` end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`_emitProgress` | boolean | false |
+`start` | number | 0 |
+`end?` | undefined &#124; number | - |
 
-**Returns:** `Promise`<`ReadableStream`>
+**Returns:** *Promise‹ReadableStream›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(_generateChecksums: *`boolean`*): `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+▸ **createSparseReadStream**(`_generateChecksums`: boolean): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Overrides [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/dmg.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/dmg.ts#L75)*
+*Defined in [lib/source-destination/dmg.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/dmg.ts#L75)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _generateChecksums | `boolean` |
+Name | Type |
+------ | ------ |
+`_generateChecksums` | boolean |
 
-**Returns:** `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseWriteStream](sourcedestination.md#createsparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L331)*
+*Defined in [lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L331)*
 
-**Returns:** `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+**Returns:** *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
 ___
-<a id="createverifier"></a>
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createWriteStream](sourcedestination.md#createwritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L327)*
+*Defined in [lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L327)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Overrides [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Overrides [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/dmg.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/dmg.ts#L83)*
+*Defined in [lib/source-destination/dmg.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/dmg.ts#L83)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_sourceOffset`: number): *Promise‹ReadResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[read](sourcedestination.md#read)*
+*Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L291)*
+*Defined in [lib/source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L291)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[write](sourcedestination.md#write)*
+*Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L300)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L300)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/classes/driverlessdevice.md
+++ b/doc/classes/driverlessdevice.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [DriverlessDevice](../classes/driverlessdevice.md)
+[etcher-sdk](../README.md) › [DriverlessDevice](driverlessdevice.md)
 
 # Class: DriverlessDevice
 
 ## Hierarchy
 
-↳  [SourceDestination](sourcedestination.md)
+  ↳ [SourceDestination](sourcedestination.md)
 
-**↳ DriverlessDevice**
+  ↳ **DriverlessDevice**
 
 ## Implements
 
@@ -30,15 +30,15 @@
 * [mountpoints](driverlessdevice.md#mountpoints)
 * [raw](driverlessdevice.md#raw)
 * [size](driverlessdevice.md#size)
-* [defaultMaxListeners](driverlessdevice.md#defaultmaxlisteners)
-* [imageExtensions](driverlessdevice.md#imageextensions)
-* [mimetype](driverlessdevice.md#mimetype)
+* [defaultMaxListeners](driverlessdevice.md#static-defaultmaxlisteners)
+* [imageExtensions](driverlessdevice.md#static-imageextensions)
+* [mimetype](driverlessdevice.md#static-optional-mimetype)
 
 ### Methods
 
-* [_close](driverlessdevice.md#_close)
-* [_getMetadata](driverlessdevice.md#_getmetadata)
-* [_open](driverlessdevice.md#_open)
+* [_close](driverlessdevice.md#protected-_close)
+* [_getMetadata](driverlessdevice.md#protected-_getmetadata)
+* [_open](driverlessdevice.md#protected-_open)
 * [addListener](driverlessdevice.md#addlistener)
 * [canCreateReadStream](driverlessdevice.md#cancreatereadstream)
 * [canCreateSparseReadStream](driverlessdevice.md#cancreatesparsereadstream)
@@ -71,163 +71,144 @@
 * [removeListener](driverlessdevice.md#removelistener)
 * [setMaxListeners](driverlessdevice.md#setmaxlisteners)
 * [write](driverlessdevice.md#write)
-* [listenerCount](driverlessdevice.md#listenercount-1)
-* [register](driverlessdevice.md#register)
-
----
+* [listenerCount](driverlessdevice.md#static-listenercount)
+* [register](driverlessdevice.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new DriverlessDevice**(driverlessDevice: *`WinUsbDriverlessDevice`*): [DriverlessDevice](driverlessdevice.md)
+\+ **new DriverlessDevice**(`driverlessDevice`: WinUsbDriverlessDevice): *[DriverlessDevice](driverlessdevice.md)*
 
-*Defined in [source-destination/driverless.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/driverless.ts#L33)*
+*Defined in [lib/source-destination/driverless.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/driverless.ts#L33)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| driverlessDevice | `WinUsbDriverlessDevice` |
+Name | Type |
+------ | ------ |
+`driverlessDevice` | WinUsbDriverlessDevice |
 
-**Returns:** [DriverlessDevice](driverlessdevice.md)
-
-___
+**Returns:** *[DriverlessDevice](driverlessdevice.md)*
 
 ## Properties
 
-<a id="accessible"></a>
-
 ###  accessible
 
-**● accessible**: *`boolean`* = false
+• **accessible**: *boolean* = false
 
-*Defined in [source-destination/driverless.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/driverless.ts#L24)*
+*Defined in [lib/source-destination/driverless.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/driverless.ts#L24)*
 
 ___
-<a id="description"></a>
 
 ###  description
 
-**● description**: *`string`* = ""
+• **description**: *string* = ""
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[description](../interfaces/adaptersourcedestination.md#description)*
 
-*Defined in [source-destination/driverless.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/driverless.ts#L33)*
+*Defined in [lib/source-destination/driverless.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/driverless.ts#L33)*
 
 ___
-<a id="device"></a>
 
 ###  device
 
-**● device**: *`null`* =  null
+• **device**: *null* = null
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[device](../interfaces/adaptersourcedestination.md#device)*
 
-*Defined in [source-destination/driverless.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/driverless.ts#L26)*
+*Defined in [lib/source-destination/driverless.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/driverless.ts#L26)*
 
 ___
-<a id="devicedescriptor"></a>
 
 ###  deviceDescriptor
 
-**● deviceDescriptor**: *`object`*
+• **deviceDescriptor**: *object*
 
-*Defined in [source-destination/driverless.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/driverless.ts#L32)*
+*Defined in [lib/source-destination/driverless.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/driverless.ts#L32)*
 
-#### Type declaration
+#### Type declaration:
 
- idProduct: `number`
+* **idProduct**: *number*
 
- idVendor: `number`
+* **idVendor**: *number*
 
 ___
-<a id="devicepath"></a>
 
 ###  devicePath
 
-**● devicePath**: *`null`* =  null
+• **devicePath**: *null* = null
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[devicePath](../interfaces/adaptersourcedestination.md#devicepath)*
 
-*Defined in [source-destination/driverless.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/driverless.ts#L27)*
+*Defined in [lib/source-destination/driverless.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/driverless.ts#L27)*
 
 ___
-<a id="emitsprogress"></a>
 
 ###  emitsProgress
 
-**● emitsProgress**: *`boolean`* = false
+• **emitsProgress**: *boolean* = false
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[emitsProgress](../interfaces/adaptersourcedestination.md#emitsprogress)*
 
-*Defined in [source-destination/driverless.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/driverless.ts#L31)*
+*Defined in [lib/source-destination/driverless.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/driverless.ts#L31)*
 
 ___
-<a id="issystem"></a>
 
 ###  isSystem
 
-**● isSystem**: *`boolean`* = false
+• **isSystem**: *boolean* = false
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[isSystem](../interfaces/adaptersourcedestination.md#issystem)*
 
-*Defined in [source-destination/driverless.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/driverless.ts#L28)*
+*Defined in [lib/source-destination/driverless.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/driverless.ts#L28)*
 
 ___
-<a id="mountpoints"></a>
 
 ###  mountpoints
 
-**● mountpoints**: *`never`[]* =  []
+• **mountpoints**: *never[]* = []
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[mountpoints](../interfaces/adaptersourcedestination.md#mountpoints)*
 
-*Defined in [source-destination/driverless.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/driverless.ts#L29)*
+*Defined in [lib/source-destination/driverless.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/driverless.ts#L29)*
 
 ___
-<a id="raw"></a>
 
 ###  raw
 
-**● raw**: *`null`* =  null
+• **raw**: *null* = null
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[raw](../interfaces/adaptersourcedestination.md#raw)*
 
-*Defined in [source-destination/driverless.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/driverless.ts#L25)*
+*Defined in [lib/source-destination/driverless.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/driverless.ts#L25)*
 
 ___
-<a id="size"></a>
 
 ###  size
 
-**● size**: *`null`* =  null
+• **size**: *null* = null
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[size](../interfaces/adaptersourcedestination.md#size)*
 
-*Defined in [source-destination/driverless.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/driverless.ts#L30)*
+*Defined in [lib/source-destination/driverless.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/driverless.ts#L30)*
 
 ___
-<a id="defaultmaxlisteners"></a>
 
-### `<Static>` defaultMaxListeners
+### `Static` defaultMaxListeners
 
-**● defaultMaxListeners**: *`number`*
+▪ **defaultMaxListeners**: *number*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[defaultMaxListeners](../interfaces/adaptersourcedestination.md#defaultmaxlisteners)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[defaultMaxListeners](../interfaces/adaptersourcedestination.md#static-defaultmaxlisteners)*
 
-*Inherited from EventEmitter.defaultMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:681*
+Defined in node_modules/@types/node/base.d.ts:681
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Static` imageExtensions
 
-**● imageExtensions**: *`string`[]* =  [
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -240,733 +221,689 @@ ___
 		'wic',
 	]
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[imageExtensions](../interfaces/adaptersourcedestination.md#imageextensions)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[imageExtensions](../interfaces/adaptersourcedestination.md#static-imageextensions)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
-
-___
-<a id="mimetype"></a>
-
-### `<Static>``<Optional>` mimetype
-
-**● mimetype**: *`undefined` \| `string`*
-
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[mimetype](../interfaces/adaptersourcedestination.md#mimetype)*
-
-*Inherited from [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
-
-*Defined in [source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L244)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
+
+### `Static` `Optional` mimetype
+
+▪ **mimetype**? : *undefined | string*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[mimetype](../interfaces/adaptersourcedestination.md#static-optional-mimetype)*
+
+*Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
+
+*Defined in [lib/source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L244)*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[_close](../interfaces/adaptersourcedestination.md#_close)*
+*Inherited from [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#_close)*
+*Defined in [lib/source-destination/source-destination.ts:353](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L353)*
 
-*Defined in [source-destination/source-destination.ts:353](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L353)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[_getMetadata](../interfaces/adaptersourcedestination.md#_getmetadata)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[_getMetadata](sourcedestination.md#_getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:287](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L287)*
+*Defined in [lib/source-destination/source-destination.ts:287](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L287)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[_open](../interfaces/adaptersourcedestination.md#_open)*
-
-*Inherited from [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#_open)*
-
-*Defined in [source-destination/source-destination.ts:349](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L349)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
+*Inherited from [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
+
+*Defined in [lib/source-destination/source-destination.ts:349](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L349)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[addListener](../interfaces/adaptersourcedestination.md#addlistener)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canCreateReadStream](../interfaces/adaptersourcedestination.md#cancreatereadstream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/source-destination.ts:264](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L264)*
+*Defined in [lib/source-destination/source-destination.ts:264](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L264)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canCreateSparseReadStream](../interfaces/adaptersourcedestination.md#cancreatesparsereadstream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L268)*
+*Defined in [lib/source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L268)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canCreateSparseWriteStream](../interfaces/adaptersourcedestination.md#cancreatesparsewritestream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseWriteStream](sourcedestination.md#cancreatesparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L276)*
+*Defined in [lib/source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L276)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canCreateWriteStream](../interfaces/adaptersourcedestination.md#cancreatewritestream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateWriteStream](sourcedestination.md#cancreatewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L272)*
+*Defined in [lib/source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L272)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canRead](../interfaces/adaptersourcedestination.md#canread)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L256)*
+*Defined in [lib/source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L256)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canWrite](../interfaces/adaptersourcedestination.md#canwrite)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canWrite](sourcedestination.md#canwrite)*
+*Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L260)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[close](../interfaces/adaptersourcedestination.md#close)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(_emitProgress?: *`boolean`*, _start?: *`number`*, _end?: *`undefined` \| `number`*): `Promise`<`ReadableStream`>
+▸ **createReadStream**(`_emitProgress`: boolean, `_start`: number, `_end?`: undefined | number): *Promise‹ReadableStream›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[createReadStream](../interfaces/adaptersourcedestination.md#createreadstream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Inherited from [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/source-destination.ts:309](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L309)*
+*Defined in [lib/source-destination/source-destination.ts:309](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L309)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _emitProgress | `boolean` | false |
-| `Default value` _start | `number` | 0 |
-| `Optional` _end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`_emitProgress` | boolean | false |
+`_start` | number | 0 |
+`_end?` | undefined &#124; number | - |
 
-**Returns:** `Promise`<`ReadableStream`>
+**Returns:** *Promise‹ReadableStream›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(_generateChecksums?: *`boolean`*): `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+▸ **createSparseReadStream**(`_generateChecksums`: boolean): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[createSparseReadStream](../interfaces/adaptersourcedestination.md#createsparsereadstream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L317)*
+*Defined in [lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L317)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _generateChecksums | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`_generateChecksums` | boolean | false |
 
-**Returns:** `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[createSparseWriteStream](../interfaces/adaptersourcedestination.md#createsparsewritestream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseWriteStream](sourcedestination.md#createsparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L331)*
+*Defined in [lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L331)*
 
-**Returns:** `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+**Returns:** *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
 ___
-<a id="createverifier"></a>
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[createVerifier](../interfaces/adaptersourcedestination.md#createverifier)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[createWriteStream](../interfaces/adaptersourcedestination.md#createwritestream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createWriteStream](sourcedestination.md#createwritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L327)*
+*Defined in [lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L327)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[emit](../interfaces/adaptersourcedestination.md#emit)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[eventNames](../interfaces/adaptersourcedestination.md#eventnames)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[getBlocks](../interfaces/adaptersourcedestination.md#getblocks)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[getInnerSource](../interfaces/adaptersourcedestination.md#getinnersource)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[getMaxListeners](../interfaces/adaptersourcedestination.md#getmaxlisteners)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[getMetadata](../interfaces/adaptersourcedestination.md#getmetadata)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[getPartitionTable](../interfaces/adaptersourcedestination.md#getpartitiontable)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[listenerCount](../interfaces/adaptersourcedestination.md#listenercount)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[listeners](../interfaces/adaptersourcedestination.md#listeners)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[on](../interfaces/adaptersourcedestination.md#on)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[once](../interfaces/adaptersourcedestination.md#once)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[open](../interfaces/adaptersourcedestination.md#open)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[prependListener](../interfaces/adaptersourcedestination.md#prependlistener)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[prependOnceListener](../interfaces/adaptersourcedestination.md#prependoncelistener)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_sourceOffset`: number): *Promise‹ReadResult›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[read](../interfaces/adaptersourcedestination.md#read)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[read](sourcedestination.md#read)*
+*Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L291)*
+*Defined in [lib/source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L291)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[removeAllListeners](../interfaces/adaptersourcedestination.md#removealllisteners)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[removeListener](../interfaces/adaptersourcedestination.md#removelistener)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[setMaxListeners](../interfaces/adaptersourcedestination.md#setmaxlisteners)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[write](../interfaces/adaptersourcedestination.md#write)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[write](sourcedestination.md#write)*
+*Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L300)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[listenerCount](../interfaces/adaptersourcedestination.md#listenercount-1)*
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L300)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[register](../interfaces/adaptersourcedestination.md#register)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/classes/driverlessdeviceadapter_.md
+++ b/doc/classes/driverlessdeviceadapter_.md
@@ -1,22 +1,22 @@
-[etcher-sdk](../README.md) > [DriverlessDeviceAdapter$](../classes/driverlessdeviceadapter_.md)
+[etcher-sdk](../README.md) › [DriverlessDeviceAdapter$](driverlessdeviceadapter_.md)
 
 # Class: DriverlessDeviceAdapter$
 
 ## Hierarchy
 
-↳  [Adapter](adapter.md)
+  ↳ [Adapter](adapter.md)
 
-**↳ DriverlessDeviceAdapter$**
+  ↳ **DriverlessDeviceAdapter$**
 
 ## Index
 
 ### Properties
 
-* [drives](driverlessdeviceadapter_.md#drives)
-* [listDriverlessDevices](driverlessdeviceadapter_.md#listdriverlessdevices)
-* [ready](driverlessdeviceadapter_.md#ready)
-* [running](driverlessdeviceadapter_.md#running)
-* [defaultMaxListeners](driverlessdeviceadapter_.md#defaultmaxlisteners)
+* [drives](driverlessdeviceadapter_.md#private-drives)
+* [listDriverlessDevices](driverlessdeviceadapter_.md#private-listdriverlessdevices)
+* [ready](driverlessdeviceadapter_.md#private-ready)
+* [running](driverlessdeviceadapter_.md#private-running)
+* [defaultMaxListeners](driverlessdeviceadapter_.md#static-defaultmaxlisteners)
 
 ### Methods
 
@@ -24,7 +24,7 @@
 * [emit](driverlessdeviceadapter_.md#emit)
 * [eventNames](driverlessdeviceadapter_.md#eventnames)
 * [getMaxListeners](driverlessdeviceadapter_.md#getmaxlisteners)
-* [listDrives](driverlessdeviceadapter_.md#listdrives)
+* [listDrives](driverlessdeviceadapter_.md#private-listdrives)
 * [listenerCount](driverlessdeviceadapter_.md#listenercount)
 * [listeners](driverlessdeviceadapter_.md#listeners)
 * [on](driverlessdeviceadapter_.md#on)
@@ -33,412 +33,379 @@
 * [prependOnceListener](driverlessdeviceadapter_.md#prependoncelistener)
 * [removeAllListeners](driverlessdeviceadapter_.md#removealllisteners)
 * [removeListener](driverlessdeviceadapter_.md#removelistener)
-* [scan](driverlessdeviceadapter_.md#scan)
-* [scanLoop](driverlessdeviceadapter_.md#scanloop)
+* [scan](driverlessdeviceadapter_.md#private-scan)
+* [scanLoop](driverlessdeviceadapter_.md#private-scanloop)
 * [setMaxListeners](driverlessdeviceadapter_.md#setmaxlisteners)
 * [start](driverlessdeviceadapter_.md#start)
 * [stop](driverlessdeviceadapter_.md#stop)
-* [listenerCount](driverlessdeviceadapter_.md#listenercount-1)
-
----
+* [listenerCount](driverlessdeviceadapter_.md#static-listenercount)
 
 ## Properties
 
-<a id="drives"></a>
+### `Private` drives
 
-### `<Private>` drives
+• **drives**: *Map‹string, [DriverlessDevice](driverlessdevice.md)›* = new Map()
 
-**● drives**: *`Map`<`string`, [DriverlessDevice](driverlessdevice.md)>* =  new Map()
-
-*Defined in [scanner/adapters/driverless.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/driverless.ts#L30)*
+*Defined in [lib/scanner/adapters/driverless.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/driverless.ts#L30)*
 
 ___
-<a id="listdriverlessdevices"></a>
 
-### `<Private>` listDriverlessDevices
+### `Private` listDriverlessDevices
 
-**● listDriverlessDevices**: *`any`*
+• **listDriverlessDevices**: *any*
 
-*Defined in [scanner/adapters/driverless.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/driverless.ts#L33)*
-
-___
-<a id="ready"></a>
-
-### `<Private>` ready
-
-**● ready**: *`boolean`* = false
-
-*Defined in [scanner/adapters/driverless.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/driverless.ts#L32)*
+*Defined in [lib/scanner/adapters/driverless.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/driverless.ts#L33)*
 
 ___
-<a id="running"></a>
 
-### `<Private>` running
+### `Private` ready
 
-**● running**: *`boolean`* = false
+• **ready**: *boolean* = false
 
-*Defined in [scanner/adapters/driverless.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/driverless.ts#L31)*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/scanner/adapters/driverless.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/driverless.ts#L32)*
 
 ___
+
+### `Private` running
+
+• **running**: *boolean* = false
+
+*Defined in [lib/scanner/adapters/driverless.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/driverless.ts#L31)*
+
+___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="addlistener"></a>
-
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
-
-___
-<a id="listdrives"></a>
-
-### `<Private>` listDrives
-
-▸ **listDrives**(): `Map`<`string`, `WinUsbDriverlessDevice`>
-
-*Defined in [scanner/adapters/driverless.ts:88](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/driverless.ts#L88)*
-
-**Returns:** `Map`<`string`, `WinUsbDriverlessDevice`>
+**Returns:** *number*
 
 ___
-<a id="listenercount"></a>
+
+### `Private` listDrives
+
+▸ **listDrives**(): *Map‹string, WinUsbDriverlessDevice›*
+
+*Defined in [lib/scanner/adapters/driverless.ts:88](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/driverless.ts#L88)*
+
+**Returns:** *Map‹string, WinUsbDriverlessDevice›*
+
+___
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
-
-___
-<a id="scan"></a>
-
-### `<Private>` scan
-
-▸ **scan**(): `void`
-
-*Defined in [scanner/adapters/driverless.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/driverless.ts#L63)*
-
-**Returns:** `void`
+**Returns:** *this*
 
 ___
-<a id="scanloop"></a>
 
-### `<Private>` scanLoop
+### `Private` scan
 
-▸ **scanLoop**(): `Promise`<`void`>
+▸ **scan**(): *void*
 
-*Defined in [scanner/adapters/driverless.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/driverless.ts#L46)*
+*Defined in [lib/scanner/adapters/driverless.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/driverless.ts#L63)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *void*
 
 ___
-<a id="setmaxlisteners"></a>
+
+### `Private` scanLoop
+
+▸ **scanLoop**(): *Promise‹void›*
+
+*Defined in [lib/scanner/adapters/driverless.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/driverless.ts#L46)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="start"></a>
 
 ###  start
 
-▸ **start**(): `void`
+▸ **start**(): *void*
 
-*Overrides [Adapter](adapter.md).[start](adapter.md#start)*
+*Overrides [Adapter](adapter.md).[start](adapter.md#abstract-start)*
 
-*Defined in [scanner/adapters/driverless.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/driverless.ts#L35)*
+*Defined in [lib/scanner/adapters/driverless.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/driverless.ts#L35)*
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="stop"></a>
 
 ###  stop
 
-▸ **stop**(): `void`
+▸ **stop**(): *void*
 
-*Overrides [Adapter](adapter.md).[stop](adapter.md#stop)*
+*Overrides [Adapter](adapter.md).[stop](adapter.md#abstract-stop)*
 
-*Defined in [scanner/adapters/driverless.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/driverless.ts#L40)*
+*Defined in [lib/scanner/adapters/driverless.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/driverless.ts#L40)*
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="listenercount-1"></a>
 
-### `<Static>` listenerCount
+### `Static` listenerCount
 
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `number`
-
-___
-
+**Returns:** *number*

--- a/doc/classes/file.md
+++ b/doc/classes/file.md
@@ -1,14 +1,14 @@
-[etcher-sdk](../README.md) > [File](../classes/file.md)
+[etcher-sdk](../README.md) › [File](file.md)
 
 # Class: File
 
 ## Hierarchy
 
-↳  [SourceDestination](sourcedestination.md)
+  ↳ [SourceDestination](sourcedestination.md)
 
-**↳ File**
+  ↳ **File**
 
-↳  [BlockDevice](blockdevice.md)
+  ↳ [BlockDevice](blockdevice.md)
 
 ## Index
 
@@ -19,21 +19,21 @@
 ### Properties
 
 * [blockSize](file.md#blocksize)
-* [fd](file.md#fd)
-* [flags](file.md#flags)
-* [path](file.md#path)
-* [OpenFlags](file.md#openflags)
-* [defaultMaxListeners](file.md#defaultmaxlisteners)
-* [imageExtensions](file.md#imageextensions)
-* [mimetype](file.md#mimetype)
+* [fd](file.md#protected-fd)
+* [flags](file.md#private-flags)
+* [path](file.md#private-path)
+* [OpenFlags](file.md#static-openflags)
+* [defaultMaxListeners](file.md#static-defaultmaxlisteners)
+* [imageExtensions](file.md#static-imageextensions)
+* [mimetype](file.md#static-optional-mimetype)
 
 ### Methods
 
-* [_canRead](file.md#_canread)
-* [_canWrite](file.md#_canwrite)
-* [_close](file.md#_close)
-* [_getMetadata](file.md#_getmetadata)
-* [_open](file.md#_open)
+* [_canRead](file.md#private-_canread)
+* [_canWrite](file.md#private-_canwrite)
+* [_close](file.md#protected-_close)
+* [_getMetadata](file.md#protected-_getmetadata)
+* [_open](file.md#protected-_open)
 * [addListener](file.md#addlistener)
 * [canCreateReadStream](file.md#cancreatereadstream)
 * [canCreateSparseReadStream](file.md#cancreatesparsereadstream)
@@ -66,95 +66,81 @@
 * [removeListener](file.md#removelistener)
 * [setMaxListeners](file.md#setmaxlisteners)
 * [write](file.md#write)
-* [listenerCount](file.md#listenercount-1)
-* [register](file.md#register)
-
----
+* [listenerCount](file.md#static-listenercount)
+* [register](file.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new File**(path: *`string`*, flags: *[OpenFlags](../enums/openflags.md)*): [File](file.md)
+\+ **new File**(`path`: string, `flags`: [OpenFlags](../enums/openflags.md)): *[File](file.md)*
 
-*Defined in [source-destination/file.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L58)*
+*Defined in [lib/source-destination/file.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L58)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| path | `string` |
-| flags | [OpenFlags](../enums/openflags.md) |
+Name | Type |
+------ | ------ |
+`path` | string |
+`flags` | [OpenFlags](../enums/openflags.md) |
 
-**Returns:** [File](file.md)
-
-___
+**Returns:** *[File](file.md)*
 
 ## Properties
 
-<a id="blocksize"></a>
-
 ###  blockSize
 
-**● blockSize**: *`number`* = 512
+• **blockSize**: *number* = 512
 
-*Defined in [source-destination/file.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L58)*
-
-___
-<a id="fd"></a>
-
-### `<Protected>` fd
-
-**● fd**: *`number`*
-
-*Defined in [source-destination/file.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L57)*
+*Defined in [lib/source-destination/file.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L58)*
 
 ___
-<a id="flags"></a>
 
-### `<Private>` flags
+### `Protected` fd
 
-**● flags**: *[OpenFlags](../enums/openflags.md)*
+• **fd**: *number*
 
-*Defined in [source-destination/file.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L60)*
-
-___
-<a id="path"></a>
-
-### `<Private>` path
-
-**● path**: *`string`*
-
-*Defined in [source-destination/file.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L60)*
+*Defined in [lib/source-destination/file.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L57)*
 
 ___
-<a id="openflags"></a>
 
-### `<Static>` OpenFlags
+### `Private` flags
 
-**● OpenFlags**: *[OpenFlags](../enums/openflags.md)* =  OpenFlags
+• **flags**: *[OpenFlags](../enums/openflags.md)*
 
-*Defined in [source-destination/file.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L56)*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/file.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L60)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Private` path
 
-**● imageExtensions**: *`string`[]* =  [
+• **path**: *string*
+
+*Defined in [lib/source-destination/file.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L60)*
+
+___
+
+### `Static` OpenFlags
+
+▪ **OpenFlags**: *[OpenFlags](../enums/openflags.md)* = OpenFlags
+
+*Defined in [lib/source-destination/file.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L56)*
+
+___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -167,677 +153,631 @@ ___
 		'wic',
 	]
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
-
-___
-<a id="mimetype"></a>
-
-### `<Static>``<Optional>` mimetype
-
-**● mimetype**: *`undefined` \| `string`*
-
-*Inherited from [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
-
-*Defined in [source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L244)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
+
+### `Static` `Optional` mimetype
+
+▪ **mimetype**? : *undefined | string*
+
+*Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
+
+*Defined in [lib/source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L244)*
 
 ## Methods
 
-<a id="_canread"></a>
+### `Private` _canRead
 
-### `<Private>` _canRead
+▸ **_canRead**(): *boolean*
 
-▸ **_canRead**(): `boolean`
+*Defined in [lib/source-destination/file.ts:64](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L64)*
 
-*Defined in [source-destination/file.ts:64](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L64)*
-
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="_canwrite"></a>
 
-### `<Private>` _canWrite
+### `Private` _canWrite
 
-▸ **_canWrite**(): `boolean`
+▸ **_canWrite**(): *boolean*
 
-*Defined in [source-destination/file.ts:72](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L72)*
+*Defined in [lib/source-destination/file.ts:72](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L72)*
 
-**Returns:** `boolean`
-
-___
-<a id="_close"></a>
-
-### `<Protected>` _close
-
-▸ **_close**(): `Promise`<`void`>
-
-*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#_close)*
-
-*Defined in [source-destination/file.ts:156](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L156)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *boolean*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _close
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_close**(): *Promise‹void›*
 
-*Overrides [SourceDestination](sourcedestination.md).[_getMetadata](sourcedestination.md#_getmetadata)*
+*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [source-destination/file.ts:99](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L99)*
+*Defined in [lib/source-destination/file.ts:156](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L156)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#_open)*
-
-*Defined in [source-destination/file.ts:152](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L152)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _getMetadata
+
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
+
+*Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
+
+*Defined in [lib/source-destination/file.ts:99](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L99)*
+
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
+
+___
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
+
+*Defined in [lib/source-destination/file.ts:152](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L152)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/file.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L87)*
+*Defined in [lib/source-destination/file.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L87)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L268)*
+*Defined in [lib/source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L268)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateSparseWriteStream](sourcedestination.md#cancreatesparsewritestream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/file.ts:95](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L95)*
+*Defined in [lib/source-destination/file.ts:95](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L95)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateWriteStream](sourcedestination.md#cancreatewritestream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/file.ts:91](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L91)*
+*Defined in [lib/source-destination/file.ts:91](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L91)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Overrides [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/file.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L79)*
+*Defined in [lib/source-destination/file.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L79)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canWrite](sourcedestination.md#canwrite)*
+*Overrides [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [source-destination/file.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L83)*
+*Defined in [lib/source-destination/file.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L83)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(emitProgress?: *`boolean`*, start?: *`number`*, end?: *`undefined` \| `number`*): `Promise`<`ReadableStream`>
+▸ **createReadStream**(`emitProgress`: boolean, `start`: number, `end?`: undefined | number): *Promise‹ReadableStream›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/file.ts:124](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L124)*
+*Defined in [lib/source-destination/file.ts:124](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L124)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` emitProgress | `boolean` | false |
-| `Default value` start | `number` | 0 |
-| `Optional` end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`emitProgress` | boolean | false |
+`start` | number | 0 |
+`end?` | undefined &#124; number | - |
 
-**Returns:** `Promise`<`ReadableStream`>
+**Returns:** *Promise‹ReadableStream›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(_generateChecksums?: *`boolean`*): `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+▸ **createSparseReadStream**(`_generateChecksums`: boolean): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L317)*
+*Defined in [lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L317)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _generateChecksums | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`_generateChecksums` | boolean | false |
 
-**Returns:** `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWriteStream](sparsewritestream.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWriteStream](sparsewritestream.md)›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createSparseWriteStream](sourcedestination.md#createsparsewritestream)*
+*Overrides [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/file.ts:146](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L146)*
+*Defined in [lib/source-destination/file.ts:146](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L146)*
 
-**Returns:** `Promise`<[SparseWriteStream](sparsewritestream.md)>
+**Returns:** *Promise‹[SparseWriteStream](sparsewritestream.md)›*
 
 ___
-<a id="createverifier"></a>
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createWriteStream](sourcedestination.md#createwritestream)*
+*Overrides [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/file.ts:137](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L137)*
+*Defined in [lib/source-destination/file.ts:137](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L137)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(buffer: *`Buffer`*, bufferOffset: *`number`*, length: *`number`*, sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`buffer`: Buffer, `bufferOffset`: number, `length`: number, `sourceOffset`: number): *Promise‹ReadResult›*
 
-*Overrides [SourceDestination](sourcedestination.md).[read](sourcedestination.md#read)*
+*Overrides [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [source-destination/file.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L106)*
+*Defined in [lib/source-destination/file.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L106)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| bufferOffset | `number` |
-| length | `number` |
-| sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
+`bufferOffset` | number |
+`length` | number |
+`sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(buffer: *`Buffer`*, bufferOffset: *`number`*, length: *`number`*, fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`buffer`: Buffer, `bufferOffset`: number, `length`: number, `fileOffset`: number): *Promise‹WriteResult›*
 
-*Overrides [SourceDestination](sourcedestination.md).[write](sourcedestination.md#write)*
+*Overrides [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [source-destination/file.ts:115](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L115)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| bufferOffset | `number` |
-| length | `number` |
-| fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/file.ts:115](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L115)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
+`bufferOffset` | number |
+`length` | number |
+`fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/classes/gzipsource.md
+++ b/doc/classes/gzipsource.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [GZipSource](../classes/gzipsource.md)
+[etcher-sdk](../README.md) › [GZipSource](gzipsource.md)
 
 # Class: GZipSource
 
 ## Hierarchy
 
-↳  [CompressedSource](compressedsource.md)
+  ↳ [CompressedSource](compressedsource.md)
 
-**↳ GZipSource**
+  ↳ **GZipSource**
 
 ## Index
 
@@ -17,17 +17,17 @@
 ### Properties
 
 * [isSizeEstimated](gzipsource.md#issizeestimated)
-* [source](gzipsource.md#source)
-* [defaultMaxListeners](gzipsource.md#defaultmaxlisteners)
-* [imageExtensions](gzipsource.md#imageextensions)
-* [mimetype](gzipsource.md#mimetype)
-* [requiresRandomReadableSource](gzipsource.md#requiresrandomreadablesource)
+* [source](gzipsource.md#protected-source)
+* [defaultMaxListeners](gzipsource.md#static-defaultmaxlisteners)
+* [imageExtensions](gzipsource.md#static-imageextensions)
+* [mimetype](gzipsource.md#static-mimetype)
+* [requiresRandomReadableSource](gzipsource.md#static-requiresrandomreadablesource)
 
 ### Methods
 
-* [_close](gzipsource.md#_close)
-* [_getMetadata](gzipsource.md#_getmetadata)
-* [_open](gzipsource.md#_open)
+* [_close](gzipsource.md#protected-_close)
+* [_getMetadata](gzipsource.md#protected-_getmetadata)
+* [_open](gzipsource.md#protected-_open)
 * [addListener](gzipsource.md#addlistener)
 * [canCreateReadStream](gzipsource.md#cancreatereadstream)
 * [canCreateSparseReadStream](gzipsource.md#cancreatesparsereadstream)
@@ -39,7 +39,7 @@
 * [createReadStream](gzipsource.md#createreadstream)
 * [createSparseReadStream](gzipsource.md#createsparsereadstream)
 * [createSparseWriteStream](gzipsource.md#createsparsewritestream)
-* [createTransform](gzipsource.md#createtransform)
+* [createTransform](gzipsource.md#protected-createtransform)
 * [createVerifier](gzipsource.md#createverifier)
 * [createWriteStream](gzipsource.md#createwritestream)
 * [emit](gzipsource.md#emit)
@@ -49,7 +49,7 @@
 * [getMaxListeners](gzipsource.md#getmaxlisteners)
 * [getMetadata](gzipsource.md#getmetadata)
 * [getPartitionTable](gzipsource.md#getpartitiontable)
-* [getSize](gzipsource.md#getsize)
+* [getSize](gzipsource.md#protected-getsize)
 * [listenerCount](gzipsource.md#listenercount)
 * [listeners](gzipsource.md#listeners)
 * [on](gzipsource.md#on)
@@ -62,73 +62,62 @@
 * [removeListener](gzipsource.md#removelistener)
 * [setMaxListeners](gzipsource.md#setmaxlisteners)
 * [write](gzipsource.md#write)
-* [listenerCount](gzipsource.md#listenercount-1)
-* [register](gzipsource.md#register)
-
----
+* [listenerCount](gzipsource.md#static-listenercount)
+* [register](gzipsource.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new GZipSource**(source: *[SourceDestination](sourcedestination.md)*): [GZipSource](gzipsource.md)
+\+ **new GZipSource**(`source`: [SourceDestination](sourcedestination.md)): *[GZipSource](gzipsource.md)*
 
 *Inherited from [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
 
-*Defined in [source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L20)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| source | [SourceDestination](sourcedestination.md) |
+Name | Type |
+------ | ------ |
+`source` | [SourceDestination](sourcedestination.md) |
 
-**Returns:** [GZipSource](gzipsource.md)
-
-___
+**Returns:** *[GZipSource](gzipsource.md)*
 
 ## Properties
 
-<a id="issizeestimated"></a>
-
 ###  isSizeEstimated
 
-**● isSizeEstimated**: *`boolean`* = true
+• **isSizeEstimated**: *boolean* = true
 
-*Overrides [CompressedSource](compressedsource.md).[isSizeEstimated](compressedsource.md#issizeestimated)*
+*Overrides [CompressedSource](compressedsource.md).[isSizeEstimated](compressedsource.md#protected-issizeestimated)*
 
-*Defined in [source-destination/gzip.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/gzip.ts#L27)*
-
-___
-<a id="source"></a>
-
-### `<Protected>` source
-
-**● source**: *[SourceDestination](sourcedestination.md)*
-
-*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#source)*
-
-*Defined in [source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L22)*
+*Defined in [lib/source-destination/gzip.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/gzip.ts#L27)*
 
 ___
-<a id="defaultmaxlisteners"></a>
 
-### `<Static>` defaultMaxListeners
+### `Protected` source
 
-**● defaultMaxListeners**: *`number`*
+• **source**: *[SourceDestination](sourcedestination.md)*
 
-*Inherited from EventEmitter.defaultMaxListeners*
+*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
 
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L22)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Static` defaultMaxListeners
 
-**● imageExtensions**: *`string`[]* =  [
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -141,702 +130,655 @@ ___
 		'wic',
 	]
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
-
-___
-<a id="mimetype"></a>
-
-### `<Static>` mimetype
-
-**● mimetype**: *"application/gzip"* = "application/gzip"
-
-*Overrides [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
-
-*Defined in [source-destination/gzip.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/gzip.ts#L26)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
-<a id="requiresrandomreadablesource"></a>
 
-### `<Static>` requiresRandomReadableSource
+### `Static` mimetype
 
-**● requiresRandomReadableSource**: *`boolean`* = false
+▪ **mimetype**: *"application/gzip"* = "application/gzip"
 
-*Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#requiresrandomreadablesource)*
+*Overrides [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
 
-*Defined in [source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/gzip.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/gzip.ts#L26)*
 
 ___
+
+### `Static` requiresRandomReadableSource
+
+▪ **requiresRandomReadableSource**: *boolean* = false
+
+*Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
+
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L20)*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Inherited from [SourceSource](sourcesource.md).[_close](sourcesource.md#protected-_close)*
 
-*Inherited from [SourceSource](sourcesource.md).[_close](sourcesource.md#_close)*
+*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#_close)*
+*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L30)*
 
-*Defined in [source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L30)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [CompressedSource](compressedsource.md).[_getMetadata](compressedsource.md#_getmetadata)*
+*Inherited from [CompressedSource](compressedsource.md).[_getMetadata](compressedsource.md#protected-_getmetadata)*
 
-*Overrides [SourceDestination](sourcedestination.md).[_getMetadata](sourcedestination.md#_getmetadata)*
+*Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [source-destination/compressed-source.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L84)*
+*Defined in [lib/source-destination/compressed-source.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L84)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Inherited from [SourceSource](sourcesource.md).[_open](sourcesource.md#_open)*
-
-*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#_open)*
-
-*Defined in [source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L26)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Inherited from [SourceSource](sourcesource.md).[_open](sourcesource.md#protected-_open)*
+
+*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
+
+*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L26)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
 *Inherited from [CompressedSource](compressedsource.md).[canCreateReadStream](compressedsource.md#cancreatereadstream)*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/compressed-source.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L50)*
+*Defined in [lib/source-destination/compressed-source.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L50)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L268)*
+*Defined in [lib/source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L268)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseWriteStream](sourcedestination.md#cancreatesparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L276)*
+*Defined in [lib/source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L276)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateWriteStream](sourcedestination.md#cancreatewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L272)*
+*Defined in [lib/source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L272)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L256)*
+*Defined in [lib/source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L256)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canWrite](sourcedestination.md#canwrite)*
+*Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L260)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(emitProgress?: *`boolean`*, start?: *`number`*, end?: *`undefined` \| `number`*): `Promise`<[SourceTransform](../interfaces/sourcetransform.md)>
+▸ **createReadStream**(`emitProgress`: boolean, `start`: number, `end?`: undefined | number): *Promise‹[SourceTransform](../interfaces/sourcetransform.md)›*
 
 *Inherited from [CompressedSource](compressedsource.md).[createReadStream](compressedsource.md#createreadstream)*
 
-*Overrides [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/compressed-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L54)*
+*Defined in [lib/source-destination/compressed-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L54)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` emitProgress | `boolean` | false |
-| `Default value` start | `number` | 0 |
-| `Optional` end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`emitProgress` | boolean | false |
+`start` | number | 0 |
+`end?` | undefined &#124; number | - |
 
-**Returns:** `Promise`<[SourceTransform](../interfaces/sourcetransform.md)>
+**Returns:** *Promise‹[SourceTransform](../interfaces/sourcetransform.md)›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(_generateChecksums?: *`boolean`*): `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+▸ **createSparseReadStream**(`_generateChecksums`: boolean): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L317)*
+*Defined in [lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L317)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _generateChecksums | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`_generateChecksums` | boolean | false |
 
-**Returns:** `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseWriteStream](sourcedestination.md#createsparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L331)*
+*Defined in [lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L331)*
 
-**Returns:** `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
-
-___
-<a id="createtransform"></a>
-
-### `<Protected>` createTransform
-
-▸ **createTransform**(): `Transform`
-
-*Overrides [CompressedSource](compressedsource.md).[createTransform](compressedsource.md#createtransform)*
-
-*Defined in [source-destination/gzip.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/gzip.ts#L29)*
-
-**Returns:** `Transform`
+**Returns:** *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
 ___
-<a id="createverifier"></a>
+
+### `Protected` createTransform
+
+▸ **createTransform**(): *Transform*
+
+*Overrides [CompressedSource](compressedsource.md).[createTransform](compressedsource.md#protected-abstract-createtransform)*
+
+*Defined in [lib/source-destination/gzip.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/gzip.ts#L29)*
+
+**Returns:** *Transform*
+
+___
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createWriteStream](sourcedestination.md#createwritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L327)*
+*Defined in [lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L327)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
-
-___
-<a id="getsize"></a>
-
-### `<Protected>` getSize
-
-▸ **getSize**(): `Promise`<`number` \| `undefined`>
-
-*Overrides [CompressedSource](compressedsource.md).[getSize](compressedsource.md#getsize)*
-
-*Defined in [source-destination/gzip.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/gzip.ts#L33)*
-
-**Returns:** `Promise`<`number` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="listenercount"></a>
+
+### `Protected` getSize
+
+▸ **getSize**(): *Promise‹number | undefined›*
+
+*Overrides [CompressedSource](compressedsource.md).[getSize](compressedsource.md#protected-getsize)*
+
+*Defined in [lib/source-destination/gzip.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/gzip.ts#L33)*
+
+**Returns:** *Promise‹number | undefined›*
+
+___
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_sourceOffset`: number): *Promise‹ReadResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[read](sourcedestination.md#read)*
+*Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L291)*
+*Defined in [lib/source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L291)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[write](sourcedestination.md#write)*
+*Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L300)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L300)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/classes/http.md
+++ b/doc/classes/http.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [Http](../classes/http.md)
+[etcher-sdk](../README.md) › [Http](http.md)
 
 # Class: Http
 
 ## Hierarchy
 
-↳  [SourceDestination](sourcedestination.md)
+  ↳ [SourceDestination](sourcedestination.md)
 
-**↳ Http**
+  ↳ **Http**
 
 ## Index
 
@@ -16,20 +16,20 @@
 
 ### Properties
 
-* [acceptsRange](http.md#acceptsrange)
-* [error](http.md#error)
-* [ready](http.md#ready)
-* [size](http.md#size)
-* [url](http.md#url)
-* [defaultMaxListeners](http.md#defaultmaxlisteners)
-* [imageExtensions](http.md#imageextensions)
-* [mimetype](http.md#mimetype)
+* [acceptsRange](http.md#private-acceptsrange)
+* [error](http.md#private-error)
+* [ready](http.md#private-ready)
+* [size](http.md#private-size)
+* [url](http.md#private-url)
+* [defaultMaxListeners](http.md#static-defaultmaxlisteners)
+* [imageExtensions](http.md#static-imageextensions)
+* [mimetype](http.md#static-optional-mimetype)
 
 ### Methods
 
-* [_close](http.md#_close)
-* [_getMetadata](http.md#_getmetadata)
-* [_open](http.md#_open)
+* [_close](http.md#protected-_close)
+* [_getMetadata](http.md#protected-_getmetadata)
+* [_open](http.md#protected-_open)
 * [addListener](http.md#addlistener)
 * [canCreateReadStream](http.md#cancreatereadstream)
 * [canCreateSparseReadStream](http.md#cancreatesparsereadstream)
@@ -46,12 +46,12 @@
 * [emit](http.md#emit)
 * [eventNames](http.md#eventnames)
 * [getBlocks](http.md#getblocks)
-* [getInfo](http.md#getinfo)
+* [getInfo](http.md#private-getinfo)
 * [getInnerSource](http.md#getinnersource)
 * [getMaxListeners](http.md#getmaxlisteners)
 * [getMetadata](http.md#getmetadata)
 * [getPartitionTable](http.md#getpartitiontable)
-* [getRange](http.md#getrange)
+* [getRange](http.md#private-getrange)
 * [listenerCount](http.md#listenercount)
 * [listeners](http.md#listeners)
 * [on](http.md#on)
@@ -64,94 +64,80 @@
 * [removeListener](http.md#removelistener)
 * [setMaxListeners](http.md#setmaxlisteners)
 * [write](http.md#write)
-* [listenerCount](http.md#listenercount-1)
-* [register](http.md#register)
-
----
+* [listenerCount](http.md#static-listenercount)
+* [register](http.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new Http**(url: *`string`*): [Http](http.md)
+\+ **new Http**(`url`: string): *[Http](http.md)*
 
-*Defined in [source-destination/http.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/http.ts#L36)*
+*Defined in [lib/source-destination/http.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/http.ts#L36)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| url | `string` |
+Name | Type |
+------ | ------ |
+`url` | string |
 
-**Returns:** [Http](http.md)
-
-___
+**Returns:** *[Http](http.md)*
 
 ## Properties
 
-<a id="acceptsrange"></a>
+### `Private` acceptsRange
 
-### `<Private>` acceptsRange
+• **acceptsRange**: *boolean*
 
-**● acceptsRange**: *`boolean`*
-
-*Defined in [source-destination/http.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/http.ts#L34)*
+*Defined in [lib/source-destination/http.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/http.ts#L34)*
 
 ___
-<a id="error"></a>
 
-### `<Private>` error
+### `Private` error
 
-**● error**: *`Error`*
+• **error**: *[Error](notcapable.md#static-error)*
 
-*Defined in [source-destination/http.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/http.ts#L36)*
-
-___
-<a id="ready"></a>
-
-### `<Private>` ready
-
-**● ready**: *`Promise`<`void`>*
-
-*Defined in [source-destination/http.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/http.ts#L35)*
+*Defined in [lib/source-destination/http.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/http.ts#L36)*
 
 ___
-<a id="size"></a>
 
-### `<Private>` size
+### `Private` ready
 
-**● size**: *`number`*
+• **ready**: *Promise‹void›*
 
-*Defined in [source-destination/http.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/http.ts#L33)*
-
-___
-<a id="url"></a>
-
-### `<Private>` url
-
-**● url**: *`string`*
-
-*Defined in [source-destination/http.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/http.ts#L38)*
+*Defined in [lib/source-destination/http.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/http.ts#L35)*
 
 ___
-<a id="defaultmaxlisteners"></a>
 
-### `<Static>` defaultMaxListeners
+### `Private` size
 
-**● defaultMaxListeners**: *`number`*
+• **size**: *number*
 
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/http.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/http.ts#L33)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Private` url
 
-**● imageExtensions**: *`string`[]* =  [
+• **url**: *string*
+
+*Defined in [lib/source-destination/http.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/http.ts#L38)*
+
+___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -164,684 +150,638 @@ ___
 		'wic',
 	]
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
-
-___
-<a id="mimetype"></a>
-
-### `<Static>``<Optional>` mimetype
-
-**● mimetype**: *`undefined` \| `string`*
-
-*Inherited from [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
-
-*Defined in [source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L244)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
+
+### `Static` `Optional` mimetype
+
+▪ **mimetype**? : *undefined | string*
+
+*Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
+
+*Defined in [lib/source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L244)*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Inherited from [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#_close)*
+*Defined in [lib/source-destination/source-destination.ts:353](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L353)*
 
-*Defined in [source-destination/source-destination.ts:353](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L353)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Overrides [SourceDestination](sourcedestination.md).[_getMetadata](sourcedestination.md#_getmetadata)*
+*Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [source-destination/http.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/http.ts#L65)*
+*Defined in [lib/source-destination/http.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/http.ts#L65)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Inherited from [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#_open)*
-
-*Defined in [source-destination/source-destination.ts:349](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L349)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Inherited from [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
+
+*Defined in [lib/source-destination/source-destination.ts:349](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L349)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/http.ts:61](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/http.ts#L61)*
+*Defined in [lib/source-destination/http.ts:61](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/http.ts#L61)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L268)*
+*Defined in [lib/source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L268)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseWriteStream](sourcedestination.md#cancreatesparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L276)*
+*Defined in [lib/source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L276)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateWriteStream](sourcedestination.md#cancreatewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L272)*
+*Defined in [lib/source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L272)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Overrides [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/http.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/http.ts#L53)*
+*Defined in [lib/source-destination/http.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/http.ts#L53)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canWrite](sourcedestination.md#canwrite)*
+*Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L260)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(emitProgress?: *`boolean`*, start?: *`number`*, end?: *`undefined` \| `number`*): `Promise`<`ReadableStream`>
+▸ **createReadStream**(`emitProgress`: boolean, `start`: number, `end?`: undefined | number): *Promise‹ReadableStream›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/http.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/http.ts#L110)*
+*Defined in [lib/source-destination/http.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/http.ts#L110)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` emitProgress | `boolean` | false |
-| `Default value` start | `number` | 0 |
-| `Optional` end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`emitProgress` | boolean | false |
+`start` | number | 0 |
+`end?` | undefined &#124; number | - |
 
-**Returns:** `Promise`<`ReadableStream`>
+**Returns:** *Promise‹ReadableStream›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(_generateChecksums?: *`boolean`*): `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+▸ **createSparseReadStream**(`_generateChecksums`: boolean): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L317)*
+*Defined in [lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L317)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _generateChecksums | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`_generateChecksums` | boolean | false |
 
-**Returns:** `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseWriteStream](sourcedestination.md#createsparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L331)*
+*Defined in [lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L331)*
 
-**Returns:** `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+**Returns:** *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
 ___
-<a id="createverifier"></a>
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createWriteStream](sourcedestination.md#createwritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L327)*
+*Defined in [lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L327)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
-
-___
-<a id="getinfo"></a>
-
-### `<Private>` getInfo
-
-▸ **getInfo**(): `Promise`<`void`>
-
-*Defined in [source-destination/http.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/http.ts#L43)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
+
+### `Private` getInfo
+
+▸ **getInfo**(): *Promise‹void›*
+
+*Defined in [lib/source-destination/http.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/http.ts#L43)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="getrange"></a>
 
-### `<Private>` getRange
+### `Private` getRange
 
-▸ **getRange**(start?: *`number`*, end?: *`undefined` \| `number`*): `string`
+▸ **getRange**(`start`: number, `end?`: undefined | number): *string*
 
-*Defined in [source-destination/http.ts:81](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/http.ts#L81)*
+*Defined in [lib/source-destination/http.ts:81](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/http.ts#L81)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` start | `number` | 0 |
-| `Optional` end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`start` | number | 0 |
+`end?` | undefined &#124; number | - |
 
-**Returns:** `string`
+**Returns:** *string*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(buffer: *`Buffer`*, bufferOffset: *`number`*, length: *`number`*, sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`buffer`: Buffer, `bufferOffset`: number, `length`: number, `sourceOffset`: number): *Promise‹ReadResult›*
 
-*Overrides [SourceDestination](sourcedestination.md).[read](sourcedestination.md#read)*
+*Overrides [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [source-destination/http.ts:90](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/http.ts#L90)*
+*Defined in [lib/source-destination/http.ts:90](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/http.ts#L90)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| bufferOffset | `number` |
-| length | `number` |
-| sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
+`bufferOffset` | number |
+`length` | number |
+`sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[write](sourcedestination.md#write)*
+*Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L300)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L300)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/classes/multidestination.md
+++ b/doc/classes/multidestination.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [MultiDestination](../classes/multidestination.md)
+[etcher-sdk](../README.md) › [MultiDestination](multidestination.md)
 
 # Class: MultiDestination
 
 ## Hierarchy
 
-↳  [SourceDestination](sourcedestination.md)
+  ↳ [SourceDestination](sourcedestination.md)
 
-**↳ MultiDestination**
+  ↳ **MultiDestination**
 
 ## Index
 
@@ -18,9 +18,9 @@
 
 * [destinations](multidestination.md#destinations)
 * [erroredDestinations](multidestination.md#erroreddestinations)
-* [defaultMaxListeners](multidestination.md#defaultmaxlisteners)
-* [imageExtensions](multidestination.md#imageextensions)
-* [mimetype](multidestination.md#mimetype)
+* [defaultMaxListeners](multidestination.md#static-defaultmaxlisteners)
+* [imageExtensions](multidestination.md#static-imageextensions)
+* [mimetype](multidestination.md#static-optional-mimetype)
 
 ### Accessors
 
@@ -28,11 +28,11 @@
 
 ### Methods
 
-* [_close](multidestination.md#_close)
-* [_getMetadata](multidestination.md#_getmetadata)
-* [_open](multidestination.md#_open)
+* [_close](multidestination.md#protected-_close)
+* [_getMetadata](multidestination.md#protected-_getmetadata)
+* [_open](multidestination.md#protected-_open)
 * [addListener](multidestination.md#addlistener)
-* [can](multidestination.md#can)
+* [can](multidestination.md#private-can)
 * [canCreateReadStream](multidestination.md#cancreatereadstream)
 * [canCreateSparseReadStream](multidestination.md#cancreatesparsereadstream)
 * [canCreateSparseWriteStream](multidestination.md#cancreatesparsewritestream)
@@ -43,7 +43,7 @@
 * [createReadStream](multidestination.md#createreadstream)
 * [createSparseReadStream](multidestination.md#createsparsereadstream)
 * [createSparseWriteStream](multidestination.md#createsparsewritestream)
-* [createStream](multidestination.md#createstream)
+* [createStream](multidestination.md#private-createstream)
 * [createVerifier](multidestination.md#createverifier)
 * [createWriteStream](multidestination.md#createwritestream)
 * [destinationError](multidestination.md#destinationerror)
@@ -66,67 +66,56 @@
 * [removeListener](multidestination.md#removelistener)
 * [setMaxListeners](multidestination.md#setmaxlisteners)
 * [write](multidestination.md#write)
-* [listenerCount](multidestination.md#listenercount-1)
-* [register](multidestination.md#register)
-
----
+* [listenerCount](multidestination.md#static-listenercount)
+* [register](multidestination.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new MultiDestination**(destinations: *[SourceDestination](sourcedestination.md)[]*): [MultiDestination](multidestination.md)
+\+ **new MultiDestination**(`destinations`: [SourceDestination](sourcedestination.md)[]): *[MultiDestination](multidestination.md)*
 
-*Defined in [source-destination/multi-destination.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L104)*
+*Defined in [lib/source-destination/multi-destination.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L104)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| destinations | [SourceDestination](sourcedestination.md)[] |
+Name | Type |
+------ | ------ |
+`destinations` | [SourceDestination](sourcedestination.md)[] |
 
-**Returns:** [MultiDestination](multidestination.md)
-
-___
+**Returns:** *[MultiDestination](multidestination.md)*
 
 ## Properties
 
-<a id="destinations"></a>
-
 ###  destinations
 
-**● destinations**: *`Set`<[SourceDestination](sourcedestination.md)>* =  new Set()
+• **destinations**: *Set‹[SourceDestination](sourcedestination.md)›* = new Set()
 
-*Defined in [source-destination/multi-destination.ts:103](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L103)*
+*Defined in [lib/source-destination/multi-destination.ts:103](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L103)*
 
 ___
-<a id="erroreddestinations"></a>
 
 ###  erroredDestinations
 
-**● erroredDestinations**: *`Set`<[SourceDestination](sourcedestination.md)>* =  new Set()
+• **erroredDestinations**: *Set‹[SourceDestination](sourcedestination.md)›* = new Set()
 
-*Defined in [source-destination/multi-destination.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L104)*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/multi-destination.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L104)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Static` defaultMaxListeners
 
-**● imageExtensions**: *`string`[]* =  [
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -139,720 +128,669 @@ ___
 		'wic',
 	]
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
-
-___
-<a id="mimetype"></a>
-
-### `<Static>``<Optional>` mimetype
-
-**● mimetype**: *`undefined` \| `string`*
-
-*Inherited from [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
-
-*Defined in [source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L244)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
+
+### `Static` `Optional` mimetype
+
+▪ **mimetype**? : *undefined | string*
+
+*Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
+
+*Defined in [lib/source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L244)*
 
 ## Accessors
 
-<a id="activedestinations"></a>
-
 ###  activeDestinations
 
-**get activeDestinations**(): `Set`<[SourceDestination](sourcedestination.md)>
+• **get activeDestinations**(): *Set‹[SourceDestination](sourcedestination.md)›*
 
-*Defined in [source-destination/multi-destination.ts:135](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L135)*
+*Defined in [lib/source-destination/multi-destination.ts:135](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L135)*
 
-**Returns:** `Set`<[SourceDestination](sourcedestination.md)>
-
-___
+**Returns:** *Set‹[SourceDestination](sourcedestination.md)›*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#_close)*
+*Defined in [lib/source-destination/multi-destination.ts:329](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L329)*
 
-*Defined in [source-destination/multi-destination.ts:329](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L329)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[_getMetadata](sourcedestination.md#_getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:287](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L287)*
+*Defined in [lib/source-destination/source-destination.ts:287](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L287)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#_open)*
-
-*Defined in [source-destination/multi-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L319)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
+
+*Defined in [lib/source-destination/multi-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L319)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
-
-**Returns:** `this`
-
-___
-<a id="can"></a>
-
-### `<Private>` can
-
-▸ **can**(methodName: *"canRead" \| "canWrite" \| "canCreateReadStream" \| "canCreateSparseReadStream" \| "canCreateWriteStream" \| "canCreateSparseWriteStream"*): `Promise`<`boolean`>
-
-*Defined in [source-destination/multi-destination.ts:139](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L139)*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| methodName | "canRead" \| "canWrite" \| "canCreateReadStream" \| "canCreateSparseReadStream" \| "canCreateWriteStream" \| "canCreateSparseWriteStream" |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
+
+### `Private` can
+
+▸ **can**(`methodName`: "canRead" | "canWrite" | "canCreateReadStream" | "canCreateSparseReadStream" | "canCreateWriteStream" | "canCreateSparseWriteStream"): *Promise‹boolean›*
+
+*Defined in [lib/source-destination/multi-destination.ts:139](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L139)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`methodName` | "canRead" &#124; "canWrite" &#124; "canCreateReadStream" &#124; "canCreateSparseReadStream" &#124; "canCreateWriteStream" &#124; "canCreateSparseWriteStream" |
+
+**Returns:** *Promise‹boolean›*
+
+___
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/multi-destination.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L166)*
+*Defined in [lib/source-destination/multi-destination.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L166)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/multi-destination.ts:170](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L170)*
+*Defined in [lib/source-destination/multi-destination.ts:170](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L170)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateSparseWriteStream](sourcedestination.md#cancreatesparsewritestream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/multi-destination.ts:178](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L178)*
+*Defined in [lib/source-destination/multi-destination.ts:178](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L178)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateWriteStream](sourcedestination.md#cancreatewritestream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/multi-destination.ts:174](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L174)*
+*Defined in [lib/source-destination/multi-destination.ts:174](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L174)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Overrides [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/multi-destination.ts:158](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L158)*
+*Defined in [lib/source-destination/multi-destination.ts:158](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L158)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canWrite](sourcedestination.md#canwrite)*
+*Overrides [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [source-destination/multi-destination.ts:162](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L162)*
+*Defined in [lib/source-destination/multi-destination.ts:162](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L162)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(...args: *`any`[]*): `Promise`<`ReadableStream`>
+▸ **createReadStream**(...`args`: any[]): *Promise‹ReadableStream›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/multi-destination.ts:219](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L219)*
+*Defined in [lib/source-destination/multi-destination.ts:219](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L219)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`...args` | any[] |
 
-**Returns:** `Promise`<`ReadableStream`>
+**Returns:** *Promise‹ReadableStream›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(...args: *`any`[]*): `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+▸ **createSparseReadStream**(...`args`: any[]): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Overrides [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/multi-destination.ts:228](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L228)*
+*Defined in [lib/source-destination/multi-destination.ts:228](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L228)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`...args` | any[] |
 
-**Returns:** `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createSparseWriteStream](sourcedestination.md#createsparsewritestream)*
+*Overrides [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/multi-destination.ts:308](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L308)*
+*Defined in [lib/source-destination/multi-destination.ts:308](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L308)*
 
-**Returns:** `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+**Returns:** *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
 ___
-<a id="createstream"></a>
 
-### `<Private>` createStream
+### `Private` createStream
 
-▸ **createStream**(methodName: *"createWriteStream" \| "createSparseWriteStream"*): `Promise`<`PassThrough`>
+▸ **createStream**(`methodName`: "createWriteStream" | "createSparseWriteStream"): *Promise‹PassThrough‹››*
 
-*Defined in [source-destination/multi-destination.ts:235](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L235)*
+*Defined in [lib/source-destination/multi-destination.ts:235](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L235)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| methodName | "createWriteStream" \| "createSparseWriteStream" |
+Name | Type |
+------ | ------ |
+`methodName` | "createWriteStream" &#124; "createSparseWriteStream" |
 
-**Returns:** `Promise`<`PassThrough`>
+**Returns:** *Promise‹PassThrough‹››*
 
 ___
-<a id="createverifier"></a>
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Overrides [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Overrides [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/multi-destination.ts:312](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L312)*
+*Defined in [lib/source-destination/multi-destination.ts:312](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L312)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createWriteStream](sourcedestination.md#createwritestream)*
+*Overrides [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/multi-destination.ts:304](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L304)*
+*Defined in [lib/source-destination/multi-destination.ts:304](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L304)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="destinationerror"></a>
 
 ###  destinationError
 
-▸ **destinationError**(destination: *[SourceDestination](sourcedestination.md)*, error: *`Error`*, stream?: *`EventEmitter`*): `void`
+▸ **destinationError**(`destination`: [SourceDestination](sourcedestination.md), `error`: [Error](notcapable.md#static-error), `stream?`: EventEmitter): *void*
 
-*Defined in [source-destination/multi-destination.ts:116](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L116)*
+*Defined in [lib/source-destination/multi-destination.ts:116](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L116)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| destination | [SourceDestination](sourcedestination.md) |
-| error | `Error` |
-| `Optional` stream | `EventEmitter` |
+Name | Type |
+------ | ------ |
+`destination` | [SourceDestination](sourcedestination.md) |
+`error` | [Error](notcapable.md#static-error) |
+`stream?` | EventEmitter |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(buffer: *`Buffer`*, bufferOffset: *`number`*, length: *`number`*, sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`buffer`: Buffer, `bufferOffset`: number, `length`: number, `sourceOffset`: number): *Promise‹ReadResult›*
 
-*Overrides [SourceDestination](sourcedestination.md).[read](sourcedestination.md#read)*
+*Overrides [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [source-destination/multi-destination.ts:182](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L182)*
+*Defined in [lib/source-destination/multi-destination.ts:182](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L182)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| bufferOffset | `number` |
-| length | `number` |
-| sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
+`bufferOffset` | number |
+`length` | number |
+`sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(buffer: *`Buffer`*, bufferOffset: *`number`*, length: *`number`*, fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`buffer`: Buffer, `bufferOffset`: number, `length`: number, `fileOffset`: number): *Promise‹WriteResult›*
 
-*Overrides [SourceDestination](sourcedestination.md).[write](sourcedestination.md#write)*
+*Overrides [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [source-destination/multi-destination.ts:197](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L197)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| bufferOffset | `number` |
-| length | `number` |
-| fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/multi-destination.ts:197](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L197)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
+`bufferOffset` | number |
+`length` | number |
+`fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/classes/multidestinationerror.md
+++ b/doc/classes/multidestinationerror.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [MultiDestinationError](../classes/multidestinationerror.md)
+[etcher-sdk](../README.md) › [MultiDestinationError](multidestinationerror.md)
 
 # Class: MultiDestinationError
 
 ## Hierarchy
 
- `Error`
+* [Error](notcapable.md#static-error)
 
-**↳ MultiDestinationError**
+  ↳ **MultiDestinationError**
 
 ## Index
 
@@ -20,94 +20,78 @@
 * [error](multidestinationerror.md#error)
 * [message](multidestinationerror.md#message)
 * [name](multidestinationerror.md#name)
-* [stack](multidestinationerror.md#stack)
-* [Error](multidestinationerror.md#error-1)
-
----
+* [stack](multidestinationerror.md#optional-stack)
+* [Error](multidestinationerror.md#static-error)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new MultiDestinationError**(error: *`Error`*, destination: *[SourceDestination](sourcedestination.md)*): [MultiDestinationError](multidestinationerror.md)
+\+ **new MultiDestinationError**(`error`: [Error](notcapable.md#static-error), `destination`: [SourceDestination](sourcedestination.md)): *[MultiDestinationError](multidestinationerror.md)*
 
-*Defined in [source-destination/multi-destination.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L35)*
+*Defined in [lib/source-destination/multi-destination.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L35)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| error | `Error` |
-| destination | [SourceDestination](sourcedestination.md) |
+Name | Type |
+------ | ------ |
+`error` | [Error](notcapable.md#static-error) |
+`destination` | [SourceDestination](sourcedestination.md) |
 
-**Returns:** [MultiDestinationError](multidestinationerror.md)
-
-___
+**Returns:** *[MultiDestinationError](multidestinationerror.md)*
 
 ## Properties
 
-<a id="destination"></a>
-
 ###  destination
 
-**● destination**: *[SourceDestination](sourcedestination.md)*
+• **destination**: *[SourceDestination](sourcedestination.md)*
 
-*Defined in [source-destination/multi-destination.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L36)*
+*Defined in [lib/source-destination/multi-destination.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L36)*
 
 ___
-<a id="error"></a>
 
 ###  error
 
-**● error**: *`Error`*
+• **error**: *[Error](notcapable.md#static-error)*
 
-*Defined in [source-destination/multi-destination.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L36)*
+*Defined in [lib/source-destination/multi-destination.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L36)*
 
 ___
-<a id="message"></a>
 
 ###  message
 
-**● message**: *`string`*
+• **message**: *string*
 
-*Inherited from Error.message*
+*Inherited from [NotCapable](notcapable.md).[message](notcapable.md#message)*
 
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:964*
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:974
 
 ___
-<a id="name"></a>
 
 ###  name
 
-**● name**: *`string`*
+• **name**: *string*
 
-*Inherited from Error.name*
+*Inherited from [NotCapable](notcapable.md).[name](notcapable.md#name)*
 
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:963*
-
-___
-<a id="stack"></a>
-
-### `<Optional>` stack
-
-**● stack**: *`undefined` \| `string`*
-
-*Inherited from Error.stack*
-
-*Overrides Error.stack*
-
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:965*
-
-___
-<a id="error-1"></a>
-
-### `<Static>` Error
-
-**● Error**: *`ErrorConstructor`*
-
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:974*
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:973
 
 ___
 
+### `Optional` stack
+
+• **stack**? : *undefined | string*
+
+*Inherited from [NotCapable](notcapable.md).[stack](notcapable.md#optional-stack)*
+
+*Overrides [NotCapable](notcapable.md).[stack](notcapable.md#optional-stack)*
+
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:975
+
+___
+
+### `Static` Error
+
+▪ **Error**: *ErrorConstructor*
+
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:984

--- a/doc/classes/multidestinationverifier.md
+++ b/doc/classes/multidestinationverifier.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [MultiDestinationVerifier](../classes/multidestinationverifier.md)
+[etcher-sdk](../README.md) › [MultiDestinationVerifier](multidestinationverifier.md)
 
 # Class: MultiDestinationVerifier
 
 ## Hierarchy
 
-↳  [Verifier](verifier.md)
+  ↳ [Verifier](verifier.md)
 
-**↳ MultiDestinationVerifier**
+  ↳ **MultiDestinationVerifier**
 
 ## Index
 
@@ -16,482 +16,434 @@
 
 ### Properties
 
-* [timer](multidestinationverifier.md#timer)
-* [verifiers](multidestinationverifier.md#verifiers)
-* [defaultMaxListeners](multidestinationverifier.md#defaultmaxlisteners)
+* [timer](multidestinationverifier.md#private-timer)
+* [verifiers](multidestinationverifier.md#private-verifiers)
+* [defaultMaxListeners](multidestinationverifier.md#static-defaultmaxlisteners)
 
 ### Methods
 
 * [addListener](multidestinationverifier.md#addlistener)
 * [emit](multidestinationverifier.md#emit)
-* [emitProgress](multidestinationverifier.md#emitprogress)
+* [emitProgress](multidestinationverifier.md#private-emitprogress)
 * [eventNames](multidestinationverifier.md#eventnames)
 * [getMaxListeners](multidestinationverifier.md#getmaxlisteners)
-* [handleEventsAndPipe](multidestinationverifier.md#handleeventsandpipe)
+* [handleEventsAndPipe](multidestinationverifier.md#protected-handleeventsandpipe)
 * [listenerCount](multidestinationverifier.md#listenercount)
 * [listeners](multidestinationverifier.md#listeners)
 * [on](multidestinationverifier.md#on)
 * [once](multidestinationverifier.md#once)
-* [oneVerifierFinished](multidestinationverifier.md#oneverifierfinished)
+* [oneVerifierFinished](multidestinationverifier.md#private-oneverifierfinished)
 * [prependListener](multidestinationverifier.md#prependlistener)
 * [prependOnceListener](multidestinationverifier.md#prependoncelistener)
 * [removeAllListeners](multidestinationverifier.md#removealllisteners)
 * [removeListener](multidestinationverifier.md#removelistener)
 * [run](multidestinationverifier.md#run)
 * [setMaxListeners](multidestinationverifier.md#setmaxlisteners)
-* [listenerCount](multidestinationverifier.md#listenercount-1)
+* [listenerCount](multidestinationverifier.md#static-listenercount)
 
 ### Object literals
 
 * [progress](multidestinationverifier.md#progress)
 
----
-
 ## Constructors
-
-<a id="constructor"></a>
 
 ###  constructor
 
-⊕ **new MultiDestinationVerifier**(source: *[MultiDestination](multidestination.md)*, checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [MultiDestinationVerifier](multidestinationverifier.md)
+\+ **new MultiDestinationVerifier**(`source`: [MultiDestination](multidestination.md), `checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[MultiDestinationVerifier](multidestinationverifier.md)*
 
-*Defined in [source-destination/multi-destination.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L43)*
+*Defined in [lib/source-destination/multi-destination.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L43)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| source | [MultiDestination](multidestination.md) |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`source` | [MultiDestination](multidestination.md) |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [MultiDestinationVerifier](multidestinationverifier.md)
-
-___
+**Returns:** *[MultiDestinationVerifier](multidestinationverifier.md)*
 
 ## Properties
 
-<a id="timer"></a>
+### `Private` timer
 
-### `<Private>` timer
+• **timer**: *Timer*
 
-**● timer**: *`Timer`*
-
-*Defined in [source-destination/multi-destination.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L43)*
+*Defined in [lib/source-destination/multi-destination.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L43)*
 
 ___
-<a id="verifiers"></a>
 
-### `<Private>` verifiers
+### `Private` verifiers
 
-**● verifiers**: *`Set`<[Verifier](verifier.md)>* =  new Set()
+• **verifiers**: *Set‹[Verifier](verifier.md)›* = new Set()
 
-*Defined in [source-destination/multi-destination.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L42)*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/multi-destination.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L42)*
 
 ___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="addlistener"></a>
-
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
-
-___
-<a id="emitprogress"></a>
-
-### `<Private>` emitProgress
-
-▸ **emitProgress**(): `void`
-
-*Defined in [source-destination/multi-destination.ts:76](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L76)*
-
-**Returns:** `void`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
+
+### `Private` emitProgress
+
+▸ **emitProgress**(): *void*
+
+*Defined in [lib/source-destination/multi-destination.ts:76](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L76)*
+
+**Returns:** *void*
+
+___
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="handleeventsandpipe"></a>
 
-### `<Protected>` handleEventsAndPipe
+### `Protected` handleEventsAndPipe
 
-▸ **handleEventsAndPipe**(stream: *`ReadableStream`*, meter: *`WritableStream`*): `void`
+▸ **handleEventsAndPipe**(`stream`: ReadableStream, `meter`: WritableStream): *void*
 
-*Inherited from [Verifier](verifier.md).[handleEventsAndPipe](verifier.md#handleeventsandpipe)*
+*Inherited from [Verifier](verifier.md).[handleEventsAndPipe](verifier.md#protected-handleeventsandpipe)*
 
-*Defined in [source-destination/source-destination.ts:134](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L134)*
+*Defined in [lib/source-destination/source-destination.ts:134](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L134)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| stream | `ReadableStream` |
-| meter | `WritableStream` |
+Name | Type |
+------ | ------ |
+`stream` | ReadableStream |
+`meter` | WritableStream |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
-
-**Returns:** `this`
-
-___
-<a id="oneverifierfinished"></a>
-
-### `<Private>` oneVerifierFinished
-
-▸ **oneVerifierFinished**(verifier: *[Verifier](verifier.md)*): `void`
-
-*Defined in [source-destination/multi-destination.ts:64](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L64)*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| verifier | [Verifier](verifier.md) |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `void`
+**Returns:** *this*
 
 ___
-<a id="prependlistener"></a>
+
+### `Private` oneVerifierFinished
+
+▸ **oneVerifierFinished**(`verifier`: [Verifier](verifier.md)): *void*
+
+*Defined in [lib/source-destination/multi-destination.ts:64](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L64)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`verifier` | [Verifier](verifier.md) |
+
+**Returns:** *void*
+
+___
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="run"></a>
 
 ###  run
 
-▸ **run**(): `Promise`<`void`>
+▸ **run**(): *Promise‹void›*
 
-*Overrides [Verifier](verifier.md).[run](verifier.md#run)*
+*Overrides [Verifier](verifier.md).[run](verifier.md#abstract-run)*
 
-*Defined in [source-destination/multi-destination.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/multi-destination.ts#L86)*
+*Defined in [lib/source-destination/multi-destination.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/multi-destination.ts#L86)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
-
-**Returns:** `this`
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `number`
+**Returns:** *this*
 
 ___
+
+### `Static` listenerCount
+
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
+
+Defined in node_modules/@types/node/base.d.ts:680
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
+
+**Returns:** *number*
 
 ## Object literals
 
-<a id="progress"></a>
-
 ###  progress
 
-**progress**: *`object`*
+### ▪ **progress**: *object*
 
 *Inherited from [Verifier](verifier.md).[progress](verifier.md#progress)*
 
-*Defined in [source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L130)*
+*Defined in [lib/source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L130)*
 
-<a id="progress.bytes"></a>
+###  bytes
 
-####  bytes
+• **bytes**: *number* = 0
 
-**● bytes**: *`number`* = 0
+*Defined in [lib/source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L130)*
 
-*Defined in [source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L130)*
+###  position
 
-___
-<a id="progress.position"></a>
+• **position**: *number* = 0
 
-####  position
+*Defined in [lib/source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L130)*
 
-**● position**: *`number`* = 0
+###  speed
 
-*Defined in [source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L130)*
+• **speed**: *number* = 0
 
-___
-<a id="progress.speed"></a>
-
-####  speed
-
-**● speed**: *`number`* = 0
-
-*Defined in [source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L130)*
-
-___
-
-___
-
+*Defined in [lib/source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L130)*

--- a/doc/classes/notcapable.md
+++ b/doc/classes/notcapable.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [NotCapable](../classes/notcapable.md)
+[etcher-sdk](../README.md) › [NotCapable](notcapable.md)
 
 # Class: NotCapable
 
 ## Hierarchy
 
- `Error`
+* [Error](notcapable.md#static-error)
 
-**↳ NotCapable**
+  ↳ **NotCapable**
 
 ## Index
 
@@ -14,55 +14,45 @@
 
 * [message](notcapable.md#message)
 * [name](notcapable.md#name)
-* [stack](notcapable.md#stack)
-* [Error](notcapable.md#error)
-
----
+* [stack](notcapable.md#optional-stack)
+* [Error](notcapable.md#static-error)
 
 ## Properties
 
-<a id="message"></a>
-
 ###  message
 
-**● message**: *`string`*
+• **message**: *string*
 
-*Inherited from Error.message*
+*Inherited from [NotCapable](notcapable.md).[message](notcapable.md#message)*
 
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:964*
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:974
 
 ___
-<a id="name"></a>
 
 ###  name
 
-**● name**: *`string`*
+• **name**: *string*
 
-*Inherited from Error.name*
+*Inherited from [NotCapable](notcapable.md).[name](notcapable.md#name)*
 
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:963*
-
-___
-<a id="stack"></a>
-
-### `<Optional>` stack
-
-**● stack**: *`undefined` \| `string`*
-
-*Inherited from Error.stack*
-
-*Overrides Error.stack*
-
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:965*
-
-___
-<a id="error"></a>
-
-### `<Static>` Error
-
-**● Error**: *`ErrorConstructor`*
-
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:974*
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:973
 
 ___
 
+### `Optional` stack
+
+• **stack**? : *undefined | string*
+
+*Inherited from [NotCapable](notcapable.md).[stack](notcapable.md#optional-stack)*
+
+*Overrides [NotCapable](notcapable.md).[stack](notcapable.md#optional-stack)*
+
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:975
+
+___
+
+### `Static` Error
+
+▪ **Error**: *ErrorConstructor*
+
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:984

--- a/doc/classes/randomaccesszipsource.md
+++ b/doc/classes/randomaccesszipsource.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [RandomAccessZipSource](../classes/randomaccesszipsource.md)
+[etcher-sdk](../README.md) › [RandomAccessZipSource](randomaccesszipsource.md)
 
 # Class: RandomAccessZipSource
 
 ## Hierarchy
 
-↳  [SourceSource](sourcesource.md)
+  ↳ [SourceSource](sourcesource.md)
 
-**↳ RandomAccessZipSource**
+  ↳ **RandomAccessZipSource**
 
 ## Index
 
@@ -16,22 +16,22 @@
 
 ### Properties
 
-* [entries](randomaccesszipsource.md#entries)
-* [match](randomaccesszipsource.md#match)
-* [ready](randomaccesszipsource.md#ready)
-* [source](randomaccesszipsource.md#source)
-* [zip](randomaccesszipsource.md#zip)
-* [defaultMaxListeners](randomaccesszipsource.md#defaultmaxlisteners)
-* [imageExtensions](randomaccesszipsource.md#imageextensions)
-* [manifestFields](randomaccesszipsource.md#manifestfields)
-* [mimetype](randomaccesszipsource.md#mimetype)
-* [requiresRandomReadableSource](randomaccesszipsource.md#requiresrandomreadablesource)
+* [entries](randomaccesszipsource.md#private-entries)
+* [match](randomaccesszipsource.md#private-match)
+* [ready](randomaccesszipsource.md#private-ready)
+* [source](randomaccesszipsource.md#protected-source)
+* [zip](randomaccesszipsource.md#private-zip)
+* [defaultMaxListeners](randomaccesszipsource.md#static-defaultmaxlisteners)
+* [imageExtensions](randomaccesszipsource.md#static-imageextensions)
+* [manifestFields](randomaccesszipsource.md#static-private-manifestfields)
+* [mimetype](randomaccesszipsource.md#static-optional-mimetype)
+* [requiresRandomReadableSource](randomaccesszipsource.md#static-requiresrandomreadablesource)
 
 ### Methods
 
-* [_close](randomaccesszipsource.md#_close)
+* [_close](randomaccesszipsource.md#protected-_close)
 * [_getMetadata](randomaccesszipsource.md#_getmetadata)
-* [_open](randomaccesszipsource.md#_open)
+* [_open](randomaccesszipsource.md#protected-_open)
 * [addListener](randomaccesszipsource.md#addlistener)
 * [canCreateReadStream](randomaccesszipsource.md#cancreatereadstream)
 * [canCreateSparseReadStream](randomaccesszipsource.md#cancreatesparsereadstream)
@@ -48,17 +48,17 @@
 * [emit](randomaccesszipsource.md#emit)
 * [eventNames](randomaccesszipsource.md#eventnames)
 * [getBlocks](randomaccesszipsource.md#getblocks)
-* [getEntries](randomaccesszipsource.md#getentries)
-* [getEntryByName](randomaccesszipsource.md#getentrybyname)
-* [getImageEntry](randomaccesszipsource.md#getimageentry)
+* [getEntries](randomaccesszipsource.md#private-getentries)
+* [getEntryByName](randomaccesszipsource.md#private-getentrybyname)
+* [getImageEntry](randomaccesszipsource.md#private-getimageentry)
 * [getInnerSource](randomaccesszipsource.md#getinnersource)
-* [getJson](randomaccesszipsource.md#getjson)
+* [getJson](randomaccesszipsource.md#private-getjson)
 * [getMaxListeners](randomaccesszipsource.md#getmaxlisteners)
 * [getMetadata](randomaccesszipsource.md#getmetadata)
 * [getPartitionTable](randomaccesszipsource.md#getpartitiontable)
-* [getStream](randomaccesszipsource.md#getstream)
-* [getString](randomaccesszipsource.md#getstring)
-* [init](randomaccesszipsource.md#init)
+* [getStream](randomaccesszipsource.md#private-getstream)
+* [getString](randomaccesszipsource.md#private-getstring)
+* [init](randomaccesszipsource.md#private-init)
 * [listenerCount](randomaccesszipsource.md#listenercount)
 * [listeners](randomaccesszipsource.md#listeners)
 * [on](randomaccesszipsource.md#on)
@@ -71,110 +71,102 @@
 * [removeListener](randomaccesszipsource.md#removelistener)
 * [setMaxListeners](randomaccesszipsource.md#setmaxlisteners)
 * [write](randomaccesszipsource.md#write)
-* [listenerCount](randomaccesszipsource.md#listenercount-1)
-* [register](randomaccesszipsource.md#register)
-
----
+* [listenerCount](randomaccesszipsource.md#static-listenercount)
+* [register](randomaccesszipsource.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new RandomAccessZipSource**(source: *[SourceDestination](sourcedestination.md)*, match?: *`function`*): [RandomAccessZipSource](randomaccesszipsource.md)
+\+ **new RandomAccessZipSource**(`source`: [SourceDestination](sourcedestination.md), `match`: function): *[RandomAccessZipSource](randomaccesszipsource.md)*
 
 *Overrides [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
 
-*Defined in [source-destination/zip.ts:162](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L162)*
+*Defined in [lib/source-destination/zip.ts:162](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L162)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| source | [SourceDestination](sourcedestination.md) | - |
-| `Default value` match | `function` |  matchSupportedExtensions |
+▪ **source**: *[SourceDestination](sourcedestination.md)*
 
-**Returns:** [RandomAccessZipSource](randomaccesszipsource.md)
+▪`Default value`  **match**: *function*= matchSupportedExtensions
 
-___
+▸ (`filename`: string): *boolean*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`filename` | string |
+
+**Returns:** *[RandomAccessZipSource](randomaccesszipsource.md)*
 
 ## Properties
 
-<a id="entries"></a>
+### `Private` entries
 
-### `<Private>` entries
+• **entries**: *Entry[]* = []
 
-**● entries**: *`Entry`[]* =  []
-
-*Defined in [source-destination/zip.ts:162](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L162)*
+*Defined in [lib/source-destination/zip.ts:162](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L162)*
 
 ___
-<a id="match"></a>
 
-### `<Private>` match
+### `Private` match
 
-**● match**: *`function`*
+• **match**: *function*
 
-*Defined in [source-destination/zip.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L166)*
+*Defined in [lib/source-destination/zip.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L166)*
 
-#### Type declaration
-▸(filename: *`string`*): `boolean`
+#### Type declaration:
+
+▸ (`filename`: string): *boolean*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| filename | `string` |
-
-**Returns:** `boolean`
+Name | Type |
+------ | ------ |
+`filename` | string |
 
 ___
-<a id="ready"></a>
 
-### `<Private>` ready
+### `Private` ready
 
-**● ready**: *`Promise`<`void`>*
+• **ready**: *Promise‹void›*
 
-*Defined in [source-destination/zip.ts:161](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L161)*
-
-___
-<a id="source"></a>
-
-### `<Protected>` source
-
-**● source**: *[SourceDestination](sourcedestination.md)*
-
-*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#source)*
-
-*Defined in [source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L22)*
+*Defined in [lib/source-destination/zip.ts:161](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L161)*
 
 ___
-<a id="zip"></a>
 
-### `<Private>` zip
+### `Protected` source
 
-**● zip**: *`ZipFile`*
+• **source**: *[SourceDestination](sourcedestination.md)*
 
-*Defined in [source-destination/zip.ts:160](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L160)*
+*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
 
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L22)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Private` zip
 
-**● imageExtensions**: *`string`[]* =  [
+• **zip**: *ZipFile*
+
+*Defined in [lib/source-destination/zip.ts:160](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L160)*
+
+___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -187,16 +179,15 @@ ___
 		'wic',
 	]
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
-<a id="manifestfields"></a>
 
-### `<Static>``<Private>` manifestFields
+### `Static` `Private` manifestFields
 
-**● manifestFields**: *`Array`<`keyof Metadata`>* =  [
+▪ **manifestFields**: *Array‹keyof Metadata›* = [
 		'bytesToZeroOutFromTheBeginning',
 		'checksum',
 		'checksumType',
@@ -207,767 +198,715 @@ ___
 		'version',
 	]
 
-*Defined in [source-destination/zip.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L150)*
+*Defined in [lib/source-destination/zip.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L150)*
 
 ___
-<a id="mimetype"></a>
 
-### `<Static>``<Optional>` mimetype
+### `Static` `Optional` mimetype
 
-**● mimetype**: *`undefined` \| `string`*
+▪ **mimetype**? : *undefined | string*
 
-*Inherited from [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
+*Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
 
-*Defined in [source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L244)*
-
-___
-<a id="requiresrandomreadablesource"></a>
-
-### `<Static>` requiresRandomReadableSource
-
-**● requiresRandomReadableSource**: *`boolean`* = false
-
-*Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#requiresrandomreadablesource)*
-
-*Defined in [source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L244)*
 
 ___
+
+### `Static` requiresRandomReadableSource
+
+▪ **requiresRandomReadableSource**: *boolean* = false
+
+*Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
+
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L20)*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Inherited from [SourceSource](sourcesource.md).[_close](sourcesource.md#protected-_close)*
 
-*Inherited from [SourceSource](sourcesource.md).[_close](sourcesource.md#_close)*
+*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#_close)*
+*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L30)*
 
-*Defined in [source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L30)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
 ###  _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Overrides [SourceDestination](sourcedestination.md).[_getMetadata](sourcedestination.md#_getmetadata)*
+*Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [source-destination/zip.ts:310](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L310)*
+*Defined in [lib/source-destination/zip.ts:310](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L310)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Overrides [SourceSource](sourcesource.md).[_open](sourcesource.md#_open)*
-
-*Defined in [source-destination/zip.ts:227](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L227)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Overrides [SourceSource](sourcesource.md).[_open](sourcesource.md#protected-_open)*
+
+*Defined in [lib/source-destination/zip.ts:227](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L227)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/zip.ts:198](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L198)*
+*Defined in [lib/source-destination/zip.ts:198](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L198)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/zip.ts:202](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L202)*
+*Defined in [lib/source-destination/zip.ts:202](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L202)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseWriteStream](sourcedestination.md#cancreatesparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L276)*
+*Defined in [lib/source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L276)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateWriteStream](sourcedestination.md#cancreatewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L272)*
+*Defined in [lib/source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L272)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L256)*
+*Defined in [lib/source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L256)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canWrite](sourcedestination.md#canwrite)*
+*Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L260)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(_emitProgress?: *`boolean`*, start?: *`number`*, end?: *`undefined` \| `number`*): `Promise`<`ReadableStream`>
+▸ **createReadStream**(`_emitProgress`: boolean, `start`: number, `end?`: undefined | number): *Promise‹ReadableStream›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/zip.ts:271](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L271)*
+*Defined in [lib/source-destination/zip.ts:271](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L271)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _emitProgress | `boolean` | false |
-| `Default value` start | `number` | 0 |
-| `Optional` end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`_emitProgress` | boolean | false |
+`start` | number | 0 |
+`end?` | undefined &#124; number | - |
 
-**Returns:** `Promise`<`ReadableStream`>
+**Returns:** *Promise‹ReadableStream›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(generateChecksums?: *`boolean`*): `Promise`<[SparseFilterStream](sparsefilterstream.md)>
+▸ **createSparseReadStream**(`generateChecksums`: boolean): *Promise‹[SparseFilterStream](sparsefilterstream.md)›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Overrides [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/zip.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L292)*
+*Defined in [lib/source-destination/zip.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L292)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` generateChecksums | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`generateChecksums` | boolean | false |
 
-**Returns:** `Promise`<[SparseFilterStream](sparsefilterstream.md)>
+**Returns:** *Promise‹[SparseFilterStream](sparsefilterstream.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseWriteStream](sourcedestination.md#createsparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L331)*
+*Defined in [lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L331)*
 
-**Returns:** `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+**Returns:** *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
 ___
-<a id="createverifier"></a>
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createWriteStream](sourcedestination.md#createwritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L327)*
+*Defined in [lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L327)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
-
-___
-<a id="getentries"></a>
-
-### `<Private>` getEntries
-
-▸ **getEntries**(): `Promise`<`Entry`[]>
-
-*Defined in [source-destination/zip.ts:207](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L207)*
-
-**Returns:** `Promise`<`Entry`[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getentrybyname"></a>
 
-### `<Private>` getEntryByName
+### `Private` getEntries
 
-▸ **getEntryByName**(name: *`string`*): `Promise`<`Entry` \| `undefined`>
+▸ **getEntries**(): *Promise‹Entry[]›*
 
-*Defined in [source-destination/zip.ts:233](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L233)*
+*Defined in [lib/source-destination/zip.ts:207](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L207)*
+
+**Returns:** *Promise‹Entry[]›*
+
+___
+
+### `Private` getEntryByName
+
+▸ **getEntryByName**(`name`: string): *Promise‹Entry | undefined›*
+
+*Defined in [lib/source-destination/zip.ts:233](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L233)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| name | `string` |
+Name | Type |
+------ | ------ |
+`name` | string |
 
-**Returns:** `Promise`<`Entry` \| `undefined`>
-
-___
-<a id="getimageentry"></a>
-
-### `<Private>` getImageEntry
-
-▸ **getImageEntry**(): `Promise`<`Entry`>
-
-*Defined in [source-destination/zip.ts:212](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L212)*
-
-**Returns:** `Promise`<`Entry`>
+**Returns:** *Promise‹Entry | undefined›*
 
 ___
-<a id="getinnersource"></a>
+
+### `Private` getImageEntry
+
+▸ **getImageEntry**(): *Promise‹Entry›*
+
+*Defined in [lib/source-destination/zip.ts:212](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L212)*
+
+**Returns:** *Promise‹Entry›*
+
+___
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getjson"></a>
 
-### `<Private>` getJson
+### `Private` getJson
 
-▸ **getJson**(name: *`string`*): `Promise`<`any`>
+▸ **getJson**(`name`: string): *Promise‹any›*
 
-*Defined in [source-destination/zip.ts:264](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L264)*
+*Defined in [lib/source-destination/zip.ts:264](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L264)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| name | `string` |
+Name | Type |
+------ | ------ |
+`name` | string |
 
-**Returns:** `Promise`<`any`>
+**Returns:** *Promise‹any›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="getstream"></a>
 
-### `<Private>` getStream
+### `Private` getStream
 
-▸ **getStream**(name: *`string`*): `Promise`<`ReadableStream` \| `undefined`>
+▸ **getStream**(`name`: string): *Promise‹ReadableStream | undefined›*
 
-*Defined in [source-destination/zip.ts:242](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L242)*
+*Defined in [lib/source-destination/zip.ts:242](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L242)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| name | `string` |
+Name | Type |
+------ | ------ |
+`name` | string |
 
-**Returns:** `Promise`<`ReadableStream` \| `undefined`>
+**Returns:** *Promise‹ReadableStream | undefined›*
 
 ___
-<a id="getstring"></a>
 
-### `<Private>` getString
+### `Private` getString
 
-▸ **getString**(name: *`string`*): `Promise`<`string` \| `undefined`>
+▸ **getString**(`name`: string): *Promise‹string | undefined›*
 
-*Defined in [source-destination/zip.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L256)*
+*Defined in [lib/source-destination/zip.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L256)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| name | `string` |
+Name | Type |
+------ | ------ |
+`name` | string |
 
-**Returns:** `Promise`<`string` \| `undefined`>
-
-___
-<a id="init"></a>
-
-### `<Private>` init
-
-▸ **init**(): `Promise`<`void`>
-
-*Defined in [source-destination/zip.ts:172](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L172)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹string | undefined›*
 
 ___
-<a id="listenercount"></a>
+
+### `Private` init
+
+▸ **init**(): *Promise‹void›*
+
+*Defined in [lib/source-destination/zip.ts:172](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L172)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_sourceOffset`: number): *Promise‹ReadResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[read](sourcedestination.md#read)*
+*Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L291)*
+*Defined in [lib/source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L291)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[write](sourcedestination.md#write)*
+*Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L300)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L300)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/classes/scanner.md
+++ b/doc/classes/scanner.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [Scanner](../classes/scanner.md)
+[etcher-sdk](../README.md) › [Scanner](scanner.md)
 
 # Class: Scanner
 
 ## Hierarchy
 
- `EventEmitter`
+* EventEmitter
 
-**↳ Scanner**
+  ↳ **Scanner**
 
 ## Index
 
@@ -16,9 +16,9 @@
 
 ### Properties
 
-* [adapters](scanner.md#adapters)
+* [adapters](scanner.md#private-adapters)
 * [drives](scanner.md#drives)
-* [defaultMaxListeners](scanner.md#defaultmaxlisteners)
+* [defaultMaxListeners](scanner.md#static-defaultmaxlisteners)
 
 ### Methods
 
@@ -30,8 +30,8 @@
 * [listenerCount](scanner.md#listenercount)
 * [listeners](scanner.md#listeners)
 * [on](scanner.md#on)
-* [onAttach](scanner.md#onattach)
-* [onDetach](scanner.md#ondetach)
+* [onAttach](scanner.md#private-onattach)
+* [onDetach](scanner.md#private-ondetach)
 * [once](scanner.md#once)
 * [prependListener](scanner.md#prependlistener)
 * [prependOnceListener](scanner.md#prependoncelistener)
@@ -40,424 +40,389 @@
 * [setMaxListeners](scanner.md#setmaxlisteners)
 * [start](scanner.md#start)
 * [stop](scanner.md#stop)
-* [listenerCount](scanner.md#listenercount-1)
-
----
+* [listenerCount](scanner.md#static-listenercount)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new Scanner**(adapters: *[Adapter](adapter.md)[]*): [Scanner](scanner.md)
+\+ **new Scanner**(`adapters`: [Adapter](adapter.md)[]): *[Scanner](scanner.md)*
 
-*Defined in [scanner/scanner.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/scanner.ts#L25)*
+*Defined in [lib/scanner/scanner.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/scanner.ts#L25)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| adapters | [Adapter](adapter.md)[] |
+Name | Type |
+------ | ------ |
+`adapters` | [Adapter](adapter.md)[] |
 
-**Returns:** [Scanner](scanner.md)
-
-___
+**Returns:** *[Scanner](scanner.md)*
 
 ## Properties
 
-<a id="adapters"></a>
+### `Private` adapters
 
-### `<Private>` adapters
+• **adapters**: *[Adapter](adapter.md)[]*
 
-**● adapters**: *[Adapter](adapter.md)[]*
-
-*Defined in [scanner/scanner.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/scanner.ts#L27)*
+*Defined in [lib/scanner/scanner.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/scanner.ts#L27)*
 
 ___
-<a id="drives"></a>
 
 ###  drives
 
-**● drives**: *`Set`<[AdapterSourceDestination](../interfaces/adaptersourcedestination.md)>* =  new Set()
+• **drives**: *Set‹[AdapterSourceDestination](../interfaces/adaptersourcedestination.md)›* = new Set()
 
-*Defined in [scanner/scanner.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/scanner.ts#L25)*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/scanner/scanner.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/scanner.ts#L25)*
 
 ___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="addlistener"></a>
-
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getby"></a>
 
 ###  getBy
 
-▸ **getBy**(field: *"raw" \| "device" \| "devicePath"*, value: *`string`*): [AdapterSourceDestination](../interfaces/adaptersourcedestination.md) \| `undefined`
+▸ **getBy**(`field`: "raw" | "device" | "devicePath", `value`: string): *[AdapterSourceDestination](../interfaces/adaptersourcedestination.md) | undefined*
 
-*Defined in [scanner/scanner.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/scanner.ts#L46)*
+*Defined in [lib/scanner/scanner.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/scanner.ts#L46)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| field | "raw" \| "device" \| "devicePath" |
-| value | `string` |
+Name | Type |
+------ | ------ |
+`field` | "raw" &#124; "device" &#124; "devicePath" |
+`value` | string |
 
-**Returns:** [AdapterSourceDestination](../interfaces/adaptersourcedestination.md) \| `undefined`
+**Returns:** *[AdapterSourceDestination](../interfaces/adaptersourcedestination.md) | undefined*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
-
-**Returns:** `this`
-
-___
-<a id="onattach"></a>
-
-### `<Private>` onAttach
-
-▸ **onAttach**(drive: *[AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*): `void`
-
-*Defined in [scanner/scanner.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/scanner.ts#L36)*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| drive | [AdapterSourceDestination](../interfaces/adaptersourcedestination.md) |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `void`
+**Returns:** *this*
 
 ___
-<a id="ondetach"></a>
 
-### `<Private>` onDetach
+### `Private` onAttach
 
-▸ **onDetach**(drive: *[AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*): `void`
+▸ **onAttach**(`drive`: [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)): *void*
 
-*Defined in [scanner/scanner.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/scanner.ts#L41)*
+*Defined in [lib/scanner/scanner.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/scanner.ts#L36)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| drive | [AdapterSourceDestination](../interfaces/adaptersourcedestination.md) |
+Name | Type |
+------ | ------ |
+`drive` | [AdapterSourceDestination](../interfaces/adaptersourcedestination.md) |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="once"></a>
+
+### `Private` onDetach
+
+▸ **onDetach**(`drive`: [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)): *void*
+
+*Defined in [lib/scanner/scanner.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/scanner.ts#L41)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`drive` | [AdapterSourceDestination](../interfaces/adaptersourcedestination.md) |
+
+**Returns:** *void*
+
+___
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="start"></a>
 
 ###  start
 
-▸ **start**(): `Promise`<`void`>
+▸ **start**(): *Promise‹void›*
 
-*Defined in [scanner/scanner.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/scanner.ts#L57)*
+*Defined in [lib/scanner/scanner.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/scanner.ts#L57)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="stop"></a>
 
 ###  stop
 
-▸ **stop**(): `void`
+▸ **stop**(): *void*
 
-*Defined in [scanner/scanner.ts:74](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/scanner.ts#L74)*
+*Defined in [lib/scanner/scanner.ts:74](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/scanner.ts#L74)*
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="listenercount-1"></a>
 
-### `<Static>` listenerCount
+### `Static` listenerCount
 
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `number`
-
-___
-
+**Returns:** *number*

--- a/doc/classes/singleusestreamsource.md
+++ b/doc/classes/singleusestreamsource.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [SingleUseStreamSource](../classes/singleusestreamsource.md)
+[etcher-sdk](../README.md) › [SingleUseStreamSource](singleusestreamsource.md)
 
 # Class: SingleUseStreamSource
 
 ## Hierarchy
 
-↳  [SourceDestination](sourcedestination.md)
+  ↳ [SourceDestination](sourcedestination.md)
 
-**↳ SingleUseStreamSource**
+  ↳ **SingleUseStreamSource**
 
 ## Index
 
@@ -16,17 +16,17 @@
 
 ### Properties
 
-* [stream](singleusestreamsource.md#stream)
-* [used](singleusestreamsource.md#used)
-* [defaultMaxListeners](singleusestreamsource.md#defaultmaxlisteners)
-* [imageExtensions](singleusestreamsource.md#imageextensions)
-* [mimetype](singleusestreamsource.md#mimetype)
+* [stream](singleusestreamsource.md#private-stream)
+* [used](singleusestreamsource.md#private-used)
+* [defaultMaxListeners](singleusestreamsource.md#static-defaultmaxlisteners)
+* [imageExtensions](singleusestreamsource.md#static-imageextensions)
+* [mimetype](singleusestreamsource.md#static-optional-mimetype)
 
 ### Methods
 
-* [_close](singleusestreamsource.md#_close)
-* [_getMetadata](singleusestreamsource.md#_getmetadata)
-* [_open](singleusestreamsource.md#_open)
+* [_close](singleusestreamsource.md#protected-_close)
+* [_getMetadata](singleusestreamsource.md#protected-_getmetadata)
+* [_open](singleusestreamsource.md#protected-_open)
 * [addListener](singleusestreamsource.md#addlistener)
 * [canCreateReadStream](singleusestreamsource.md#cancreatereadstream)
 * [canCreateSparseReadStream](singleusestreamsource.md#cancreatesparsereadstream)
@@ -59,67 +59,56 @@
 * [removeListener](singleusestreamsource.md#removelistener)
 * [setMaxListeners](singleusestreamsource.md#setmaxlisteners)
 * [write](singleusestreamsource.md#write)
-* [listenerCount](singleusestreamsource.md#listenercount-1)
-* [register](singleusestreamsource.md#register)
-
----
+* [listenerCount](singleusestreamsource.md#static-listenercount)
+* [register](singleusestreamsource.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new SingleUseStreamSource**(stream: *`ReadableStream`*): [SingleUseStreamSource](singleusestreamsource.md)
+\+ **new SingleUseStreamSource**(`stream`: ReadableStream): *[SingleUseStreamSource](singleusestreamsource.md)*
 
-*Defined in [source-destination/single-use-stream-source.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/single-use-stream-source.ts#L23)*
+*Defined in [lib/source-destination/single-use-stream-source.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/single-use-stream-source.ts#L23)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| stream | `ReadableStream` |
+Name | Type |
+------ | ------ |
+`stream` | ReadableStream |
 
-**Returns:** [SingleUseStreamSource](singleusestreamsource.md)
-
-___
+**Returns:** *[SingleUseStreamSource](singleusestreamsource.md)*
 
 ## Properties
 
-<a id="stream"></a>
+### `Private` stream
 
-### `<Private>` stream
+• **stream**: *ReadableStream*
 
-**● stream**: *`ReadableStream`*
-
-*Defined in [source-destination/single-use-stream-source.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/single-use-stream-source.ts#L25)*
+*Defined in [lib/source-destination/single-use-stream-source.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/single-use-stream-source.ts#L25)*
 
 ___
-<a id="used"></a>
 
-### `<Private>` used
+### `Private` used
 
-**● used**: *`boolean`* = false
+• **used**: *boolean* = false
 
-*Defined in [source-destination/single-use-stream-source.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/single-use-stream-source.ts#L23)*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/single-use-stream-source.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/single-use-stream-source.ts#L23)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Static` defaultMaxListeners
 
-**● imageExtensions**: *`string`[]* =  [
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -132,655 +121,611 @@ ___
 		'wic',
 	]
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
-
-___
-<a id="mimetype"></a>
-
-### `<Static>``<Optional>` mimetype
-
-**● mimetype**: *`undefined` \| `string`*
-
-*Inherited from [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
-
-*Defined in [source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L244)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
+
+### `Static` `Optional` mimetype
+
+▪ **mimetype**? : *undefined | string*
+
+*Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
+
+*Defined in [lib/source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L244)*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Inherited from [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#_close)*
+*Defined in [lib/source-destination/source-destination.ts:353](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L353)*
 
-*Defined in [source-destination/source-destination.ts:353](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L353)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[_getMetadata](sourcedestination.md#_getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:287](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L287)*
+*Defined in [lib/source-destination/source-destination.ts:287](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L287)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Inherited from [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#_open)*
-
-*Defined in [source-destination/source-destination.ts:349](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L349)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Inherited from [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
+
+*Defined in [lib/source-destination/source-destination.ts:349](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L349)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/single-use-stream-source.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/single-use-stream-source.ts#L29)*
+*Defined in [lib/source-destination/single-use-stream-source.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/single-use-stream-source.ts#L29)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L268)*
+*Defined in [lib/source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L268)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseWriteStream](sourcedestination.md#cancreatesparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L276)*
+*Defined in [lib/source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L276)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateWriteStream](sourcedestination.md#cancreatewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L272)*
+*Defined in [lib/source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L272)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L256)*
+*Defined in [lib/source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L256)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canWrite](sourcedestination.md#canwrite)*
+*Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L260)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(_emitProgress?: *`boolean`*, start?: *`number`*, end?: *`undefined` \| `number`*): `Promise`<`ReadableStream`>
+▸ **createReadStream**(`_emitProgress`: boolean, `start`: number, `end?`: undefined | number): *Promise‹ReadableStream›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/single-use-stream-source.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/single-use-stream-source.ts#L33)*
+*Defined in [lib/source-destination/single-use-stream-source.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/single-use-stream-source.ts#L33)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _emitProgress | `boolean` | false |
-| `Default value` start | `number` | 0 |
-| `Optional` end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`_emitProgress` | boolean | false |
+`start` | number | 0 |
+`end?` | undefined &#124; number | - |
 
-**Returns:** `Promise`<`ReadableStream`>
+**Returns:** *Promise‹ReadableStream›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(_generateChecksums?: *`boolean`*): `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+▸ **createSparseReadStream**(`_generateChecksums`: boolean): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L317)*
+*Defined in [lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L317)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _generateChecksums | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`_generateChecksums` | boolean | false |
 
-**Returns:** `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseWriteStream](sourcedestination.md#createsparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L331)*
+*Defined in [lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L331)*
 
-**Returns:** `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+**Returns:** *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
 ___
-<a id="createverifier"></a>
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createWriteStream](sourcedestination.md#createwritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L327)*
+*Defined in [lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L327)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_sourceOffset`: number): *Promise‹ReadResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[read](sourcedestination.md#read)*
+*Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L291)*
+*Defined in [lib/source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L291)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[write](sourcedestination.md#write)*
+*Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L300)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L300)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/classes/sourcedestination.md
+++ b/doc/classes/sourcedestination.md
@@ -1,47 +1,47 @@
-[etcher-sdk](../README.md) > [SourceDestination](../classes/sourcedestination.md)
+[etcher-sdk](../README.md) › [SourceDestination](sourcedestination.md)
 
 # Class: SourceDestination
 
 ## Hierarchy
 
- `EventEmitter`
+* EventEmitter
 
-**↳ SourceDestination**
+  ↳ **SourceDestination**
 
-↳  [SourceSource](sourcesource.md)
+  ↳ [SourceSource](sourcesource.md)
 
-↳  [File](file.md)
+  ↳ [File](file.md)
 
-↳  [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)
+  ↳ [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)
 
-↳  [MultiDestination](multidestination.md)
+  ↳ [MultiDestination](multidestination.md)
 
-↳  [UsbbootDrive](usbbootdrive.md)
+  ↳ [UsbbootDrive](usbbootdrive.md)
 
-↳  [DriverlessDevice](driverlessdevice.md)
+  ↳ [DriverlessDevice](driverlessdevice.md)
 
-↳  [Http](http.md)
+  ↳ [Http](http.md)
 
-↳  [BalenaS3Source](balenas3source.md)
+  ↳ [BalenaS3Source](balenas3source.md)
 
-↳  [SingleUseStreamSource](singleusestreamsource.md)
+  ↳ [SingleUseStreamSource](singleusestreamsource.md)
 
 ## Index
 
 ### Properties
 
-* [isOpen](sourcedestination.md#isopen)
-* [metadata](sourcedestination.md#metadata)
-* [defaultMaxListeners](sourcedestination.md#defaultmaxlisteners)
-* [imageExtensions](sourcedestination.md#imageextensions)
-* [mimetype](sourcedestination.md#mimetype)
-* [mimetypes](sourcedestination.md#mimetypes)
+* [isOpen](sourcedestination.md#private-isopen)
+* [metadata](sourcedestination.md#private-metadata)
+* [defaultMaxListeners](sourcedestination.md#static-defaultmaxlisteners)
+* [imageExtensions](sourcedestination.md#static-imageextensions)
+* [mimetype](sourcedestination.md#static-optional-mimetype)
+* [mimetypes](sourcedestination.md#static-private-mimetypes)
 
 ### Methods
 
-* [_close](sourcedestination.md#_close)
-* [_getMetadata](sourcedestination.md#_getmetadata)
-* [_open](sourcedestination.md#_open)
+* [_close](sourcedestination.md#protected-_close)
+* [_getMetadata](sourcedestination.md#protected-_getmetadata)
+* [_open](sourcedestination.md#protected-_open)
 * [addListener](sourcedestination.md#addlistener)
 * [canCreateReadStream](sourcedestination.md#cancreatereadstream)
 * [canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)
@@ -59,11 +59,11 @@
 * [eventNames](sourcedestination.md#eventnames)
 * [getBlocks](sourcedestination.md#getblocks)
 * [getInnerSource](sourcedestination.md#getinnersource)
-* [getInnerSourceHelper](sourcedestination.md#getinnersourcehelper)
+* [getInnerSourceHelper](sourcedestination.md#private-getinnersourcehelper)
 * [getMaxListeners](sourcedestination.md#getmaxlisteners)
 * [getMetadata](sourcedestination.md#getmetadata)
-* [getMimeTypeFromContent](sourcedestination.md#getmimetypefromcontent)
-* [getMimeTypeFromName](sourcedestination.md#getmimetypefromname)
+* [getMimeTypeFromContent](sourcedestination.md#private-getmimetypefromcontent)
+* [getMimeTypeFromName](sourcedestination.md#private-getmimetypefromname)
 * [getPartitionTable](sourcedestination.md#getpartitiontable)
 * [listenerCount](sourcedestination.md#listenercount)
 * [listeners](sourcedestination.md#listeners)
@@ -77,47 +77,40 @@
 * [removeListener](sourcedestination.md#removelistener)
 * [setMaxListeners](sourcedestination.md#setmaxlisteners)
 * [write](sourcedestination.md#write)
-* [listenerCount](sourcedestination.md#listenercount-1)
-* [register](sourcedestination.md#register)
-
----
+* [listenerCount](sourcedestination.md#static-listenercount)
+* [register](sourcedestination.md#static-register)
 
 ## Properties
 
-<a id="isopen"></a>
+### `Private` isOpen
 
-### `<Private>` isOpen
+• **isOpen**: *boolean* = false
 
-**● isOpen**: *`boolean`* = false
-
-*Defined in [source-destination/source-destination.ts:248](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L248)*
+*Defined in [lib/source-destination/source-destination.ts:248](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L248)*
 
 ___
-<a id="metadata"></a>
 
-### `<Private>` metadata
+### `Private` metadata
 
-**● metadata**: *[Metadata](../interfaces/metadata.md)*
+• **metadata**: *[Metadata](../interfaces/metadata.md)*
 
-*Defined in [source-destination/source-destination.ts:247](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L247)*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/source-destination.ts:247](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L247)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Static` defaultMaxListeners
 
-**● imageExtensions**: *`string`[]* =  [
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -130,653 +123,605 @@ ___
 		'wic',
 	]
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
-<a id="mimetype"></a>
 
-### `<Static>``<Optional>` mimetype
+### `Static` `Optional` mimetype
 
-**● mimetype**: *`undefined` \| `string`*
+▪ **mimetype**? : *undefined | string*
 
-*Defined in [source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L244)*
-
-___
-<a id="mimetypes"></a>
-
-### `<Static>``<Private>` mimetypes
-
-**● mimetypes**: *`Map`<`string`, [SourceSource](sourcesource.md)>* =  new Map<string, typeof SourceSource>()
-
-*Defined in [source-destination/source-destination.ts:245](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L245)*
+*Defined in [lib/source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L244)*
 
 ___
+
+### `Static` `Private` mimetypes
+
+▪ **mimetypes**: *Map‹string, [SourceSource](sourcesource.md)›* = new Map<string, typeof SourceSource>()
+
+*Defined in [lib/source-destination/source-destination.ts:245](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L245)*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Defined in [lib/source-destination/source-destination.ts:353](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L353)*
 
-*Defined in [source-destination/source-destination.ts:353](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L353)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Defined in [source-destination/source-destination.ts:287](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L287)*
+*Defined in [lib/source-destination/source-destination.ts:287](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L287)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Defined in [source-destination/source-destination.ts:349](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L349)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Defined in [lib/source-destination/source-destination.ts:349](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L349)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Defined in [source-destination/source-destination.ts:264](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L264)*
+*Defined in [lib/source-destination/source-destination.ts:264](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L264)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Defined in [source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L268)*
+*Defined in [lib/source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L268)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Defined in [source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L276)*
+*Defined in [lib/source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L276)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Defined in [source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L272)*
+*Defined in [lib/source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L272)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Defined in [source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L256)*
+*Defined in [lib/source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L256)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Defined in [source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L260)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(_emitProgress?: *`boolean`*, _start?: *`number`*, _end?: *`undefined` \| `number`*): `Promise`<`ReadableStream`>
+▸ **createReadStream**(`_emitProgress`: boolean, `_start`: number, `_end?`: undefined | number): *Promise‹ReadableStream›*
 
-*Defined in [source-destination/source-destination.ts:309](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L309)*
+*Defined in [lib/source-destination/source-destination.ts:309](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L309)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _emitProgress | `boolean` | false |
-| `Default value` _start | `number` | 0 |
-| `Optional` _end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`_emitProgress` | boolean | false |
+`_start` | number | 0 |
+`_end?` | undefined &#124; number | - |
 
-**Returns:** `Promise`<`ReadableStream`>
+**Returns:** *Promise‹ReadableStream›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(_generateChecksums?: *`boolean`*): `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+▸ **createSparseReadStream**(`_generateChecksums`: boolean): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Defined in [source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L317)*
+*Defined in [lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L317)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _generateChecksums | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`_generateChecksums` | boolean | false |
 
-**Returns:** `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Defined in [source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L331)*
+*Defined in [lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L331)*
 
-**Returns:** `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+**Returns:** *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
 ___
-<a id="createverifier"></a>
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Defined in [source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L327)*
+*Defined in [lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L327)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getinnersourcehelper"></a>
 
-### `<Private>` getInnerSourceHelper
+### `Private` getInnerSourceHelper
 
-▸ **getInnerSourceHelper**(mimetype?: *`undefined` \| `string`*): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSourceHelper**(`mimetype?`: undefined | string): *Promise‹[SourceDestination](sourcedestination.md)‹››*
 
-*Defined in [source-destination/source-destination.ts:407](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L407)*
+*Defined in [lib/source-destination/source-destination.ts:407](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L407)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` mimetype | `undefined` \| `string` |
+Name | Type |
+------ | ------ |
+`mimetype?` | undefined &#124; string |
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)‹››*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="getmimetypefromcontent"></a>
-
-### `<Private>` getMimeTypeFromContent
-
-▸ **getMimeTypeFromContent**(): `Promise`<`string` \| `undefined`>
-
-*Defined in [source-destination/source-destination.ts:391](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L391)*
-
-**Returns:** `Promise`<`string` \| `undefined`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getmimetypefromname"></a>
 
-### `<Private>` getMimeTypeFromName
+### `Private` getMimeTypeFromContent
 
-▸ **getMimeTypeFromName**(): `Promise`<`string` \| `undefined`>
+▸ **getMimeTypeFromContent**(): *Promise‹string | undefined›*
 
-*Defined in [source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L380)*
+*Defined in [lib/source-destination/source-destination.ts:391](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L391)*
 
-**Returns:** `Promise`<`string` \| `undefined`>
+**Returns:** *Promise‹string | undefined›*
 
 ___
-<a id="getpartitiontable"></a>
+
+### `Private` getMimeTypeFromName
+
+▸ **getMimeTypeFromName**(): *Promise‹string | undefined›*
+
+*Defined in [lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L380)*
+
+**Returns:** *Promise‹string | undefined›*
+
+___
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_sourceOffset`: number): *Promise‹ReadResult›*
 
-*Defined in [source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L291)*
+*Defined in [lib/source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L291)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Defined in [source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L300)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L300)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
+
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/classes/sourcedestinationfs.md
+++ b/doc/classes/sourcedestinationfs.md
@@ -1,10 +1,10 @@
-[etcher-sdk](../README.md) > [SourceDestinationFs](../classes/sourcedestinationfs.md)
+[etcher-sdk](../README.md) › [SourceDestinationFs](sourcedestinationfs.md)
 
 # Class: SourceDestinationFs
 
 ## Hierarchy
 
-**SourceDestinationFs**
+* **SourceDestinationFs**
 
 ## Index
 
@@ -14,7 +14,7 @@
 
 ### Properties
 
-* [source](sourcedestinationfs.md#source)
+* [source](sourcedestinationfs.md#private-source)
 
 ### Methods
 
@@ -23,117 +23,136 @@
 * [open](sourcedestinationfs.md#open)
 * [read](sourcedestinationfs.md#read)
 
----
-
 ## Constructors
-
-<a id="constructor"></a>
 
 ###  constructor
 
-⊕ **new SourceDestinationFs**(source: *[SourceDestination](sourcedestination.md)*): [SourceDestinationFs](sourcedestinationfs.md)
+\+ **new SourceDestinationFs**(`source`: [SourceDestination](sourcedestination.md)): *[SourceDestinationFs](sourcedestinationfs.md)*
 
-*Defined in [source-destination/source-destination.ts:74](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L74)*
+*Defined in [lib/source-destination/source-destination.ts:74](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L74)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| source | [SourceDestination](sourcedestination.md) |
+Name | Type |
+------ | ------ |
+`source` | [SourceDestination](sourcedestination.md) |
 
-**Returns:** [SourceDestinationFs](sourcedestinationfs.md)
-
-___
+**Returns:** *[SourceDestinationFs](sourcedestinationfs.md)*
 
 ## Properties
 
-<a id="source"></a>
+### `Private` source
 
-### `<Private>` source
+• **source**: *[SourceDestination](sourcedestination.md)*
 
-**● source**: *[SourceDestination](sourcedestination.md)*
-
-*Defined in [source-destination/source-destination.ts:76](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L76)*
-
-___
+*Defined in [lib/source-destination/source-destination.ts:76](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L76)*
 
 ## Methods
 
-<a id="close"></a>
-
 ###  close
 
-▸ **close**(_fd: *`number`*, callback: *`function`*): `void`
+▸ **close**(`_fd`: number, `callback`: function): *void*
 
-*Defined in [source-destination/source-destination.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L86)*
+*Defined in [lib/source-destination/source-destination.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L86)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _fd | `number` |
-| callback | `function` |
+▪ **_fd**: *number*
 
-**Returns:** `void`
+▪ **callback**: *function*
+
+▸ (`error`: [Error](notcapable.md#static-error) | null): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`error` | [Error](notcapable.md#static-error) &#124; null |
+
+**Returns:** *void*
 
 ___
-<a id="fstat"></a>
 
 ###  fstat
 
-▸ **fstat**(_fd: *`number`*, callback: *`function`*): `void`
+▸ **fstat**(`_fd`: number, `callback`: function): *void*
 
-*Defined in [source-destination/source-destination.ts:90](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L90)*
+*Defined in [lib/source-destination/source-destination.ts:90](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L90)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _fd | `number` |
-| callback | `function` |
+▪ **_fd**: *number*
 
-**Returns:** `void`
+▪ **callback**: *function*
+
+▸ (`error`: [Error](notcapable.md#static-error) | null, `stats?`: undefined | object): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`error` | [Error](notcapable.md#static-error) &#124; null |
+`stats?` | undefined &#124; object |
+
+**Returns:** *void*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(_path: *`string`*, _options: *`any`*, callback: *`function`*): `void`
+▸ **open**(`_path`: string, `_options`: any, `callback`: function): *void*
 
-*Defined in [source-destination/source-destination.ts:78](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L78)*
+*Defined in [lib/source-destination/source-destination.ts:78](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L78)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _path | `string` |
-| _options | `any` |
-| callback | `function` |
+▪ **_path**: *string*
 
-**Returns:** `void`
+▪ **_options**: *any*
+
+▪ **callback**: *function*
+
+▸ (`error`: [Error](notcapable.md#static-error) | null, `fd?`: undefined | number): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`error` | [Error](notcapable.md#static-error) &#124; null |
+`fd?` | undefined &#124; number |
+
+**Returns:** *void*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(_fd: *`number`*, buffer: *`Buffer`*, bufferOffset: *`number`*, length: *`number`*, sourceOffset: *`number`*, callback: *`function`*): `void`
+▸ **read**(`_fd`: number, `buffer`: Buffer, `bufferOffset`: number, `length`: number, `sourceOffset`: number, `callback`: function): *void*
 
-*Defined in [source-destination/source-destination.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L106)*
+*Defined in [lib/source-destination/source-destination.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L106)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _fd | `number` |
-| buffer | `Buffer` |
-| bufferOffset | `number` |
-| length | `number` |
-| sourceOffset | `number` |
-| callback | `function` |
+▪ **_fd**: *number*
 
-**Returns:** `void`
+▪ **buffer**: *Buffer*
 
-___
+▪ **bufferOffset**: *number*
 
+▪ **length**: *number*
+
+▪ **sourceOffset**: *number*
+
+▪ **callback**: *function*
+
+▸ (`error`: [Error](notcapable.md#static-error) | null, `bytesRead?`: undefined | number, `buffer?`: Buffer): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`error` | [Error](notcapable.md#static-error) &#124; null |
+`bytesRead?` | undefined &#124; number |
+`buffer?` | Buffer |
+
+**Returns:** *void*

--- a/doc/classes/sourcedisk.md
+++ b/doc/classes/sourcedisk.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [SourceDisk](../classes/sourcedisk.md)
+[etcher-sdk](../README.md) › [SourceDisk](sourcedisk.md)
 
 # Class: SourceDisk
 
 ## Hierarchy
 
- `Disk`
+* Disk
 
-**↳ SourceDisk**
+  ↳ **SourceDisk**
 
 ## Index
 
@@ -22,14 +22,14 @@
 * [readOnly](sourcedisk.md#readonly)
 * [recordReads](sourcedisk.md#recordreads)
 * [recordWrites](sourcedisk.md#recordwrites)
-* [source](sourcedisk.md#source)
+* [source](sourcedisk.md#private-source)
 
 ### Methods
 
-* [_flush](sourcedisk.md#_flush)
-* [_getCapacity](sourcedisk.md#_getcapacity)
-* [_read](sourcedisk.md#_read)
-* [_write](sourcedisk.md#_write)
+* [_flush](sourcedisk.md#protected-_flush)
+* [_getCapacity](sourcedisk.md#protected-_getcapacity)
+* [_read](sourcedisk.md#protected-_read)
+* [_write](sourcedisk.md#protected-_write)
 * [discard](sourcedisk.md#discard)
 * [flush](sourcedisk.md#flush)
 * [getCapacity](sourcedisk.md#getcapacity)
@@ -40,334 +40,301 @@
 * [read](sourcedisk.md#read)
 * [write](sourcedisk.md#write)
 
----
-
 ## Constructors
-
-<a id="constructor"></a>
 
 ###  constructor
 
-⊕ **new SourceDisk**(source: *[SourceDestination](sourcedestination.md)*): [SourceDisk](sourcedisk.md)
+\+ **new SourceDisk**(`source`: [SourceDestination](sourcedestination.md)): *[SourceDisk](sourcedisk.md)*
 
-*Overrides Disk.__constructor*
+*Overrides void*
 
-*Defined in [source-destination/configured-source/configured-source.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L43)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L43)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| source | [SourceDestination](sourcedestination.md) |
+Name | Type |
+------ | ------ |
+`source` | [SourceDestination](sourcedestination.md) |
 
-**Returns:** [SourceDisk](sourcedisk.md)
-
-___
+**Returns:** *[SourceDisk](sourcedisk.md)*
 
 ## Properties
 
-<a id="capacity"></a>
-
 ###  capacity
 
-**● capacity**: *`number` \| `null`*
+• **capacity**: *number | null*
 
-*Inherited from Disk.capacity*
+*Inherited from [SourceDisk](sourcedisk.md).[capacity](sourcedisk.md#capacity)*
 
-*Defined in /node_modules/file-disk/build/index.d.ts:26*
+Defined in node_modules/file-disk/build/index.d.ts:26
 
 ___
-<a id="discardiszero"></a>
 
 ###  discardIsZero
 
-**● discardIsZero**: *`boolean`*
+• **discardIsZero**: *boolean*
 
-*Inherited from Disk.discardIsZero*
+*Inherited from [SourceDisk](sourcedisk.md).[discardIsZero](sourcedisk.md#discardiszero)*
 
-*Defined in /node_modules/file-disk/build/index.d.ts:24*
+Defined in node_modules/file-disk/build/index.d.ts:24
 
 ___
-<a id="knownchunks"></a>
 
 ###  knownChunks
 
-**● knownChunks**: *`DiskChunk`[]*
+• **knownChunks**: *DiskChunk[]*
 
-*Inherited from Disk.knownChunks*
+*Inherited from [SourceDisk](sourcedisk.md).[knownChunks](sourcedisk.md#knownchunks)*
 
-*Defined in /node_modules/file-disk/build/index.d.ts:25*
+Defined in node_modules/file-disk/build/index.d.ts:25
 
 ___
-<a id="readonly"></a>
 
 ###  readOnly
 
-**● readOnly**: *`boolean`*
+• **readOnly**: *boolean*
 
-*Inherited from Disk.readOnly*
+*Inherited from [SourceDisk](sourcedisk.md).[readOnly](sourcedisk.md#readonly)*
 
-*Defined in /node_modules/file-disk/build/index.d.ts:21*
+Defined in node_modules/file-disk/build/index.d.ts:21
 
 ___
-<a id="recordreads"></a>
 
 ###  recordReads
 
-**● recordReads**: *`boolean`*
+• **recordReads**: *boolean*
 
-*Inherited from Disk.recordReads*
+*Inherited from [SourceDisk](sourcedisk.md).[recordReads](sourcedisk.md#recordreads)*
 
-*Defined in /node_modules/file-disk/build/index.d.ts:23*
+Defined in node_modules/file-disk/build/index.d.ts:23
 
 ___
-<a id="recordwrites"></a>
 
 ###  recordWrites
 
-**● recordWrites**: *`boolean`*
+• **recordWrites**: *boolean*
 
-*Inherited from Disk.recordWrites*
+*Inherited from [SourceDisk](sourcedisk.md).[recordWrites](sourcedisk.md#recordwrites)*
 
-*Defined in /node_modules/file-disk/build/index.d.ts:22*
-
-___
-<a id="source"></a>
-
-### `<Private>` source
-
-**● source**: *[SourceDestination](sourcedestination.md)*
-
-*Defined in [source-destination/configured-source/configured-source.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L44)*
+Defined in node_modules/file-disk/build/index.d.ts:22
 
 ___
+
+### `Private` source
+
+• **source**: *[SourceDestination](sourcedestination.md)*
+
+*Defined in [lib/source-destination/configured-source/configured-source.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L44)*
 
 ## Methods
 
-<a id="_flush"></a>
+### `Protected` _flush
 
-### `<Protected>` _flush
+▸ **_flush**(): *Promise‹void›*
 
-▸ **_flush**(): `Promise`<`void`>
+*Overrides void*
 
-*Overrides Disk._flush*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L80)*
 
-*Defined in [source-destination/configured-source/configured-source.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L80)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getcapacity"></a>
 
-### `<Protected>` _getCapacity
+### `Protected` _getCapacity
 
-▸ **_getCapacity**(): `Promise`<`number`>
+▸ **_getCapacity**(): *Promise‹number›*
 
-*Overrides Disk._getCapacity*
+*Overrides void*
 
-*Defined in [source-destination/configured-source/configured-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L53)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L53)*
 
-**Returns:** `Promise`<`number`>
+**Returns:** *Promise‹number›*
 
 ___
-<a id="_read"></a>
 
-### `<Protected>` _read
+### `Protected` _read
 
-▸ **_read**(buffer: *`Buffer`*, bufferOffset: *`number`*, length: *`number`*, fileOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **_read**(`buffer`: Buffer, `bufferOffset`: number, `length`: number, `fileOffset`: number): *Promise‹ReadResult›*
 
-*Overrides Disk._read*
+*Overrides void*
 
-*Defined in [source-destination/configured-source/configured-source.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L62)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L62)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| bufferOffset | `number` |
-| length | `number` |
-| fileOffset | `number` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
+`bufferOffset` | number |
+`length` | number |
+`fileOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="_write"></a>
 
-### `<Protected>` _write
+### `Protected` _write
 
-▸ **_write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **_write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Overrides Disk._write*
+*Overrides void*
 
-*Defined in [source-destination/configured-source/configured-source.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configured-source.ts#L71)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configured-source.ts#L71)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `Promise`<`WriteResult`>
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="discard"></a>
 
 ###  discard
 
-▸ **discard**(offset: *`number`*, length: *`number`*): `Promise`<`void`>
+▸ **discard**(`offset`: number, `length`: number): *Promise‹void›*
 
-*Inherited from Disk.discard*
+*Inherited from [SourceDisk](sourcedisk.md).[discard](sourcedisk.md#discard)*
 
-*Defined in /node_modules/file-disk/build/index.d.ts:36*
+Defined in node_modules/file-disk/build/index.d.ts:36
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| offset | `number` |
-| length | `number` |
+Name | Type |
+------ | ------ |
+`offset` | number |
+`length` | number |
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="flush"></a>
 
 ###  flush
 
-▸ **flush**(): `Promise`<`void`>
+▸ **flush**(): *Promise‹void›*
 
-*Inherited from Disk.flush*
+*Inherited from [SourceDisk](sourcedisk.md).[flush](sourcedisk.md#flush)*
 
-*Defined in /node_modules/file-disk/build/index.d.ts:35*
+Defined in node_modules/file-disk/build/index.d.ts:35
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="getcapacity"></a>
 
 ###  getCapacity
 
-▸ **getCapacity**(): `Promise`<`number`>
+▸ **getCapacity**(): *Promise‹number›*
 
-*Inherited from Disk.getCapacity*
+*Inherited from [SourceDisk](sourcedisk.md).[getCapacity](sourcedisk.md#getcapacity)*
 
-*Defined in /node_modules/file-disk/build/index.d.ts:37*
+Defined in node_modules/file-disk/build/index.d.ts:37
 
-**Returns:** `Promise`<`number`>
+**Returns:** *Promise‹number›*
 
 ___
-<a id="getdiscardedchunks"></a>
 
 ###  getDiscardedChunks
 
-▸ **getDiscardedChunks**(): `DiskChunk`[]
+▸ **getDiscardedChunks**(): *DiskChunk[]*
 
-*Inherited from Disk.getDiscardedChunks*
+*Inherited from [SourceDisk](sourcedisk.md).[getDiscardedChunks](sourcedisk.md#getdiscardedchunks)*
 
-*Defined in /node_modules/file-disk/build/index.d.ts:39*
+Defined in node_modules/file-disk/build/index.d.ts:39
 
-**Returns:** `DiskChunk`[]
+**Returns:** *DiskChunk[]*
 
 ___
-<a id="getranges"></a>
 
 ###  getRanges
 
-▸ **getRanges**(blockSize: *`number`*): `Promise`<`Range`[]>
+▸ **getRanges**(`blockSize`: number): *Promise‹Range[]›*
 
-*Inherited from Disk.getRanges*
+*Inherited from [SourceDisk](sourcedisk.md).[getRanges](sourcedisk.md#getranges)*
 
-*Defined in /node_modules/file-disk/build/index.d.ts:40*
+Defined in node_modules/file-disk/build/index.d.ts:40
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| blockSize | `number` |
+Name | Type |
+------ | ------ |
+`blockSize` | number |
 
-**Returns:** `Promise`<`Range`[]>
+**Returns:** *Promise‹Range[]›*
 
 ___
-<a id="getstream"></a>
 
 ###  getStream
 
-▸ **getStream**(position?: *`undefined` \| `number`*, length?: *`number` \| `null`*, highWaterMark?: *`undefined` \| `number`*): `Promise`<`DiskStream`>
+▸ **getStream**(`position?`: undefined | number, `length?`: number | null, `highWaterMark?`: undefined | number): *Promise‹DiskStream›*
 
-*Inherited from Disk.getStream*
+*Inherited from [SourceDisk](sourcedisk.md).[getStream](sourcedisk.md#getstream)*
 
-*Defined in /node_modules/file-disk/build/index.d.ts:38*
+Defined in node_modules/file-disk/build/index.d.ts:38
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` position | `undefined` \| `number` |
-| `Optional` length | `number` \| `null` |
-| `Optional` highWaterMark | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`position?` | undefined &#124; number |
+`length?` | number &#124; null |
+`highWaterMark?` | undefined &#124; number |
 
-**Returns:** `Promise`<`DiskStream`>
+**Returns:** *Promise‹DiskStream›*
 
 ___
-<a id="gettransformstream"></a>
 
 ###  getTransformStream
 
-▸ **getTransformStream**(): `Transform`
+▸ **getTransformStream**(): *Transform*
 
-*Inherited from Disk.getTransformStream*
+*Inherited from [SourceDisk](sourcedisk.md).[getTransformStream](sourcedisk.md#gettransformstream)*
 
-*Defined in /node_modules/file-disk/build/index.d.ts:32*
+Defined in node_modules/file-disk/build/index.d.ts:32
 
-**Returns:** `Transform`
+**Returns:** *Transform*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(buffer: *`Buffer`*, _bufferOffset: *`number`*, length: *`number`*, fileOffset: *`number`*): `Promise`<`fs.ReadResult`>
+▸ **read**(`buffer`: Buffer, `_bufferOffset`: number, `length`: number, `fileOffset`: number): *Promise‹ReadResult›*
 
-*Inherited from Disk.read*
+*Inherited from [SourceDisk](sourcedisk.md).[read](sourcedisk.md#read)*
 
-*Defined in /node_modules/file-disk/build/index.d.ts:33*
+Defined in node_modules/file-disk/build/index.d.ts:33
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| _bufferOffset | `number` |
-| length | `number` |
-| fileOffset | `number` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
+`_bufferOffset` | number |
+`length` | number |
+`fileOffset` | number |
 
-**Returns:** `Promise`<`fs.ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(buffer: *`Buffer`*, bufferOffset: *`number`*, length: *`number`*, fileOffset: *`number`*): `Promise`<`fs.WriteResult`>
+▸ **write**(`buffer`: Buffer, `bufferOffset`: number, `length`: number, `fileOffset`: number): *Promise‹WriteResult›*
 
-*Inherited from Disk.write*
+*Inherited from [SourceDisk](sourcedisk.md).[write](sourcedisk.md#write)*
 
-*Defined in /node_modules/file-disk/build/index.d.ts:34*
+Defined in node_modules/file-disk/build/index.d.ts:34
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| bufferOffset | `number` |
-| length | `number` |
-| fileOffset | `number` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
+`bufferOffset` | number |
+`length` | number |
+`fileOffset` | number |
 
-**Returns:** `Promise`<`fs.WriteResult`>
-
-___
-
+**Returns:** *Promise‹WriteResult›*

--- a/doc/classes/sourcerandomaccessreader.md
+++ b/doc/classes/sourcerandomaccessreader.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [SourceRandomAccessReader](../classes/sourcerandomaccessreader.md)
+[etcher-sdk](../README.md) › [SourceRandomAccessReader](sourcerandomaccessreader.md)
 
 # Class: SourceRandomAccessReader
 
 ## Hierarchy
 
- `RandomAccessReader`
+* RandomAccessReader
 
-**↳ SourceRandomAccessReader**
+  ↳ **SourceRandomAccessReader**
 
 ## Index
 
@@ -16,8 +16,8 @@
 
 ### Properties
 
-* [source](sourcerandomaccessreader.md#source)
-* [defaultMaxListeners](sourcerandomaccessreader.md#defaultmaxlisteners)
+* [source](sourcerandomaccessreader.md#private-source)
+* [defaultMaxListeners](sourcerandomaccessreader.md#static-defaultmaxlisteners)
 
 ### Methods
 
@@ -38,425 +38,408 @@
 * [removeAllListeners](sourcerandomaccessreader.md#removealllisteners)
 * [removeListener](sourcerandomaccessreader.md#removelistener)
 * [setMaxListeners](sourcerandomaccessreader.md#setmaxlisteners)
-* [listenerCount](sourcerandomaccessreader.md#listenercount-1)
-
----
+* [listenerCount](sourcerandomaccessreader.md#static-listenercount)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new SourceRandomAccessReader**(source: *[SourceDestination](sourcedestination.md)*): [SourceRandomAccessReader](sourcerandomaccessreader.md)
+\+ **new SourceRandomAccessReader**(`source`: [SourceDestination](sourcedestination.md)): *[SourceRandomAccessReader](sourcerandomaccessreader.md)*
 
-*Defined in [source-destination/zip.ts:128](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L128)*
+*Defined in [lib/source-destination/zip.ts:128](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L128)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| source | [SourceDestination](sourcedestination.md) |
+Name | Type |
+------ | ------ |
+`source` | [SourceDestination](sourcedestination.md) |
 
-**Returns:** [SourceRandomAccessReader](sourcerandomaccessreader.md)
-
-___
+**Returns:** *[SourceRandomAccessReader](sourcerandomaccessreader.md)*
 
 ## Properties
 
-<a id="source"></a>
+### `Private` source
 
-### `<Private>` source
+• **source**: *[SourceDestination](sourcedestination.md)*
 
-**● source**: *[SourceDestination](sourcedestination.md)*
-
-*Defined in [source-destination/zip.ts:129](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L129)*
+*Defined in [lib/source-destination/zip.ts:129](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L129)*
 
 ___
-<a id="defaultmaxlisteners"></a>
 
-### `<Static>` defaultMaxListeners
+### `Static` defaultMaxListeners
 
-**● defaultMaxListeners**: *`number`*
+▪ **defaultMaxListeners**: *number*
 
-*Inherited from EventEmitter.defaultMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:681*
-
-___
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="_readstreamforrange"></a>
-
 ###  _readStreamForRange
 
-▸ **_readStreamForRange**(start: *`number`*, end: *`number`*): `PassThrough`
+▸ **_readStreamForRange**(`start`: number, `end`: number): *PassThrough‹›*
 
-*Overrides RandomAccessReader._readStreamForRange*
+*Overrides void*
 
-*Defined in [source-destination/zip.ts:133](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L133)*
+*Defined in [lib/source-destination/zip.ts:133](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L133)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| start | `number` |
-| end | `number` |
+Name | Type |
+------ | ------ |
+`start` | number |
+`end` | number |
 
-**Returns:** `PassThrough`
+**Returns:** *PassThrough‹›*
 
 ___
-<a id="addlistener"></a>
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(callback: *`function`*): `void`
+▸ **close**(`callback`: function): *void*
 
-*Inherited from RandomAccessReader.close*
+*Inherited from [SourceRandomAccessReader](sourcerandomaccessreader.md).[close](sourcerandomaccessreader.md#close)*
 
-*Defined in /node_modules/@types/yauzl/index.d.ts:15*
+Defined in node_modules/@types/yauzl/index.d.ts:15
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| callback | `function` |
+▪ **callback**: *function*
 
-**Returns:** `void`
+▸ (`err?`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err?` | [Error](notcapable.md#static-error) |
+
+**Returns:** *void*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(options: *`object`*): `void`
+▸ **createReadStream**(`options`: object): *void*
 
-*Inherited from RandomAccessReader.createReadStream*
+*Inherited from [SourceRandomAccessReader](sourcerandomaccessreader.md).[createReadStream](sourcerandomaccessreader.md#createreadstream)*
 
-*Defined in /node_modules/@types/yauzl/index.d.ts:13*
+Defined in node_modules/@types/yauzl/index.d.ts:13
 
 **Parameters:**
 
-**options: `object`**
+▪ **options**: *object*
 
-| Name | Type |
-| ------ | ------ |
-| end | `number` |
-| start | `number` |
+Name | Type |
+------ | ------ |
+`end` | number |
+`start` | number |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(buffer: *`Buffer`*, offset: *`number`*, length: *`number`*, position: *`number`*, callback: *`function`*): `void`
+▸ **read**(`buffer`: Buffer, `offset`: number, `length`: number, `position`: number, `callback`: function): *void*
 
-*Inherited from RandomAccessReader.read*
+*Inherited from [SourceRandomAccessReader](sourcerandomaccessreader.md).[read](sourcerandomaccessreader.md#read)*
 
-*Defined in /node_modules/@types/yauzl/index.d.ts:14*
+Defined in node_modules/@types/yauzl/index.d.ts:14
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| offset | `number` |
-| length | `number` |
-| position | `number` |
-| callback | `function` |
+▪ **buffer**: *Buffer*
 
-**Returns:** `void`
+▪ **offset**: *number*
+
+▪ **length**: *number*
+
+▪ **position**: *number*
+
+▪ **callback**: *function*
+
+▸ (`err?`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err?` | [Error](notcapable.md#static-error) |
+
+**Returns:** *void*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
-
-**Returns:** `this`
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `number`
+**Returns:** *this*
 
 ___
 
+### `Static` listenerCount
+
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
+
+Defined in node_modules/@types/node/base.d.ts:680
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
+
+**Returns:** *number*

--- a/doc/classes/sourcesource.md
+++ b/doc/classes/sourcesource.md
@@ -1,24 +1,24 @@
-[etcher-sdk](../README.md) > [SourceSource](../classes/sourcesource.md)
+[etcher-sdk](../README.md) › [SourceSource](sourcesource.md)
 
 # Class: SourceSource
 
 ## Hierarchy
 
-↳  [SourceDestination](sourcedestination.md)
+  ↳ [SourceDestination](sourcedestination.md)
 
-**↳ SourceSource**
+  ↳ **SourceSource**
 
-↳  [CompressedSource](compressedsource.md)
+  ↳ [CompressedSource](compressedsource.md)
 
-↳  [ConfiguredSource](configuredsource.md)
+  ↳ [ConfiguredSource](configuredsource.md)
 
-↳  [DmgSource](dmgsource.md)
+  ↳ [DmgSource](dmgsource.md)
 
-↳  [StreamZipSource](streamzipsource.md)
+  ↳ [StreamZipSource](streamzipsource.md)
 
-↳  [RandomAccessZipSource](randomaccesszipsource.md)
+  ↳ [RandomAccessZipSource](randomaccesszipsource.md)
 
-↳  [ZipSource](zipsource.md)
+  ↳ [ZipSource](zipsource.md)
 
 ## Index
 
@@ -28,17 +28,17 @@
 
 ### Properties
 
-* [source](sourcesource.md#source)
-* [defaultMaxListeners](sourcesource.md#defaultmaxlisteners)
-* [imageExtensions](sourcesource.md#imageextensions)
-* [mimetype](sourcesource.md#mimetype)
-* [requiresRandomReadableSource](sourcesource.md#requiresrandomreadablesource)
+* [source](sourcesource.md#protected-source)
+* [defaultMaxListeners](sourcesource.md#static-defaultmaxlisteners)
+* [imageExtensions](sourcesource.md#static-imageextensions)
+* [mimetype](sourcesource.md#static-optional-mimetype)
+* [requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)
 
 ### Methods
 
-* [_close](sourcesource.md#_close)
-* [_getMetadata](sourcesource.md#_getmetadata)
-* [_open](sourcesource.md#_open)
+* [_close](sourcesource.md#protected-_close)
+* [_getMetadata](sourcesource.md#protected-_getmetadata)
+* [_open](sourcesource.md#protected-_open)
 * [addListener](sourcesource.md#addlistener)
 * [canCreateReadStream](sourcesource.md#cancreatereadstream)
 * [canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)
@@ -71,58 +71,48 @@
 * [removeListener](sourcesource.md#removelistener)
 * [setMaxListeners](sourcesource.md#setmaxlisteners)
 * [write](sourcesource.md#write)
-* [listenerCount](sourcesource.md#listenercount-1)
-* [register](sourcesource.md#register)
-
----
+* [listenerCount](sourcesource.md#static-listenercount)
+* [register](sourcesource.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new SourceSource**(source: *[SourceDestination](sourcedestination.md)*): [SourceSource](sourcesource.md)
+\+ **new SourceSource**(`source`: [SourceDestination](sourcedestination.md)): *[SourceSource](sourcesource.md)*
 
-*Defined in [source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L20)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| source | [SourceDestination](sourcedestination.md) |
+Name | Type |
+------ | ------ |
+`source` | [SourceDestination](sourcedestination.md) |
 
-**Returns:** [SourceSource](sourcesource.md)
-
-___
+**Returns:** *[SourceSource](sourcesource.md)*
 
 ## Properties
 
-<a id="source"></a>
+### `Protected` source
 
-### `<Protected>` source
+• **source**: *[SourceDestination](sourcedestination.md)*
 
-**● source**: *[SourceDestination](sourcedestination.md)*
-
-*Defined in [source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L22)*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L22)*
 
 ___
-<a id="defaultmaxlisteners"></a>
 
-### `<Static>` defaultMaxListeners
+### `Static` defaultMaxListeners
 
-**● defaultMaxListeners**: *`number`*
+▪ **defaultMaxListeners**: *number*
 
-*Inherited from EventEmitter.defaultMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:681*
+Defined in node_modules/@types/node/base.d.ts:681
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Static` imageExtensions
 
-**● imageExtensions**: *`string`[]* =  [
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -135,664 +125,619 @@ ___
 		'wic',
 	]
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
-
-___
-<a id="mimetype"></a>
-
-### `<Static>``<Optional>` mimetype
-
-**● mimetype**: *`undefined` \| `string`*
-
-*Inherited from [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
-
-*Defined in [source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L244)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
-<a id="requiresrandomreadablesource"></a>
 
-### `<Static>` requiresRandomReadableSource
+### `Static` `Optional` mimetype
 
-**● requiresRandomReadableSource**: *`boolean`* = false
+▪ **mimetype**? : *undefined | string*
 
-*Defined in [source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L20)*
+*Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
+
+*Defined in [lib/source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L244)*
 
 ___
+
+### `Static` requiresRandomReadableSource
+
+▪ **requiresRandomReadableSource**: *boolean* = false
+
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L20)*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#_close)*
+*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L30)*
 
-*Defined in [source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L30)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[_getMetadata](sourcedestination.md#_getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:287](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L287)*
+*Defined in [lib/source-destination/source-destination.ts:287](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L287)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#_open)*
-
-*Defined in [source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L26)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
+
+*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L26)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/source-destination.ts:264](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L264)*
+*Defined in [lib/source-destination/source-destination.ts:264](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L264)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L268)*
+*Defined in [lib/source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L268)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseWriteStream](sourcedestination.md#cancreatesparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L276)*
+*Defined in [lib/source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L276)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateWriteStream](sourcedestination.md#cancreatewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L272)*
+*Defined in [lib/source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L272)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L256)*
+*Defined in [lib/source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L256)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canWrite](sourcedestination.md#canwrite)*
+*Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L260)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(_emitProgress?: *`boolean`*, _start?: *`number`*, _end?: *`undefined` \| `number`*): `Promise`<`ReadableStream`>
+▸ **createReadStream**(`_emitProgress`: boolean, `_start`: number, `_end?`: undefined | number): *Promise‹ReadableStream›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Inherited from [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/source-destination.ts:309](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L309)*
+*Defined in [lib/source-destination/source-destination.ts:309](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L309)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _emitProgress | `boolean` | false |
-| `Default value` _start | `number` | 0 |
-| `Optional` _end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`_emitProgress` | boolean | false |
+`_start` | number | 0 |
+`_end?` | undefined &#124; number | - |
 
-**Returns:** `Promise`<`ReadableStream`>
+**Returns:** *Promise‹ReadableStream›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(_generateChecksums?: *`boolean`*): `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+▸ **createSparseReadStream**(`_generateChecksums`: boolean): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L317)*
+*Defined in [lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L317)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _generateChecksums | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`_generateChecksums` | boolean | false |
 
-**Returns:** `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseWriteStream](sourcedestination.md#createsparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L331)*
+*Defined in [lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L331)*
 
-**Returns:** `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+**Returns:** *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
 ___
-<a id="createverifier"></a>
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createWriteStream](sourcedestination.md#createwritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L327)*
+*Defined in [lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L327)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_sourceOffset`: number): *Promise‹ReadResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[read](sourcedestination.md#read)*
+*Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L291)*
+*Defined in [lib/source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L291)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[write](sourcedestination.md#write)*
+*Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L300)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L300)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/classes/sparsefilterstream.md
+++ b/doc/classes/sparsefilterstream.md
@@ -1,17 +1,17 @@
-[etcher-sdk](../README.md) > [SparseFilterStream](../classes/sparsefilterstream.md)
+[etcher-sdk](../README.md) › [SparseFilterStream](sparsefilterstream.md)
 
 # Class: SparseFilterStream
 
 ## Hierarchy
 
- `Transform`
+* Transform
 
-**↳ SparseFilterStream**
+  ↳ **SparseFilterStream**
 
 ## Implements
 
-* `ReadableStream`
-* `Writable`
+* ReadableStream
+* Writable
 * [SparseReadable](../interfaces/sparsereadable.md)
 
 ## Index
@@ -23,16 +23,16 @@
 ### Properties
 
 * [blocks](sparsefilterstream.md#blocks)
-* [position](sparsefilterstream.md#position)
+* [position](sparsefilterstream.md#private-position)
 * [readable](sparsefilterstream.md#readable)
-* [state](sparsefilterstream.md#state)
-* [stateIterator](sparsefilterstream.md#stateiterator)
+* [state](sparsefilterstream.md#private-optional-state)
+* [stateIterator](sparsefilterstream.md#private-stateiterator)
 * [writable](sparsefilterstream.md#writable)
-* [defaultMaxListeners](sparsefilterstream.md#defaultmaxlisteners)
+* [defaultMaxListeners](sparsefilterstream.md#static-defaultmaxlisteners)
 
 ### Methods
 
-* [__transform](sparsefilterstream.md#__transform)
+* [__transform](sparsefilterstream.md#private-__transform)
 * [_read](sparsefilterstream.md#_read)
 * [_transform](sparsefilterstream.md#_transform)
 * [_write](sparsefilterstream.md#_write)
@@ -44,7 +44,7 @@
 * [isPaused](sparsefilterstream.md#ispaused)
 * [listenerCount](sparsefilterstream.md#listenercount)
 * [listeners](sparsefilterstream.md#listeners)
-* [nextBlock](sparsefilterstream.md#nextblock)
+* [nextBlock](sparsefilterstream.md#private-nextblock)
 * [on](sparsefilterstream.md#on)
 * [once](sparsefilterstream.md#once)
 * [pause](sparsefilterstream.md#pause)
@@ -63,1401 +63,1449 @@
 * [unshift](sparsefilterstream.md#unshift)
 * [wrap](sparsefilterstream.md#wrap)
 * [write](sparsefilterstream.md#write)
-* [listenerCount](sparsefilterstream.md#listenercount-1)
-
----
+* [listenerCount](sparsefilterstream.md#static-listenercount)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new SparseFilterStream**(blocks: *[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, verify: *`boolean`*, generateChecksums: *`boolean`*, options?: *`TransformOptions`*): [SparseFilterStream](sparsefilterstream.md)
+\+ **new SparseFilterStream**(`blocks`: [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `verify`: boolean, `generateChecksums`: boolean, `options`: TransformOptions): *[SparseFilterStream](sparsefilterstream.md)*
 
-*Overrides Transform.__constructor*
+*Overrides [SourceTransform](../interfaces/sourcetransform.md).[constructor](../interfaces/sourcetransform.md#constructor)*
 
-*Defined in [sparse-stream/sparse-filter-stream.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-filter-stream.ts#L30)*
+*Defined in [lib/sparse-stream/sparse-filter-stream.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-filter-stream.ts#L30)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| blocks | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] | - |
-| verify | `boolean` | - |
-| generateChecksums | `boolean` | - |
-| `Default value` options | `TransformOptions` |  {} |
+Name | Type | Default |
+------ | ------ | ------ |
+`blocks` | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] | - |
+`verify` | boolean | - |
+`generateChecksums` | boolean | - |
+`options` | TransformOptions | {} |
 
-**Returns:** [SparseFilterStream](sparsefilterstream.md)
-
-___
+**Returns:** *[SparseFilterStream](sparsefilterstream.md)*
 
 ## Properties
 
-<a id="blocks"></a>
-
 ###  blocks
 
-**● blocks**: *[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*
+• **blocks**: *[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*
 
 *Implementation of [SparseReadable](../interfaces/sparsereadable.md).[blocks](../interfaces/sparsereadable.md#blocks)*
 
-*Defined in [sparse-stream/sparse-filter-stream.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-filter-stream.ts#L33)*
+*Defined in [lib/sparse-stream/sparse-filter-stream.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-filter-stream.ts#L33)*
 
 ___
-<a id="position"></a>
 
-### `<Private>` position
+### `Private` position
 
-**● position**: *`number`* = 0
+• **position**: *number* = 0
 
-*Defined in [sparse-stream/sparse-filter-stream.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-filter-stream.ts#L30)*
+*Defined in [lib/sparse-stream/sparse-filter-stream.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-filter-stream.ts#L30)*
 
 ___
-<a id="readable"></a>
 
 ###  readable
 
-**● readable**: *`boolean`*
+• **readable**: *boolean*
 
 *Implementation of [SparseReadable](../interfaces/sparsereadable.md).[readable](../interfaces/sparsereadable.md#readable)*
 
-*Inherited from Readable.readable*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[readable](sparsefilterstream.md#readable)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3688*
-
-___
-<a id="state"></a>
-
-### `<Private>``<Optional>` state
-
-**● state**: *[SparseReaderState](../interfaces/sparsereaderstate.md)*
-
-*Defined in [sparse-stream/sparse-filter-stream.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-filter-stream.ts#L29)*
+Defined in node_modules/@types/node/base.d.ts:3688
 
 ___
-<a id="stateiterator"></a>
 
-### `<Private>` stateIterator
+### `Private` `Optional` state
 
-**● stateIterator**: *`Iterator`<[SparseReaderState](../interfaces/sparsereaderstate.md)>*
+• **state**? : *[SparseReaderState](../interfaces/sparsereaderstate.md)*
 
-*Defined in [sparse-stream/sparse-filter-stream.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-filter-stream.ts#L28)*
+*Defined in [lib/sparse-stream/sparse-filter-stream.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-filter-stream.ts#L29)*
 
 ___
-<a id="writable"></a>
+
+### `Private` stateIterator
+
+• **stateIterator**: *Iterator‹[SparseReaderState](../interfaces/sparsereaderstate.md)›*
+
+*Defined in [lib/sparse-stream/sparse-filter-stream.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-filter-stream.ts#L28)*
+
+___
 
 ###  writable
 
-**● writable**: *`boolean`*
+• **writable**: *boolean*
 
-*Inherited from Duplex.writable*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[writable](sparsefilterstream.md#writable)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3855*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+Defined in node_modules/@types/node/base.d.ts:3855
 
 ___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="__transform"></a>
+### `Private` __transform
 
-### `<Private>` __transform
+▸ **__transform**(`buffer`: Buffer): *void*
 
-▸ **__transform**(buffer: *`Buffer`*): `void`
-
-*Defined in [sparse-stream/sparse-filter-stream.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-filter-stream.ts#L65)*
+*Defined in [lib/sparse-stream/sparse-filter-stream.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-filter-stream.ts#L65)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="_read"></a>
 
 ###  _read
 
-▸ **_read**(size: *`number`*): `void`
+▸ **_read**(`size`: number): *void*
 
-*Inherited from Readable._read*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[_read](sparsefilterstream.md#_read)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3690*
+Defined in node_modules/@types/node/base.d.ts:3690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| size | `number` |
+Name | Type |
+------ | ------ |
+`size` | number |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="_transform"></a>
 
 ###  _transform
 
-▸ **_transform**(chunk: *`Buffer`*, _encoding: *`string`*, callback: *`function`*): `void`
+▸ **_transform**(`chunk`: Buffer, `_encoding`: string, `callback`: function): *void*
 
-*Overrides Transform._transform*
+*Overrides [SourceTransform](../interfaces/sourcetransform.md).[_transform](../interfaces/sourcetransform.md#_transform)*
 
-*Defined in [sparse-stream/sparse-filter-stream.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-filter-stream.ts#L51)*
+*Defined in [lib/sparse-stream/sparse-filter-stream.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-filter-stream.ts#L51)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `Buffer` |
-| _encoding | `string` |
-| callback | `function` |
+▪ **chunk**: *Buffer*
 
-**Returns:** `void`
+▪ **_encoding**: *string*
+
+▪ **callback**: *function*
+
+▸ (`error`: [Error](notcapable.md#static-error) | null): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`error` | [Error](notcapable.md#static-error) &#124; null |
+
+**Returns:** *void*
 
 ___
-<a id="_write"></a>
 
 ###  _write
 
-▸ **_write**(chunk: *`any`*, encoding: *`string`*, callback: *`Function`*): `void`
+▸ **_write**(`chunk`: any, `encoding`: string, `callback`: Function): *void*
 
-*Inherited from Duplex._write*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[_write](sparsefilterstream.md#_write)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3857*
+Defined in node_modules/@types/node/base.d.ts:3857
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| encoding | `string` |
-| callback | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding` | string |
+`callback` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="addlistener"></a>
 
 ###  addListener
 
-▸ **addListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string, `listener`: Function): *this*
 
-▸ **addListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-▸ **addListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-▸ **addListener**(event: *"end"*, listener: *`function`*): `this`
+Defined in node_modules/@types/node/base.d.ts:3711
 
-▸ **addListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **addListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3711*
-
-Event emitter The defined events on documents including:
-
-1.  close
-2.  data
-3.  end
-4.  readable
-5.  error
+Event emitter
+The defined events on documents including:
+  1. close
+  2. data
+  3. end
+  4. readable
+  5. error
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.addListener*
+▸ **addListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.addListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3712*
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3713*
+Defined in node_modules/@types/node/base.d.ts:3712
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.addListener*
+▸ (): *void*
 
-*Overrides EventEmitter.addListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3714*
+▸ **addListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3715*
+Defined in node_modules/@types/node/base.d.ts:3713
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3716*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **addListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3714
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3715
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3716
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-▸ **emit**(event: *"close"*): `boolean`
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-▸ **emit**(event: *"data"*, chunk: *`Buffer` \| `string`*): `boolean`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-▸ **emit**(event: *"end"*): `boolean`
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-▸ **emit**(event: *"readable"*): `boolean`
-
-▸ **emit**(event: *"error"*, err: *`Error`*): `boolean`
-
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3718*
+Defined in node_modules/@types/node/base.d.ts:3718
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "close"): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3719*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-
-**Returns:** `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3720*
+Defined in node_modules/@types/node/base.d.ts:3719
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| chunk | `Buffer` \| `string` |
+Name | Type |
+------ | ------ |
+`event` | "close" |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "data", `chunk`: Buffer | string): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3721*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-
-**Returns:** `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3722*
+Defined in node_modules/@types/node/base.d.ts:3720
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
+Name | Type |
+------ | ------ |
+`event` | "data" |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "end"): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3723*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3721
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| err | `Error` |
+Name | Type |
+------ | ------ |
+`event` | "end" |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "readable"): *boolean*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3722
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "readable" |
+
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "error", `err`: [Error](notcapable.md#static-error)): *boolean*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3723
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "error" |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *boolean*
 
 ___
-<a id="end"></a>
 
 ###  end
 
-▸ **end**(cb?: *`Function`*): `void`
+▸ **end**(`cb?`: Function): *void*
 
-▸ **end**(chunk: *`any`*, cb?: *`Function`*): `void`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[end](sparsefilterstream.md#end)*
 
-▸ **end**(chunk: *`any`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `void`
-
-*Inherited from Duplex.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:3861*
+Defined in node_modules/@types/node/base.d.ts:3861
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
 
-*Inherited from Duplex.end*
+▸ **end**(`chunk`: any, `cb?`: Function): *void*
 
-*Defined in /node_modules/@types/node/base.d.ts:3862*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[end](sparsefilterstream.md#end)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` cb | `Function` |
-
-**Returns:** `void`
-
-*Inherited from Duplex.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:3863*
+Defined in node_modules/@types/node/base.d.ts:3862
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
+
+▸ **end**(`chunk`: any, `encoding?`: undefined | string, `cb?`: Function): *void*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[end](sparsefilterstream.md#end)*
+
+Defined in node_modules/@types/node/base.d.ts:3863
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
+
+**Returns:** *void*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+Defined in node_modules/@types/node/base.d.ts:694
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
-
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+Defined in node_modules/@types/node/base.d.ts:691
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
-
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="ispaused"></a>
 
 ###  isPaused
 
-▸ **isPaused**(): `boolean`
+▸ **isPaused**(): *boolean*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[isPaused](../interfaces/sparsereadable.md#ispaused)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from Readable.isPaused*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[isPaused](sparsefilterstream.md#ispaused)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3695*
+Defined in node_modules/@types/node/base.d.ts:3695
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
-
-___
-<a id="nextblock"></a>
-
-### `<Private>` nextBlock
-
-▸ **nextBlock**(): `void`
-
-*Defined in [sparse-stream/sparse-filter-stream.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-filter-stream.ts#L47)*
-
-**Returns:** `void`
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
+
+### `Private` nextBlock
+
+▸ **nextBlock**(): *void*
+
+*Defined in [lib/sparse-stream/sparse-filter-stream.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-filter-stream.ts#L47)*
+
+**Returns:** *void*
+
+___
 
 ###  on
 
-▸ **on**(event: *`string`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string, `listener`: Function): *this*
 
-▸ **on**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-▸ **on**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-▸ **on**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3725*
+Defined in node_modules/@types/node/base.d.ts:3725
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.on*
+▸ **on**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.on*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3726*
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3727*
+Defined in node_modules/@types/node/base.d.ts:3726
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.on*
+▸ (): *void*
 
-*Overrides EventEmitter.on*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3728*
+▸ **on**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Returns:** `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3729*
+Defined in node_modules/@types/node/base.d.ts:3727
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3730*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **on**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3728
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **on**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3729
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **on**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3730
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string, `listener`: Function): *this*
 
-▸ **once**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-▸ **once**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-▸ **once**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3732*
+Defined in node_modules/@types/node/base.d.ts:3732
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.once*
+▸ **once**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.once*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3733*
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3734*
+Defined in node_modules/@types/node/base.d.ts:3733
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.once*
+▸ (): *void*
 
-*Overrides EventEmitter.once*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3735*
+▸ **once**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Returns:** `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3736*
+Defined in node_modules/@types/node/base.d.ts:3734
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3737*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **once**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3735
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **once**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3736
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **once**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3737
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="pause"></a>
 
 ###  pause
 
-▸ **pause**(): `this`
+▸ **pause**(): *this*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[pause](../interfaces/sparsereadable.md#pause)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from Readable.pause*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[pause](sparsefilterstream.md#pause)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3693*
+Defined in node_modules/@types/node/base.d.ts:3693
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="pipe"></a>
 
 ###  pipe
 
-▸ **pipe**<`T`>(destination: *`T`*, options?: *`undefined` \| `object`*): `T`
+▸ **pipe**<**T**>(`destination`: T, `options?`: undefined | object): *T*
 
-*Inherited from Readable.pipe*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[pipe](sparsefilterstream.md#pipe)*
 
-*Overrides internal.pipe*
+*Overrides [CountingWritable](countingwritable.md).[pipe](countingwritable.md#pipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3696*
+Defined in node_modules/@types/node/base.d.ts:3696
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| destination | `T` |
-| `Optional` options | `undefined` \| `object` |
+Name | Type |
+------ | ------ |
+`destination` | T |
+`options?` | undefined &#124; object |
 
-**Returns:** `T`
+**Returns:** *T*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-▸ **prependListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-▸ **prependListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3739*
+Defined in node_modules/@types/node/base.d.ts:3739
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.prependListener*
+▸ **prependListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3740*
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3741*
+Defined in node_modules/@types/node/base.d.ts:3740
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3742*
+▸ **prependListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3743*
+Defined in node_modules/@types/node/base.d.ts:3741
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3744*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3742
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3743
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3744
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependOnceListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3746*
+Defined in node_modules/@types/node/base.d.ts:3746
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.prependOnceListener*
+▸ **prependOnceListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependOnceListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3747*
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3748*
+Defined in node_modules/@types/node/base.d.ts:3747
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependOnceListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependOnceListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3749*
+▸ **prependOnceListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3750*
+Defined in node_modules/@types/node/base.d.ts:3748
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3751*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3749
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3750
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3751
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="push"></a>
 
 ###  push
 
-▸ **push**(chunk: *`any`*, encoding?: *`undefined` \| `string`*): `boolean`
+▸ **push**(`chunk`: any, `encoding?`: undefined | string): *boolean*
 
-*Inherited from Readable.push*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[push](sparsefilterstream.md#push)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3700*
+Defined in node_modules/@types/node/base.d.ts:3700
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(size?: *`undefined` \| `number`*): `any`
+▸ **read**(`size?`: undefined | number): *any*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[read](../interfaces/sparsereadable.md#read)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from Readable.read*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[read](sparsefilterstream.md#read)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3691*
+Defined in node_modules/@types/node/base.d.ts:3691
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`size?` | undefined &#124; number |
 
-**Returns:** `any`
+**Returns:** *any*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string, `listener`: Function): *this*
 
-▸ **removeListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-▸ **removeListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-▸ **removeListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3753*
+Defined in node_modules/@types/node/base.d.ts:3753
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.removeListener*
+▸ **removeListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.removeListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3754*
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3755*
+Defined in node_modules/@types/node/base.d.ts:3754
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.removeListener*
+▸ (): *void*
 
-*Overrides EventEmitter.removeListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3756*
+▸ **removeListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3757*
+Defined in node_modules/@types/node/base.d.ts:3755
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3758*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3756
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3757
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3758
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="resume"></a>
 
 ###  resume
 
-▸ **resume**(): `this`
+▸ **resume**(): *this*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[resume](../interfaces/sparsereadable.md#resume)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from Readable.resume*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[resume](sparsefilterstream.md#resume)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3694*
+Defined in node_modules/@types/node/base.d.ts:3694
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setdefaultencoding"></a>
 
 ###  setDefaultEncoding
 
-▸ **setDefaultEncoding**(encoding: *`string`*): `this`
+▸ **setDefaultEncoding**(`encoding`: string): *this*
 
-*Inherited from Duplex.setDefaultEncoding*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[setDefaultEncoding](sparsefilterstream.md#setdefaultencoding)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3860*
+Defined in node_modules/@types/node/base.d.ts:3860
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| encoding | `string` |
+Name | Type |
+------ | ------ |
+`encoding` | string |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setencoding"></a>
 
 ###  setEncoding
 
-▸ **setEncoding**(encoding: *`string`*): `void`
+▸ **setEncoding**(`encoding`: string): *void*
 
-*Inherited from Readable.setEncoding*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[setEncoding](sparsefilterstream.md#setencoding)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3692*
+Defined in node_modules/@types/node/base.d.ts:3692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| encoding | `string` |
+Name | Type |
+------ | ------ |
+`encoding` | string |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="unpipe"></a>
 
 ###  unpipe
 
-▸ **unpipe**<`T`>(destination?: *[T]()*): `void`
+▸ **unpipe**<**T**>(`destination?`: T): *void*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[unpipe](../interfaces/sparsereadable.md#unpipe)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from Readable.unpipe*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[unpipe](sparsefilterstream.md#unpipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3697*
+Defined in node_modules/@types/node/base.d.ts:3697
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` destination | [T]() |
+Name | Type |
+------ | ------ |
+`destination?` | T |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="unshift"></a>
 
 ###  unshift
 
-▸ **unshift**(chunk: *`any`*): `void`
+▸ **unshift**(`chunk`: any): *void*
 
-*Inherited from Readable.unshift*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[unshift](sparsefilterstream.md#unshift)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3698*
+Defined in node_modules/@types/node/base.d.ts:3698
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="wrap"></a>
 
 ###  wrap
 
-▸ **wrap**(oldStream: *`ReadableStream`*): `Readable`
+▸ **wrap**(`oldStream`: ReadableStream): *Readable*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[wrap](../interfaces/sparsereadable.md#wrap)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from Readable.wrap*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[wrap](sparsefilterstream.md#wrap)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3699*
+Defined in node_modules/@types/node/base.d.ts:3699
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| oldStream | `ReadableStream` |
+Name | Type |
+------ | ------ |
+`oldStream` | ReadableStream |
 
-**Returns:** `Readable`
+**Returns:** *Readable*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(chunk: *`any`*, cb?: *`Function`*): `boolean`
+▸ **write**(`chunk`: any, `cb?`: Function): *boolean*
 
-▸ **write**(chunk: *`any`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `boolean`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[write](sparsefilterstream.md#write)*
 
-*Inherited from Duplex.write*
-
-*Defined in /node_modules/@types/node/base.d.ts:3858*
+Defined in node_modules/@types/node/base.d.ts:3858
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`cb?` | Function |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Duplex.write*
+▸ **write**(`chunk`: any, `encoding?`: undefined | string, `cb?`: Function): *boolean*
 
-*Defined in /node_modules/@types/node/base.d.ts:3859*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[write](sparsefilterstream.md#write)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
-
-**Returns:** `boolean`
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:3859
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
 
-**Returns:** `number`
+**Returns:** *boolean*
 
 ___
 
+### `Static` listenerCount
+
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
+
+Defined in node_modules/@types/node/base.d.ts:680
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
+
+**Returns:** *number*

--- a/doc/classes/sparsereadstream.md
+++ b/doc/classes/sparsereadstream.md
@@ -1,16 +1,16 @@
-[etcher-sdk](../README.md) > [SparseReadStream](../classes/sparsereadstream.md)
+[etcher-sdk](../README.md) › [SparseReadStream](sparsereadstream.md)
 
 # Class: SparseReadStream
 
 ## Hierarchy
 
- `Readable`
+* Readable
 
-**↳ SparseReadStream**
+  ↳ **SparseReadStream**
 
 ## Implements
 
-* `ReadableStream`
+* ReadableStream
 * [SparseReadable](../interfaces/sparsereadable.md)
 
 ## Index
@@ -22,17 +22,17 @@
 ### Properties
 
 * [blocks](sparsereadstream.md#blocks)
-* [chunkSize](sparsereadstream.md#chunksize)
-* [positionInBlock](sparsereadstream.md#positioninblock)
+* [chunkSize](sparsereadstream.md#private-chunksize)
+* [positionInBlock](sparsereadstream.md#private-positioninblock)
 * [readable](sparsereadstream.md#readable)
-* [source](sparsereadstream.md#source)
-* [state](sparsereadstream.md#state)
-* [stateIterator](sparsereadstream.md#stateiterator)
-* [defaultMaxListeners](sparsereadstream.md#defaultmaxlisteners)
+* [source](sparsereadstream.md#private-source)
+* [state](sparsereadstream.md#private-optional-state)
+* [stateIterator](sparsereadstream.md#private-stateiterator)
+* [defaultMaxListeners](sparsereadstream.md#static-defaultmaxlisteners)
 
 ### Methods
 
-* [__read](sparsereadstream.md#__read)
+* [__read](sparsereadstream.md#private-__read)
 * [_read](sparsereadstream.md#_read)
 * [addListener](sparsereadstream.md#addlistener)
 * [emit](sparsereadstream.md#emit)
@@ -41,7 +41,7 @@
 * [isPaused](sparsereadstream.md#ispaused)
 * [listenerCount](sparsereadstream.md#listenercount)
 * [listeners](sparsereadstream.md#listeners)
-* [nextBlock](sparsereadstream.md#nextblock)
+* [nextBlock](sparsereadstream.md#private-nextblock)
 * [on](sparsereadstream.md#on)
 * [once](sparsereadstream.md#once)
 * [pause](sparsereadstream.md#pause)
@@ -58,1251 +58,1295 @@
 * [unpipe](sparsereadstream.md#unpipe)
 * [unshift](sparsereadstream.md#unshift)
 * [wrap](sparsereadstream.md#wrap)
-* [listenerCount](sparsereadstream.md#listenercount-1)
-
----
+* [listenerCount](sparsereadstream.md#static-listenercount)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new SparseReadStream**(source: *[SourceDestination](sourcedestination.md)*, blocks: *[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, chunkSize: *`number`*, verify: *`boolean`*, generateChecksums: *`boolean`*, options?: *`ReadableOptions`*): [SparseReadStream](sparsereadstream.md)
+\+ **new SparseReadStream**(`source`: [SourceDestination](sourcedestination.md), `blocks`: [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `chunkSize`: number, `verify`: boolean, `generateChecksums`: boolean, `options`: ReadableOptions): *[SparseReadStream](sparsereadstream.md)*
 
-*Overrides Readable.__constructor*
+*Overrides void*
 
-*Defined in [sparse-stream/sparse-read-stream.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-read-stream.ts#L32)*
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-read-stream.ts#L32)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| source | [SourceDestination](sourcedestination.md) | - |
-| blocks | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] | - |
-| chunkSize | `number` | - |
-| verify | `boolean` | - |
-| generateChecksums | `boolean` | - |
-| `Default value` options | `ReadableOptions` |  {} |
+Name | Type | Default |
+------ | ------ | ------ |
+`source` | [SourceDestination](sourcedestination.md) | - |
+`blocks` | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] | - |
+`chunkSize` | number | - |
+`verify` | boolean | - |
+`generateChecksums` | boolean | - |
+`options` | ReadableOptions | {} |
 
-**Returns:** [SparseReadStream](sparsereadstream.md)
-
-___
+**Returns:** *[SparseReadStream](sparsereadstream.md)*
 
 ## Properties
 
-<a id="blocks"></a>
-
 ###  blocks
 
-**● blocks**: *[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*
+• **blocks**: *[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*
 
 *Implementation of [SparseReadable](../interfaces/sparsereadable.md).[blocks](../interfaces/sparsereadable.md#blocks)*
 
-*Defined in [sparse-stream/sparse-read-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-read-stream.ts#L36)*
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-read-stream.ts#L36)*
 
 ___
-<a id="chunksize"></a>
 
-### `<Private>` chunkSize
+### `Private` chunkSize
 
-**● chunkSize**: *`number`*
+• **chunkSize**: *number*
 
-*Defined in [sparse-stream/sparse-read-stream.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-read-stream.ts#L37)*
-
-___
-<a id="positioninblock"></a>
-
-### `<Private>` positionInBlock
-
-**● positionInBlock**: *`number`* = 0
-
-*Defined in [sparse-stream/sparse-read-stream.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-read-stream.ts#L32)*
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-read-stream.ts#L37)*
 
 ___
-<a id="readable"></a>
+
+### `Private` positionInBlock
+
+• **positionInBlock**: *number* = 0
+
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-read-stream.ts#L32)*
+
+___
 
 ###  readable
 
-**● readable**: *`boolean`*
+• **readable**: *boolean*
 
 *Implementation of [SparseReadable](../interfaces/sparsereadable.md).[readable](../interfaces/sparsereadable.md#readable)*
 
-*Inherited from Readable.readable*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[readable](sparsefilterstream.md#readable)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3688*
-
-___
-<a id="source"></a>
-
-### `<Private>` source
-
-**● source**: *[SourceDestination](sourcedestination.md)*
-
-*Defined in [sparse-stream/sparse-read-stream.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-read-stream.ts#L35)*
+Defined in node_modules/@types/node/base.d.ts:3688
 
 ___
-<a id="state"></a>
 
-### `<Private>``<Optional>` state
+### `Private` source
 
-**● state**: *[SparseReaderState](../interfaces/sparsereaderstate.md)*
+• **source**: *[SourceDestination](sourcedestination.md)*
 
-*Defined in [sparse-stream/sparse-read-stream.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-read-stream.ts#L31)*
-
-___
-<a id="stateiterator"></a>
-
-### `<Private>` stateIterator
-
-**● stateIterator**: *`Iterator`<[SparseReaderState](../interfaces/sparsereaderstate.md)>*
-
-*Defined in [sparse-stream/sparse-read-stream.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-read-stream.ts#L30)*
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-read-stream.ts#L35)*
 
 ___
-<a id="defaultmaxlisteners"></a>
 
-### `<Static>` defaultMaxListeners
+### `Private` `Optional` state
 
-**● defaultMaxListeners**: *`number`*
+• **state**? : *[SparseReaderState](../interfaces/sparsereaderstate.md)*
 
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-read-stream.ts#L31)*
 
 ___
+
+### `Private` stateIterator
+
+• **stateIterator**: *Iterator‹[SparseReaderState](../interfaces/sparsereaderstate.md)›*
+
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-read-stream.ts#L30)*
+
+___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="__read"></a>
+### `Private` __read
 
-### `<Private>` __read
+▸ **__read**(): *Promise‹[SparseStreamChunk](../interfaces/sparsestreamchunk.md) | null›*
 
-▸ **__read**(): `Promise`<[SparseStreamChunk](../interfaces/sparsestreamchunk.md) \| `null`>
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-read-stream.ts#L65)*
 
-*Defined in [sparse-stream/sparse-read-stream.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-read-stream.ts#L65)*
-
-**Returns:** `Promise`<[SparseStreamChunk](../interfaces/sparsestreamchunk.md) \| `null`>
+**Returns:** *Promise‹[SparseStreamChunk](../interfaces/sparsestreamchunk.md) | null›*
 
 ___
-<a id="_read"></a>
 
 ###  _read
 
-▸ **_read**(): `Promise`<`void`>
+▸ **_read**(): *Promise‹void›*
 
-*Overrides Readable._read*
+*Overrides [SparseFilterStream](sparsefilterstream.md).[_read](sparsefilterstream.md#_read)*
 
-*Defined in [sparse-stream/sparse-read-stream.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-read-stream.ts#L51)*
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-read-stream.ts#L51)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="addlistener"></a>
 
 ###  addListener
 
-▸ **addListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string, `listener`: Function): *this*
 
-▸ **addListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-▸ **addListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-▸ **addListener**(event: *"end"*, listener: *`function`*): `this`
+Defined in node_modules/@types/node/base.d.ts:3711
 
-▸ **addListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **addListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3711*
-
-Event emitter The defined events on documents including:
-
-1.  close
-2.  data
-3.  end
-4.  readable
-5.  error
+Event emitter
+The defined events on documents including:
+  1. close
+  2. data
+  3. end
+  4. readable
+  5. error
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.addListener*
+▸ **addListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.addListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3712*
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3713*
+Defined in node_modules/@types/node/base.d.ts:3712
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.addListener*
+▸ (): *void*
 
-*Overrides EventEmitter.addListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3714*
+▸ **addListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3715*
+Defined in node_modules/@types/node/base.d.ts:3713
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3716*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **addListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3714
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3715
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3716
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-▸ **emit**(event: *"close"*): `boolean`
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-▸ **emit**(event: *"data"*, chunk: *`Buffer` \| `string`*): `boolean`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-▸ **emit**(event: *"end"*): `boolean`
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-▸ **emit**(event: *"readable"*): `boolean`
-
-▸ **emit**(event: *"error"*, err: *`Error`*): `boolean`
-
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3718*
+Defined in node_modules/@types/node/base.d.ts:3718
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "close"): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3719*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-
-**Returns:** `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3720*
+Defined in node_modules/@types/node/base.d.ts:3719
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| chunk | `Buffer` \| `string` |
+Name | Type |
+------ | ------ |
+`event` | "close" |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "data", `chunk`: Buffer | string): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3721*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-
-**Returns:** `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3722*
+Defined in node_modules/@types/node/base.d.ts:3720
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
+Name | Type |
+------ | ------ |
+`event` | "data" |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "end"): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3723*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3721
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| err | `Error` |
+Name | Type |
+------ | ------ |
+`event` | "end" |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "readable"): *boolean*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3722
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "readable" |
+
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "error", `err`: [Error](notcapable.md#static-error)): *boolean*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3723
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "error" |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+Defined in node_modules/@types/node/base.d.ts:694
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
-
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+Defined in node_modules/@types/node/base.d.ts:691
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
-
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="ispaused"></a>
 
 ###  isPaused
 
-▸ **isPaused**(): `boolean`
+▸ **isPaused**(): *boolean*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[isPaused](../interfaces/sparsereadable.md#ispaused)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from Readable.isPaused*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[isPaused](sparsefilterstream.md#ispaused)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3695*
+Defined in node_modules/@types/node/base.d.ts:3695
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
-
-___
-<a id="nextblock"></a>
-
-### `<Private>` nextBlock
-
-▸ **nextBlock**(): `void`
-
-*Defined in [sparse-stream/sparse-read-stream.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-read-stream.ts#L60)*
-
-**Returns:** `void`
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
+
+### `Private` nextBlock
+
+▸ **nextBlock**(): *void*
+
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-read-stream.ts#L60)*
+
+**Returns:** *void*
+
+___
 
 ###  on
 
-▸ **on**(event: *`string`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string, `listener`: Function): *this*
 
-▸ **on**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-▸ **on**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-▸ **on**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3725*
+Defined in node_modules/@types/node/base.d.ts:3725
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.on*
+▸ **on**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.on*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3726*
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3727*
+Defined in node_modules/@types/node/base.d.ts:3726
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.on*
+▸ (): *void*
 
-*Overrides EventEmitter.on*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3728*
+▸ **on**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Returns:** `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3729*
+Defined in node_modules/@types/node/base.d.ts:3727
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3730*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **on**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3728
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **on**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3729
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **on**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3730
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string, `listener`: Function): *this*
 
-▸ **once**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-▸ **once**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-▸ **once**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3732*
+Defined in node_modules/@types/node/base.d.ts:3732
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.once*
+▸ **once**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.once*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3733*
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3734*
+Defined in node_modules/@types/node/base.d.ts:3733
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.once*
+▸ (): *void*
 
-*Overrides EventEmitter.once*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3735*
+▸ **once**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Returns:** `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3736*
+Defined in node_modules/@types/node/base.d.ts:3734
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3737*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **once**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3735
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **once**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3736
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **once**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3737
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="pause"></a>
 
 ###  pause
 
-▸ **pause**(): `this`
+▸ **pause**(): *this*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[pause](../interfaces/sparsereadable.md#pause)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from Readable.pause*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[pause](sparsefilterstream.md#pause)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3693*
+Defined in node_modules/@types/node/base.d.ts:3693
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="pipe"></a>
 
 ###  pipe
 
-▸ **pipe**<`T`>(destination: *`T`*, options?: *`undefined` \| `object`*): `T`
+▸ **pipe**<**T**>(`destination`: T, `options?`: undefined | object): *T*
 
-*Inherited from Readable.pipe*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[pipe](sparsefilterstream.md#pipe)*
 
-*Overrides internal.pipe*
+*Overrides [CountingWritable](countingwritable.md).[pipe](countingwritable.md#pipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3696*
+Defined in node_modules/@types/node/base.d.ts:3696
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| destination | `T` |
-| `Optional` options | `undefined` \| `object` |
+Name | Type |
+------ | ------ |
+`destination` | T |
+`options?` | undefined &#124; object |
 
-**Returns:** `T`
+**Returns:** *T*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-▸ **prependListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-▸ **prependListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3739*
+Defined in node_modules/@types/node/base.d.ts:3739
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.prependListener*
+▸ **prependListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3740*
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3741*
+Defined in node_modules/@types/node/base.d.ts:3740
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3742*
+▸ **prependListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3743*
+Defined in node_modules/@types/node/base.d.ts:3741
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3744*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3742
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3743
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3744
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependOnceListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3746*
+Defined in node_modules/@types/node/base.d.ts:3746
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.prependOnceListener*
+▸ **prependOnceListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependOnceListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3747*
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3748*
+Defined in node_modules/@types/node/base.d.ts:3747
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependOnceListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependOnceListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3749*
+▸ **prependOnceListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3750*
+Defined in node_modules/@types/node/base.d.ts:3748
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3751*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3749
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3750
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3751
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="push"></a>
 
 ###  push
 
-▸ **push**(chunk: *`any`*, encoding?: *`undefined` \| `string`*): `boolean`
+▸ **push**(`chunk`: any, `encoding?`: undefined | string): *boolean*
 
-*Inherited from Readable.push*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[push](sparsefilterstream.md#push)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3700*
+Defined in node_modules/@types/node/base.d.ts:3700
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(size?: *`undefined` \| `number`*): `any`
+▸ **read**(`size?`: undefined | number): *any*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[read](../interfaces/sparsereadable.md#read)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from Readable.read*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[read](sparsefilterstream.md#read)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3691*
+Defined in node_modules/@types/node/base.d.ts:3691
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`size?` | undefined &#124; number |
 
-**Returns:** `any`
+**Returns:** *any*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string, `listener`: Function): *this*
 
-▸ **removeListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-▸ **removeListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-▸ **removeListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3753*
+Defined in node_modules/@types/node/base.d.ts:3753
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.removeListener*
+▸ **removeListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.removeListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3754*
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3755*
+Defined in node_modules/@types/node/base.d.ts:3754
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.removeListener*
+▸ (): *void*
 
-*Overrides EventEmitter.removeListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3756*
+▸ **removeListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3757*
+Defined in node_modules/@types/node/base.d.ts:3755
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3758*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3756
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3757
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3758
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="resume"></a>
 
 ###  resume
 
-▸ **resume**(): `this`
+▸ **resume**(): *this*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[resume](../interfaces/sparsereadable.md#resume)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from Readable.resume*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[resume](sparsefilterstream.md#resume)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3694*
+Defined in node_modules/@types/node/base.d.ts:3694
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setencoding"></a>
 
 ###  setEncoding
 
-▸ **setEncoding**(encoding: *`string`*): `void`
+▸ **setEncoding**(`encoding`: string): *void*
 
-*Inherited from Readable.setEncoding*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[setEncoding](sparsefilterstream.md#setencoding)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3692*
+Defined in node_modules/@types/node/base.d.ts:3692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| encoding | `string` |
+Name | Type |
+------ | ------ |
+`encoding` | string |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="unpipe"></a>
 
 ###  unpipe
 
-▸ **unpipe**<`T`>(destination?: *[T]()*): `void`
+▸ **unpipe**<**T**>(`destination?`: T): *void*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[unpipe](../interfaces/sparsereadable.md#unpipe)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from Readable.unpipe*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[unpipe](sparsefilterstream.md#unpipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3697*
+Defined in node_modules/@types/node/base.d.ts:3697
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` destination | [T]() |
+Name | Type |
+------ | ------ |
+`destination?` | T |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="unshift"></a>
 
 ###  unshift
 
-▸ **unshift**(chunk: *`any`*): `void`
+▸ **unshift**(`chunk`: any): *void*
 
-*Inherited from Readable.unshift*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[unshift](sparsefilterstream.md#unshift)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3698*
+Defined in node_modules/@types/node/base.d.ts:3698
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="wrap"></a>
 
 ###  wrap
 
-▸ **wrap**(oldStream: *`ReadableStream`*): `Readable`
+▸ **wrap**(`oldStream`: ReadableStream): *Readable*
 
-*Implementation of [SparseReadable](../interfaces/sparsereadable.md).[wrap](../interfaces/sparsereadable.md#wrap)*
+*Implementation of [SparseReadable](../interfaces/sparsereadable.md)*
 
-*Inherited from Readable.wrap*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[wrap](sparsefilterstream.md#wrap)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3699*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| oldStream | `ReadableStream` |
-
-**Returns:** `Readable`
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:3699
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`oldStream` | ReadableStream |
 
-**Returns:** `number`
+**Returns:** *Readable*
 
 ___
 
+### `Static` listenerCount
+
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
+
+Defined in node_modules/@types/node/base.d.ts:680
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
+
+**Returns:** *number*

--- a/doc/classes/sparsestreamverifier.md
+++ b/doc/classes/sparsestreamverifier.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [SparseStreamVerifier](../classes/sparsestreamverifier.md)
+[etcher-sdk](../README.md) › [SparseStreamVerifier](sparsestreamverifier.md)
 
 # Class: SparseStreamVerifier
 
 ## Hierarchy
 
-↳  [Verifier](verifier.md)
+  ↳ [Verifier](verifier.md)
 
-**↳ SparseStreamVerifier**
+  ↳ **SparseStreamVerifier**
 
 ## Index
 
@@ -16,9 +16,9 @@
 
 ### Properties
 
-* [blocks](sparsestreamverifier.md#blocks)
-* [source](sparsestreamverifier.md#source)
-* [defaultMaxListeners](sparsestreamverifier.md#defaultmaxlisteners)
+* [blocks](sparsestreamverifier.md#private-blocks)
+* [source](sparsestreamverifier.md#private-source)
+* [defaultMaxListeners](sparsestreamverifier.md#static-defaultmaxlisteners)
 
 ### Methods
 
@@ -26,7 +26,7 @@
 * [emit](sparsestreamverifier.md#emit)
 * [eventNames](sparsestreamverifier.md#eventnames)
 * [getMaxListeners](sparsestreamverifier.md#getmaxlisteners)
-* [handleEventsAndPipe](sparsestreamverifier.md#handleeventsandpipe)
+* [handleEventsAndPipe](sparsestreamverifier.md#protected-handleeventsandpipe)
 * [listenerCount](sparsestreamverifier.md#listenercount)
 * [listeners](sparsestreamverifier.md#listeners)
 * [on](sparsestreamverifier.md#on)
@@ -37,430 +37,384 @@
 * [removeListener](sparsestreamverifier.md#removelistener)
 * [run](sparsestreamverifier.md#run)
 * [setMaxListeners](sparsestreamverifier.md#setmaxlisteners)
-* [listenerCount](sparsestreamverifier.md#listenercount-1)
+* [listenerCount](sparsestreamverifier.md#static-listenercount)
 
 ### Object literals
 
 * [progress](sparsestreamverifier.md#progress)
 
----
-
 ## Constructors
-
-<a id="constructor"></a>
 
 ###  constructor
 
-⊕ **new SparseStreamVerifier**(source: *[SourceDestination](sourcedestination.md)*, blocks: *[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*): [SparseStreamVerifier](sparsestreamverifier.md)
+\+ **new SparseStreamVerifier**(`source`: [SourceDestination](sourcedestination.md), `blocks`: [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]): *[SparseStreamVerifier](sparsestreamverifier.md)*
 
-*Defined in [source-destination/source-destination.ts:182](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L182)*
+*Defined in [lib/source-destination/source-destination.ts:182](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L182)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| source | [SourceDestination](sourcedestination.md) |
-| blocks | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+Name | Type |
+------ | ------ |
+`source` | [SourceDestination](sourcedestination.md) |
+`blocks` | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
 
-**Returns:** [SparseStreamVerifier](sparsestreamverifier.md)
-
-___
+**Returns:** *[SparseStreamVerifier](sparsestreamverifier.md)*
 
 ## Properties
 
-<a id="blocks"></a>
+### `Private` blocks
 
-### `<Private>` blocks
+• **blocks**: *[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*
 
-**● blocks**: *[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*
-
-*Defined in [source-destination/source-destination.ts:185](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L185)*
+*Defined in [lib/source-destination/source-destination.ts:185](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L185)*
 
 ___
-<a id="source"></a>
 
-### `<Private>` source
+### `Private` source
 
-**● source**: *[SourceDestination](sourcedestination.md)*
+• **source**: *[SourceDestination](sourcedestination.md)*
 
-*Defined in [source-destination/source-destination.ts:184](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L184)*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/source-destination.ts:184](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L184)*
 
 ___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="addlistener"></a>
-
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="handleeventsandpipe"></a>
 
-### `<Protected>` handleEventsAndPipe
+### `Protected` handleEventsAndPipe
 
-▸ **handleEventsAndPipe**(stream: *`ReadableStream`*, meter: *`WritableStream`*): `void`
+▸ **handleEventsAndPipe**(`stream`: ReadableStream, `meter`: WritableStream): *void*
 
-*Inherited from [Verifier](verifier.md).[handleEventsAndPipe](verifier.md#handleeventsandpipe)*
+*Inherited from [Verifier](verifier.md).[handleEventsAndPipe](verifier.md#protected-handleeventsandpipe)*
 
-*Defined in [source-destination/source-destination.ts:134](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L134)*
+*Defined in [lib/source-destination/source-destination.ts:134](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L134)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| stream | `ReadableStream` |
-| meter | `WritableStream` |
+Name | Type |
+------ | ------ |
+`stream` | ReadableStream |
+`meter` | WritableStream |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="run"></a>
 
 ###  run
 
-▸ **run**(): `Promise`<`void`>
+▸ **run**(): *Promise‹void›*
 
-*Overrides [Verifier](verifier.md).[run](verifier.md#run)*
+*Overrides [Verifier](verifier.md).[run](verifier.md#abstract-run)*
 
-*Defined in [source-destination/source-destination.ts:190](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L190)*
+*Defined in [lib/source-destination/source-destination.ts:190](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L190)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
-
-**Returns:** `this`
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `number`
+**Returns:** *this*
 
 ___
+
+### `Static` listenerCount
+
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
+
+Defined in node_modules/@types/node/base.d.ts:680
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
+
+**Returns:** *number*
 
 ## Object literals
 
-<a id="progress"></a>
-
 ###  progress
 
-**progress**: *`object`*
+### ▪ **progress**: *object*
 
 *Inherited from [Verifier](verifier.md).[progress](verifier.md#progress)*
 
-*Defined in [source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L130)*
+*Defined in [lib/source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L130)*
 
-<a id="progress.bytes"></a>
+###  bytes
 
-####  bytes
+• **bytes**: *number* = 0
 
-**● bytes**: *`number`* = 0
+*Defined in [lib/source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L130)*
 
-*Defined in [source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L130)*
+###  position
 
-___
-<a id="progress.position"></a>
+• **position**: *number* = 0
 
-####  position
+*Defined in [lib/source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L130)*
 
-**● position**: *`number`* = 0
+###  speed
 
-*Defined in [source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L130)*
+• **speed**: *number* = 0
 
-___
-<a id="progress.speed"></a>
-
-####  speed
-
-**● speed**: *`number`* = 0
-
-*Defined in [source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L130)*
-
-___
-
-___
-
+*Defined in [lib/source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L130)*

--- a/doc/classes/sparsewritestream.md
+++ b/doc/classes/sparsewritestream.md
@@ -1,16 +1,16 @@
-[etcher-sdk](../README.md) > [SparseWriteStream](../classes/sparsewritestream.md)
+[etcher-sdk](../README.md) › [SparseWriteStream](sparsewritestream.md)
 
 # Class: SparseWriteStream
 
 ## Hierarchy
 
- `Writable`
+* Writable
 
-**↳ SparseWriteStream**
+  ↳ **SparseWriteStream**
 
 ## Implements
 
-* `WritableStream`
+* WritableStream
 * [SparseWritable](../interfaces/sparsewritable.md)
 
 ## Index
@@ -21,19 +21,19 @@
 
 ### Properties
 
-* [_firstChunks](sparsewritestream.md#_firstchunks)
+* [_firstChunks](sparsewritestream.md#private-_firstchunks)
 * [bytesWritten](sparsewritestream.md#byteswritten)
-* [destination](sparsewritestream.md#destination)
+* [destination](sparsewritestream.md#private-destination)
 * [firstBytesToKeep](sparsewritestream.md#firstbytestokeep)
-* [maxRetries](sparsewritestream.md#maxretries)
+* [maxRetries](sparsewritestream.md#private-maxretries)
 * [position](sparsewritestream.md#position)
 * [writable](sparsewritestream.md#writable)
-* [defaultMaxListeners](sparsewritestream.md#defaultmaxlisteners)
+* [defaultMaxListeners](sparsewritestream.md#static-defaultmaxlisteners)
 
 ### Methods
 
-* [__final](sparsewritestream.md#__final)
-* [__write](sparsewritestream.md#__write)
+* [__final](sparsewritestream.md#private-__final)
+* [__write](sparsewritestream.md#private-__write)
 * [_final](sparsewritestream.md#_final)
 * [_write](sparsewritestream.md#_write)
 * [addListener](sparsewritestream.md#addlistener)
@@ -54,1374 +54,1476 @@
 * [setDefaultEncoding](sparsewritestream.md#setdefaultencoding)
 * [setMaxListeners](sparsewritestream.md#setmaxlisteners)
 * [write](sparsewritestream.md#write)
-* [writeChunk](sparsewritestream.md#writechunk)
-* [listenerCount](sparsewritestream.md#listenercount-1)
-
----
+* [writeChunk](sparsewritestream.md#private-writechunk)
+* [listenerCount](sparsewritestream.md#static-listenercount)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new SparseWriteStream**(destination: *[SourceDestination](sourcedestination.md)*, firstBytesToKeep?: *`number`*, maxRetries?: *`number`*): [SparseWriteStream](sparsewritestream.md)
+\+ **new SparseWriteStream**(`destination`: [SourceDestination](sourcedestination.md), `firstBytesToKeep`: number, `maxRetries`: number): *[SparseWriteStream](sparsewritestream.md)*
 
-*Overrides Writable.__constructor*
+*Overrides [CountingWritable](countingwritable.md).[constructor](countingwritable.md#constructor)*
 
-*Defined in [sparse-stream/sparse-write-stream.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-write-stream.ts#L22)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-write-stream.ts#L22)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| destination | [SourceDestination](sourcedestination.md) | - |
-| `Default value` firstBytesToKeep | `number` | 0 |
-| `Default value` maxRetries | `number` | 5 |
+Name | Type | Default |
+------ | ------ | ------ |
+`destination` | [SourceDestination](sourcedestination.md) | - |
+`firstBytesToKeep` | number | 0 |
+`maxRetries` | number | 5 |
 
-**Returns:** [SparseWriteStream](sparsewritestream.md)
-
-___
+**Returns:** *[SparseWriteStream](sparsewritestream.md)*
 
 ## Properties
 
-<a id="_firstchunks"></a>
+### `Private` _firstChunks
 
-### `<Private>` _firstChunks
+• **_firstChunks**: *[SparseStreamChunk](../interfaces/sparsestreamchunk.md)[]* = []
 
-**● _firstChunks**: *[SparseStreamChunk](../interfaces/sparsestreamchunk.md)[]* =  []
-
-*Defined in [sparse-stream/sparse-write-stream.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-write-stream.ts#L22)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-write-stream.ts#L22)*
 
 ___
-<a id="byteswritten"></a>
 
 ###  bytesWritten
 
-**● bytesWritten**: *`number`* = 0
+• **bytesWritten**: *number* = 0
 
-*Defined in [sparse-stream/sparse-write-stream.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-write-stream.ts#L21)*
-
-___
-<a id="destination"></a>
-
-### `<Private>` destination
-
-**● destination**: *[SourceDestination](sourcedestination.md)*
-
-*Defined in [sparse-stream/sparse-write-stream.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-write-stream.ts#L25)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-write-stream.ts#L21)*
 
 ___
-<a id="firstbytestokeep"></a>
+
+### `Private` destination
+
+• **destination**: *[SourceDestination](sourcedestination.md)*
+
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-write-stream.ts#L25)*
+
+___
 
 ###  firstBytesToKeep
 
-**● firstBytesToKeep**: *`number`*
+• **firstBytesToKeep**: *number*
 
-*Defined in [sparse-stream/sparse-write-stream.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-write-stream.ts#L26)*
-
-___
-<a id="maxretries"></a>
-
-### `<Private>` maxRetries
-
-**● maxRetries**: *`number`*
-
-*Defined in [sparse-stream/sparse-write-stream.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-write-stream.ts#L27)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-write-stream.ts#L26)*
 
 ___
-<a id="position"></a>
+
+### `Private` maxRetries
+
+• **maxRetries**: *number*
+
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-write-stream.ts#L27)*
+
+___
 
 ###  position
 
-**● position**: *`number`*
+• **position**: *number*
 
-*Defined in [sparse-stream/sparse-write-stream.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-write-stream.ts#L20)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-write-stream.ts#L20)*
 
 ___
-<a id="writable"></a>
 
 ###  writable
 
-**● writable**: *`boolean`*
+• **writable**: *boolean*
 
 *Implementation of [SparseWritable](../interfaces/sparsewritable.md).[writable](../interfaces/sparsewritable.md#writable)*
 
-*Inherited from Writable.writable*
+*Inherited from [CountingWritable](countingwritable.md).[writable](countingwritable.md#writable)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3770*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+Defined in node_modules/@types/node/base.d.ts:3770
 
 ___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="__final"></a>
+### `Private` __final
 
-### `<Private>` __final
+▸ **__final**(): *Promise‹void›*
 
-▸ **__final**(): `Promise`<`void`>
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-write-stream.ts#L101)*
 
-*Defined in [sparse-stream/sparse-write-stream.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-write-stream.ts#L101)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="__write"></a>
 
-### `<Private>` __write
+### `Private` __write
 
-▸ **__write**(chunk: *[SparseStreamChunk](../interfaces/sparsestreamchunk.md)*): `Promise`<`void`>
+▸ **__write**(`chunk`: [SparseStreamChunk](../interfaces/sparsestreamchunk.md)): *Promise‹void›*
 
-*Defined in [sparse-stream/sparse-write-stream.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-write-stream.ts#L65)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-write-stream.ts#L65)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | [SparseStreamChunk](../interfaces/sparsestreamchunk.md) |
+Name | Type |
+------ | ------ |
+`chunk` | [SparseStreamChunk](../interfaces/sparsestreamchunk.md) |
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_final"></a>
 
 ###  _final
 
-▸ **_final**(callback: *`function`*): `void`
+▸ **_final**(`callback`: function): *void*
 
-*Defined in [sparse-stream/sparse-write-stream.ts:115](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-write-stream.ts#L115)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:115](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-write-stream.ts#L115)*
 
-*__summary__*: Write buffered data before a stream ends, called by stream internals
+**`summary`** Write buffered data before a stream ends, called by stream internals
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| callback | `function` |
+▪ **callback**: *function*
 
-**Returns:** `void`
+▸ (`error?`: [Error](notcapable.md#static-error) | void): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`error?` | [Error](notcapable.md#static-error) &#124; void |
+
+**Returns:** *void*
 
 ___
-<a id="_write"></a>
 
 ###  _write
 
-▸ **_write**(chunk: *[SparseStreamChunk](../interfaces/sparsestreamchunk.md)*, _enc: *`string`*, callback: *`function`*): `void`
+▸ **_write**(`chunk`: [SparseStreamChunk](../interfaces/sparsestreamchunk.md), `_enc`: string, `callback`: function): *void*
 
-*Overrides Writable._write*
+*Overrides void*
 
-*Defined in [sparse-stream/sparse-write-stream.ts:93](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-write-stream.ts#L93)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:93](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-write-stream.ts#L93)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | [SparseStreamChunk](../interfaces/sparsestreamchunk.md) |
-| _enc | `string` |
-| callback | `function` |
+▪ **chunk**: *[SparseStreamChunk](../interfaces/sparsestreamchunk.md)*
 
-**Returns:** `void`
+▪ **_enc**: *string*
+
+▪ **callback**: *function*
+
+▸ (`error`: [Error](notcapable.md#static-error) | undefined): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`error` | [Error](notcapable.md#static-error) &#124; undefined |
+
+**Returns:** *void*
 
 ___
-<a id="addlistener"></a>
 
 ###  addListener
 
-▸ **addListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string, `listener`: Function): *this*
 
-▸ **addListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
 
-▸ **addListener**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-▸ **addListener**(event: *"error"*, listener: *`function`*): `this`
+Defined in node_modules/@types/node/base.d.ts:3790
 
-▸ **addListener**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **addListener**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **addListener**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3790*
-
-Event emitter The defined events on documents including:
-
-1.  close
-2.  drain
-3.  error
-4.  finish
-5.  pipe
-6.  unpipe
+Event emitter
+The defined events on documents including:
+  1. close
+  2. drain
+  3. error
+  4. finish
+  5. pipe
+  6. unpipe
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.addListener*
+▸ **addListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.addListener*
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3791*
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3792*
+Defined in node_modules/@types/node/base.d.ts:3791
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.addListener*
+▸ (): *void*
 
-*Overrides EventEmitter.addListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3793*
+▸ **addListener**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3794*
+Defined in node_modules/@types/node/base.d.ts:3792
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.addListener*
+▸ (): *void*
 
-*Overrides EventEmitter.addListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3795*
+▸ **addListener**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3796*
+Defined in node_modules/@types/node/base.d.ts:3793
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3794
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3795
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[addListener](countingwritable.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3796
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="destroy"></a>
 
 ###  destroy
 
-▸ **destroy**(error?: *[Error](notcapable.md#error)*): `this`
+▸ **destroy**(`error?`: [Error](notcapable.md#static-error)): *this*
 
-*Inherited from Writable.destroy*
+*Inherited from [SparseWriteStream](sparsewritestream.md).[destroy](sparsewritestream.md#destroy)*
 
-*Defined in [/typings/readable-stream/index.d.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/typings/readable-stream/index.d.ts#L18)*
+*Defined in [typings/readable-stream/index.d.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/typings/readable-stream/index.d.ts#L18)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` error | [Error](notcapable.md#error) |
+Name | Type |
+------ | ------ |
+`error?` | [Error](notcapable.md#static-error) |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-▸ **emit**(event: *"close"*): `boolean`
+*Implementation of [SparseWritable](../interfaces/sparsewritable.md)*
 
-▸ **emit**(event: *"drain"*, chunk: *`Buffer` \| `string`*): `boolean`
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
 
-▸ **emit**(event: *"error"*, err: *`Error`*): `boolean`
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-▸ **emit**(event: *"finish"*): `boolean`
-
-▸ **emit**(event: *"pipe"*, src: *`Readable`*): `boolean`
-
-▸ **emit**(event: *"unpipe"*, src: *`Readable`*): `boolean`
-
-*Implementation of [SparseWritable](../interfaces/sparsewritable.md).[emit](../interfaces/sparsewritable.md#emit)*
-
-*Inherited from Writable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3798*
+Defined in node_modules/@types/node/base.d.ts:3798
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Writable.emit*
+▸ **emit**(`event`: "close"): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3799*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-
-**Returns:** `boolean`
-
-*Inherited from Writable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3800*
+Defined in node_modules/@types/node/base.d.ts:3799
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| chunk | `Buffer` \| `string` |
+Name | Type |
+------ | ------ |
+`event` | "close" |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Writable.emit*
+▸ **emit**(`event`: "drain", `chunk`: Buffer | string): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3801*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| err | `Error` |
-
-**Returns:** `boolean`
-
-*Inherited from Writable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3802*
+Defined in node_modules/@types/node/base.d.ts:3800
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
+Name | Type |
+------ | ------ |
+`event` | "drain" |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Writable.emit*
+▸ **emit**(`event`: "error", `err`: [Error](notcapable.md#static-error)): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3803*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| src | `Readable` |
-
-**Returns:** `boolean`
-
-*Inherited from Writable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3804*
+Defined in node_modules/@types/node/base.d.ts:3801
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| src | `Readable` |
+Name | Type |
+------ | ------ |
+`event` | "error" |
+`err` | [Error](notcapable.md#static-error) |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "finish"): *boolean*
+
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3802
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "finish" |
+
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "pipe", `src`: Readable): *boolean*
+
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3803
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "pipe" |
+`src` | Readable |
+
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "unpipe", `src`: Readable): *boolean*
+
+*Inherited from [CountingWritable](countingwritable.md).[emit](countingwritable.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3804
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "unpipe" |
+`src` | Readable |
+
+**Returns:** *boolean*
 
 ___
-<a id="end"></a>
 
 ###  end
 
-▸ **end**(cb?: *`Function`*): `void`
+▸ **end**(`cb?`: Function): *void*
 
-▸ **end**(chunk: *`any`*, cb?: *`Function`*): `void`
+*Implementation of [SparseWritable](../interfaces/sparsewritable.md)*
 
-▸ **end**(chunk: *`any`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `void`
+*Inherited from [CountingWritable](countingwritable.md).[end](countingwritable.md#end)*
 
-*Implementation of [SparseWritable](../interfaces/sparsewritable.md).[end](../interfaces/sparsewritable.md#end)*
-
-*Inherited from Writable.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:3776*
+Defined in node_modules/@types/node/base.d.ts:3776
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
 
-*Inherited from Writable.end*
+▸ **end**(`chunk`: any, `cb?`: Function): *void*
 
-*Defined in /node_modules/@types/node/base.d.ts:3777*
+*Inherited from [CountingWritable](countingwritable.md).[end](countingwritable.md#end)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` cb | `Function` |
-
-**Returns:** `void`
-
-*Inherited from Writable.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:3778*
+Defined in node_modules/@types/node/base.d.ts:3777
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
+
+▸ **end**(`chunk`: any, `encoding?`: undefined | string, `cb?`: Function): *void*
+
+*Inherited from [CountingWritable](countingwritable.md).[end](countingwritable.md#end)*
+
+Defined in node_modules/@types/node/base.d.ts:3778
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
+
+**Returns:** *void*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Implementation of [SparseWritable](../interfaces/sparsewritable.md).[eventNames](../interfaces/sparsewritable.md#eventnames)*
+*Implementation of [SparseWritable](../interfaces/sparsewritable.md)*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+Defined in node_modules/@types/node/base.d.ts:694
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
-
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Implementation of [SparseWritable](../interfaces/sparsewritable.md).[getMaxListeners](../interfaces/sparsewritable.md#getmaxlisteners)*
+*Implementation of [SparseWritable](../interfaces/sparsewritable.md)*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+Defined in node_modules/@types/node/base.d.ts:691
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
-
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Implementation of [SparseWritable](../interfaces/sparsewritable.md).[listenerCount](../interfaces/sparsewritable.md#listenercount)*
+*Implementation of [SparseWritable](../interfaces/sparsewritable.md)*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Implementation of [SparseWritable](../interfaces/sparsewritable.md).[listeners](../interfaces/sparsewritable.md#listeners)*
+*Implementation of [SparseWritable](../interfaces/sparsewritable.md)*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string, `listener`: Function): *this*
 
-▸ **on**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
 
-▸ **on**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-▸ **on**(event: *"error"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3806*
+Defined in node_modules/@types/node/base.d.ts:3806
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.on*
+▸ **on**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.on*
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3807*
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3808*
+Defined in node_modules/@types/node/base.d.ts:3807
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.on*
+▸ (): *void*
 
-*Overrides EventEmitter.on*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3809*
+▸ **on**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Returns:** `this`
-
-*Inherited from Writable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3810*
+Defined in node_modules/@types/node/base.d.ts:3808
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.on*
+▸ (): *void*
 
-*Overrides EventEmitter.on*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3811*
+▸ **on**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Returns:** `this`
-
-*Inherited from Writable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3812*
+Defined in node_modules/@types/node/base.d.ts:3809
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **on**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3810
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **on**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3811
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **on**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[on](countingwritable.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3812
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string, `listener`: Function): *this*
 
-▸ **once**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
 
-▸ **once**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-▸ **once**(event: *"error"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3814*
+Defined in node_modules/@types/node/base.d.ts:3814
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.once*
+▸ **once**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.once*
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3815*
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3816*
+Defined in node_modules/@types/node/base.d.ts:3815
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.once*
+▸ (): *void*
 
-*Overrides EventEmitter.once*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3817*
+▸ **once**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Returns:** `this`
-
-*Inherited from Writable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3818*
+Defined in node_modules/@types/node/base.d.ts:3816
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.once*
+▸ (): *void*
 
-*Overrides EventEmitter.once*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3819*
+▸ **once**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Returns:** `this`
-
-*Inherited from Writable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3820*
+Defined in node_modules/@types/node/base.d.ts:3817
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **once**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3818
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **once**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3819
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **once**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[once](countingwritable.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3820
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="pipe"></a>
 
 ###  pipe
 
-▸ **pipe**<`T`>(destination: *`T`*, options?: *`undefined` \| `object`*): `T`
+▸ **pipe**<**T**>(`destination`: T, `options?`: undefined | object): *T*
 
-*Inherited from internal.pipe*
+*Inherited from [CountingWritable](countingwritable.md).[pipe](countingwritable.md#pipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3673*
+Defined in node_modules/@types/node/base.d.ts:3673
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| destination | `T` |
-| `Optional` options | `undefined` \| `object` |
+Name | Type |
+------ | ------ |
+`destination` | T |
+`options?` | undefined &#124; object |
 
-**Returns:** `T`
+**Returns:** *T*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
 
-▸ **prependListener**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-▸ **prependListener**(event: *"error"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3822*
+Defined in node_modules/@types/node/base.d.ts:3822
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.prependListener*
+▸ **prependListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependListener*
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3823*
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3824*
+Defined in node_modules/@types/node/base.d.ts:3823
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.prependListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3825*
+▸ **prependListener**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3826*
+Defined in node_modules/@types/node/base.d.ts:3824
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.prependListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3827*
+▸ **prependListener**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3828*
+Defined in node_modules/@types/node/base.d.ts:3825
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3826
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3827
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependListener](countingwritable.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3828
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependOnceListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"error"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3830*
+Defined in node_modules/@types/node/base.d.ts:3830
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.prependOnceListener*
+▸ **prependOnceListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependOnceListener*
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3831*
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3832*
+Defined in node_modules/@types/node/base.d.ts:3831
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.prependOnceListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependOnceListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3833*
+▸ **prependOnceListener**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3834*
+Defined in node_modules/@types/node/base.d.ts:3832
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.prependOnceListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependOnceListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3835*
+▸ **prependOnceListener**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3836*
+Defined in node_modules/@types/node/base.d.ts:3833
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3834
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3835
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[prependOnceListener](countingwritable.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3836
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Implementation of [SparseWritable](../interfaces/sparsewritable.md).[removeAllListeners](../interfaces/sparsewritable.md#removealllisteners)*
+*Implementation of [SparseWritable](../interfaces/sparsewritable.md)*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string, `listener`: Function): *this*
 
-▸ **removeListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
 
-▸ **removeListener**(event: *"drain"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-▸ **removeListener**(event: *"error"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"finish"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"pipe"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"unpipe"*, listener: *`function`*): `this`
-
-*Inherited from Writable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3838*
+Defined in node_modules/@types/node/base.d.ts:3838
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Writable.removeListener*
+▸ **removeListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.removeListener*
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3839*
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Writable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3840*
+Defined in node_modules/@types/node/base.d.ts:3839
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "drain" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.removeListener*
+▸ (): *void*
 
-*Overrides EventEmitter.removeListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3841*
+▸ **removeListener**(`event`: "drain", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3842*
+Defined in node_modules/@types/node/base.d.ts:3840
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "finish" |
-| listener | `function` |
+▪ **event**: *"drain"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Writable.removeListener*
+▸ (): *void*
 
-*Overrides EventEmitter.removeListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3843*
+▸ **removeListener**(`event`: "error", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "pipe" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Returns:** `this`
-
-*Inherited from Writable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3844*
+Defined in node_modules/@types/node/base.d.ts:3841
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "unpipe" |
-| listener | `function` |
+▪ **event**: *"error"*
 
-**Returns:** `this`
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "finish", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3842
+
+**Parameters:**
+
+▪ **event**: *"finish"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "pipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3843
+
+**Parameters:**
+
+▪ **event**: *"pipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "unpipe", `listener`: function): *this*
+
+*Inherited from [CountingWritable](countingwritable.md).[removeListener](countingwritable.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3844
+
+**Parameters:**
+
+▪ **event**: *"unpipe"*
+
+▪ **listener**: *function*
+
+▸ (`src`: Readable): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`src` | Readable |
+
+**Returns:** *this*
 
 ___
-<a id="setdefaultencoding"></a>
 
 ###  setDefaultEncoding
 
-▸ **setDefaultEncoding**(encoding: *`string`*): `this`
+▸ **setDefaultEncoding**(`encoding`: string): *this*
 
-*Inherited from Writable.setDefaultEncoding*
+*Inherited from [CountingWritable](countingwritable.md).[setDefaultEncoding](countingwritable.md#setdefaultencoding)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3775*
+Defined in node_modules/@types/node/base.d.ts:3775
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| encoding | `string` |
+Name | Type |
+------ | ------ |
+`encoding` | string |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Implementation of [SparseWritable](../interfaces/sparsewritable.md).[setMaxListeners](../interfaces/sparsewritable.md#setmaxlisteners)*
+*Implementation of [SparseWritable](../interfaces/sparsewritable.md)*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(chunk: *`any`*, cb?: *`Function`*): `boolean`
+▸ **write**(`chunk`: any, `cb?`: Function): *boolean*
 
-▸ **write**(chunk: *`any`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `boolean`
+*Inherited from [CountingWritable](countingwritable.md).[write](countingwritable.md#write)*
 
-*Inherited from Writable.write*
-
-*Defined in /node_modules/@types/node/base.d.ts:3773*
+Defined in node_modules/@types/node/base.d.ts:3773
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`cb?` | Function |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Writable.write*
+▸ **write**(`chunk`: any, `encoding?`: undefined | string, `cb?`: Function): *boolean*
 
-*Defined in /node_modules/@types/node/base.d.ts:3774*
+*Inherited from [CountingWritable](countingwritable.md).[write](countingwritable.md#write)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
-
-**Returns:** `boolean`
-
-___
-<a id="writechunk"></a>
-
-### `<Private>` writeChunk
-
-▸ **writeChunk**(chunk: *[SparseStreamChunk](../interfaces/sparsestreamchunk.md)*, flushing?: *`boolean`*): `Promise`<`void`>
-
-*Defined in [sparse-stream/sparse-write-stream.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-write-stream.ts#L32)*
+Defined in node_modules/@types/node/base.d.ts:3774
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| chunk | [SparseStreamChunk](../interfaces/sparsestreamchunk.md) | - |
-| `Default value` flushing | `boolean` | false |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
 
-**Returns:** `Promise`<`void`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
-
-**Returns:** `number`
+**Returns:** *boolean*
 
 ___
 
+### `Private` writeChunk
+
+▸ **writeChunk**(`chunk`: [SparseStreamChunk](../interfaces/sparsestreamchunk.md), `flushing`: boolean): *Promise‹void›*
+
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-write-stream.ts#L32)*
+
+**Parameters:**
+
+Name | Type | Default |
+------ | ------ | ------ |
+`chunk` | [SparseStreamChunk](../interfaces/sparsestreamchunk.md) | - |
+`flushing` | boolean | false |
+
+**Returns:** *Promise‹void›*
+
+___
+
+### `Static` listenerCount
+
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
+
+Defined in node_modules/@types/node/base.d.ts:680
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
+
+**Returns:** *number*

--- a/doc/classes/streamlimiter.md
+++ b/doc/classes/streamlimiter.md
@@ -1,17 +1,17 @@
-[etcher-sdk](../README.md) > [StreamLimiter](../classes/streamlimiter.md)
+[etcher-sdk](../README.md) › [StreamLimiter](streamlimiter.md)
 
 # Class: StreamLimiter
 
 ## Hierarchy
 
- `Transform`
+* Transform
 
-**↳ StreamLimiter**
+  ↳ **StreamLimiter**
 
 ## Implements
 
-* `ReadableStream`
-* `Writable`
+* ReadableStream
+* Writable
 
 ## Index
 
@@ -21,11 +21,11 @@
 
 ### Properties
 
-* [maxBytes](streamlimiter.md#maxbytes)
+* [maxBytes](streamlimiter.md#private-maxbytes)
 * [readable](streamlimiter.md#readable)
-* [stream](streamlimiter.md#stream)
+* [stream](streamlimiter.md#private-stream)
 * [writable](streamlimiter.md#writable)
-* [defaultMaxListeners](streamlimiter.md#defaultmaxlisteners)
+* [defaultMaxListeners](streamlimiter.md#static-defaultmaxlisteners)
 
 ### Methods
 
@@ -58,1323 +58,1376 @@
 * [unshift](streamlimiter.md#unshift)
 * [wrap](streamlimiter.md#wrap)
 * [write](streamlimiter.md#write)
-* [listenerCount](streamlimiter.md#listenercount-1)
-
----
+* [listenerCount](streamlimiter.md#static-listenercount)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new StreamLimiter**(stream: *`ReadableStream`*, maxBytes: *`number`*): [StreamLimiter](streamlimiter.md)
+\+ **new StreamLimiter**(`stream`: ReadableStream, `maxBytes`: number): *[StreamLimiter](streamlimiter.md)*
 
-*Overrides Transform.__constructor*
+*Overrides [SourceTransform](../interfaces/sourcetransform.md).[constructor](../interfaces/sourcetransform.md#constructor)*
 
-*Defined in [stream-limiter.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/stream-limiter.ts#L22)*
+*Defined in [lib/stream-limiter.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/stream-limiter.ts#L22)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| stream | `ReadableStream` |
-| maxBytes | `number` |
+Name | Type |
+------ | ------ |
+`stream` | ReadableStream |
+`maxBytes` | number |
 
-**Returns:** [StreamLimiter](streamlimiter.md)
-
-___
+**Returns:** *[StreamLimiter](streamlimiter.md)*
 
 ## Properties
 
-<a id="maxbytes"></a>
+### `Private` maxBytes
 
-### `<Private>` maxBytes
+• **maxBytes**: *number*
 
-**● maxBytes**: *`number`*
-
-*Defined in [stream-limiter.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/stream-limiter.ts#L23)*
+*Defined in [lib/stream-limiter.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/stream-limiter.ts#L23)*
 
 ___
-<a id="readable"></a>
 
 ###  readable
 
-**● readable**: *`boolean`*
+• **readable**: *boolean*
 
-*Inherited from Readable.readable*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[readable](sparsefilterstream.md#readable)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3688*
-
-___
-<a id="stream"></a>
-
-### `<Private>` stream
-
-**● stream**: *`ReadableStream`*
-
-*Defined in [stream-limiter.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/stream-limiter.ts#L23)*
+Defined in node_modules/@types/node/base.d.ts:3688
 
 ___
-<a id="writable"></a>
+
+### `Private` stream
+
+• **stream**: *ReadableStream*
+
+*Defined in [lib/stream-limiter.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/stream-limiter.ts#L23)*
+
+___
 
 ###  writable
 
-**● writable**: *`boolean`*
+• **writable**: *boolean*
 
-*Inherited from Duplex.writable*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[writable](sparsefilterstream.md#writable)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3855*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+Defined in node_modules/@types/node/base.d.ts:3855
 
 ___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="_read"></a>
-
 ###  _read
 
-▸ **_read**(size: *`number`*): `void`
+▸ **_read**(`size`: number): *void*
 
-*Inherited from Readable._read*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[_read](sparsefilterstream.md#_read)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3690*
+Defined in node_modules/@types/node/base.d.ts:3690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| size | `number` |
+Name | Type |
+------ | ------ |
+`size` | number |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="_transform"></a>
 
 ###  _transform
 
-▸ **_transform**(buffer: *`Buffer`*, _encoding: *`string`*, callback: *`function`*): `void`
+▸ **_transform**(`buffer`: Buffer, `_encoding`: string, `callback`: function): *void*
 
-*Overrides Transform._transform*
+*Overrides [SourceTransform](../interfaces/sourcetransform.md).[_transform](../interfaces/sourcetransform.md#_transform)*
 
-*Defined in [stream-limiter.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/stream-limiter.ts#L29)*
+*Defined in [lib/stream-limiter.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/stream-limiter.ts#L29)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| _encoding | `string` |
-| callback | `function` |
+▪ **buffer**: *Buffer*
 
-**Returns:** `void`
+▪ **_encoding**: *string*
+
+▪ **callback**: *function*
+
+▸ (`error?`: [Error](notcapable.md#static-error) | null, `data?`: Buffer): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`error?` | [Error](notcapable.md#static-error) &#124; null |
+`data?` | Buffer |
+
+**Returns:** *void*
 
 ___
-<a id="_write"></a>
 
 ###  _write
 
-▸ **_write**(chunk: *`any`*, encoding: *`string`*, callback: *`Function`*): `void`
+▸ **_write**(`chunk`: any, `encoding`: string, `callback`: Function): *void*
 
-*Inherited from Duplex._write*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[_write](sparsefilterstream.md#_write)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3857*
+Defined in node_modules/@types/node/base.d.ts:3857
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| encoding | `string` |
-| callback | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding` | string |
+`callback` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="addlistener"></a>
 
 ###  addListener
 
-▸ **addListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string, `listener`: Function): *this*
 
-▸ **addListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-▸ **addListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-▸ **addListener**(event: *"end"*, listener: *`function`*): `this`
+Defined in node_modules/@types/node/base.d.ts:3711
 
-▸ **addListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **addListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3711*
-
-Event emitter The defined events on documents including:
-
-1.  close
-2.  data
-3.  end
-4.  readable
-5.  error
+Event emitter
+The defined events on documents including:
+  1. close
+  2. data
+  3. end
+  4. readable
+  5. error
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.addListener*
+▸ **addListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.addListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3712*
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3713*
+Defined in node_modules/@types/node/base.d.ts:3712
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.addListener*
+▸ (): *void*
 
-*Overrides EventEmitter.addListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3714*
+▸ **addListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3715*
+Defined in node_modules/@types/node/base.d.ts:3713
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3716*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **addListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3714
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3715
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[addListener](sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3716
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-▸ **emit**(event: *"close"*): `boolean`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-▸ **emit**(event: *"data"*, chunk: *`Buffer` \| `string`*): `boolean`
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-▸ **emit**(event: *"end"*): `boolean`
-
-▸ **emit**(event: *"readable"*): `boolean`
-
-▸ **emit**(event: *"error"*, err: *`Error`*): `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3718*
+Defined in node_modules/@types/node/base.d.ts:3718
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "close"): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3719*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-
-**Returns:** `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3720*
+Defined in node_modules/@types/node/base.d.ts:3719
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| chunk | `Buffer` \| `string` |
+Name | Type |
+------ | ------ |
+`event` | "close" |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "data", `chunk`: Buffer | string): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3721*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-
-**Returns:** `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3722*
+Defined in node_modules/@types/node/base.d.ts:3720
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
+Name | Type |
+------ | ------ |
+`event` | "data" |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "end"): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3723*
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3721
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| err | `Error` |
+Name | Type |
+------ | ------ |
+`event` | "end" |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "readable"): *boolean*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3722
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "readable" |
+
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "error", `err`: [Error](notcapable.md#static-error)): *boolean*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[emit](sparsefilterstream.md#emit)*
+
+*Overrides [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3723
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "error" |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *boolean*
 
 ___
-<a id="end"></a>
 
 ###  end
 
-▸ **end**(cb?: *`Function`*): `void`
+▸ **end**(`cb?`: Function): *void*
 
-▸ **end**(chunk: *`any`*, cb?: *`Function`*): `void`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[end](sparsefilterstream.md#end)*
 
-▸ **end**(chunk: *`any`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `void`
-
-*Inherited from Duplex.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:3861*
+Defined in node_modules/@types/node/base.d.ts:3861
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
 
-*Inherited from Duplex.end*
+▸ **end**(`chunk`: any, `cb?`: Function): *void*
 
-*Defined in /node_modules/@types/node/base.d.ts:3862*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[end](sparsefilterstream.md#end)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` cb | `Function` |
-
-**Returns:** `void`
-
-*Inherited from Duplex.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:3863*
+Defined in node_modules/@types/node/base.d.ts:3862
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
+
+▸ **end**(`chunk`: any, `encoding?`: undefined | string, `cb?`: Function): *void*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[end](sparsefilterstream.md#end)*
+
+Defined in node_modules/@types/node/base.d.ts:3863
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
+
+**Returns:** *void*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+Defined in node_modules/@types/node/base.d.ts:694
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
-
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+Defined in node_modules/@types/node/base.d.ts:691
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
-
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="ispaused"></a>
 
 ###  isPaused
 
-▸ **isPaused**(): `boolean`
+▸ **isPaused**(): *boolean*
 
-*Inherited from Readable.isPaused*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[isPaused](sparsefilterstream.md#ispaused)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3695*
+Defined in node_modules/@types/node/base.d.ts:3695
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string, `listener`: Function): *this*
 
-▸ **on**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-▸ **on**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-▸ **on**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3725*
+Defined in node_modules/@types/node/base.d.ts:3725
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.on*
+▸ **on**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.on*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3726*
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3727*
+Defined in node_modules/@types/node/base.d.ts:3726
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.on*
+▸ (): *void*
 
-*Overrides EventEmitter.on*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3728*
+▸ **on**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-**Returns:** `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3729*
+Defined in node_modules/@types/node/base.d.ts:3727
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3730*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **on**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3728
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **on**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3729
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **on**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[on](sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3730
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string, `listener`: Function): *this*
 
-▸ **once**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-▸ **once**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-▸ **once**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3732*
+Defined in node_modules/@types/node/base.d.ts:3732
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.once*
+▸ **once**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.once*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3733*
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3734*
+Defined in node_modules/@types/node/base.d.ts:3733
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.once*
+▸ (): *void*
 
-*Overrides EventEmitter.once*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3735*
+▸ **once**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-**Returns:** `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3736*
+Defined in node_modules/@types/node/base.d.ts:3734
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3737*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **once**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3735
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **once**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3736
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **once**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[once](sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3737
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="pause"></a>
 
 ###  pause
 
-▸ **pause**(): `this`
+▸ **pause**(): *this*
 
-*Inherited from Readable.pause*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[pause](sparsefilterstream.md#pause)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3693*
+Defined in node_modules/@types/node/base.d.ts:3693
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="pipe"></a>
 
 ###  pipe
 
-▸ **pipe**<`T`>(destination: *`T`*, options?: *`undefined` \| `object`*): `T`
+▸ **pipe**<**T**>(`destination`: T, `options?`: undefined | object): *T*
 
-*Inherited from Readable.pipe*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[pipe](sparsefilterstream.md#pipe)*
 
-*Overrides internal.pipe*
+*Overrides [CountingWritable](countingwritable.md).[pipe](countingwritable.md#pipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3696*
+Defined in node_modules/@types/node/base.d.ts:3696
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| destination | `T` |
-| `Optional` options | `undefined` \| `object` |
+Name | Type |
+------ | ------ |
+`destination` | T |
+`options?` | undefined &#124; object |
 
-**Returns:** `T`
+**Returns:** *T*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-▸ **prependListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-▸ **prependListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3739*
+Defined in node_modules/@types/node/base.d.ts:3739
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.prependListener*
+▸ **prependListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3740*
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3741*
+Defined in node_modules/@types/node/base.d.ts:3740
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3742*
+▸ **prependListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3743*
+Defined in node_modules/@types/node/base.d.ts:3741
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3744*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3742
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3743
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependListener](sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3744
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependOnceListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3746*
+Defined in node_modules/@types/node/base.d.ts:3746
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.prependOnceListener*
+▸ **prependOnceListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependOnceListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3747*
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3748*
+Defined in node_modules/@types/node/base.d.ts:3747
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependOnceListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependOnceListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3749*
+▸ **prependOnceListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3750*
+Defined in node_modules/@types/node/base.d.ts:3748
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3751*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3749
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3750
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[prependOnceListener](sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3751
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="push"></a>
 
 ###  push
 
-▸ **push**(chunk: *`any`*, encoding?: *`undefined` \| `string`*): `boolean`
+▸ **push**(`chunk`: any, `encoding?`: undefined | string): *boolean*
 
-*Inherited from Readable.push*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[push](sparsefilterstream.md#push)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3700*
+Defined in node_modules/@types/node/base.d.ts:3700
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(size?: *`undefined` \| `number`*): `any`
+▸ **read**(`size?`: undefined | number): *any*
 
-*Inherited from Readable.read*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[read](sparsefilterstream.md#read)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3691*
+Defined in node_modules/@types/node/base.d.ts:3691
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`size?` | undefined &#124; number |
 
-**Returns:** `any`
+**Returns:** *any*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string, `listener`: Function): *this*
 
-▸ **removeListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-▸ **removeListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-▸ **removeListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3753*
+Defined in node_modules/@types/node/base.d.ts:3753
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.removeListener*
+▸ **removeListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.removeListener*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3754*
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3755*
+Defined in node_modules/@types/node/base.d.ts:3754
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.removeListener*
+▸ (): *void*
 
-*Overrides EventEmitter.removeListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3756*
+▸ **removeListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3757*
+Defined in node_modules/@types/node/base.d.ts:3755
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3758*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3756
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3757
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[removeListener](sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3758
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="resume"></a>
 
 ###  resume
 
-▸ **resume**(): `this`
+▸ **resume**(): *this*
 
-*Inherited from Readable.resume*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[resume](sparsefilterstream.md#resume)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3694*
+Defined in node_modules/@types/node/base.d.ts:3694
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setdefaultencoding"></a>
 
 ###  setDefaultEncoding
 
-▸ **setDefaultEncoding**(encoding: *`string`*): `this`
+▸ **setDefaultEncoding**(`encoding`: string): *this*
 
-*Inherited from Duplex.setDefaultEncoding*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[setDefaultEncoding](sparsefilterstream.md#setdefaultencoding)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3860*
+Defined in node_modules/@types/node/base.d.ts:3860
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| encoding | `string` |
+Name | Type |
+------ | ------ |
+`encoding` | string |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setencoding"></a>
 
 ###  setEncoding
 
-▸ **setEncoding**(encoding: *`string`*): `void`
+▸ **setEncoding**(`encoding`: string): *void*
 
-*Inherited from Readable.setEncoding*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[setEncoding](sparsefilterstream.md#setencoding)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3692*
+Defined in node_modules/@types/node/base.d.ts:3692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| encoding | `string` |
+Name | Type |
+------ | ------ |
+`encoding` | string |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="unpipe"></a>
 
 ###  unpipe
 
-▸ **unpipe**<`T`>(destination?: *[T]()*): `void`
+▸ **unpipe**<**T**>(`destination?`: T): *void*
 
-*Inherited from Readable.unpipe*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[unpipe](sparsefilterstream.md#unpipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3697*
+Defined in node_modules/@types/node/base.d.ts:3697
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` destination | [T]() |
+Name | Type |
+------ | ------ |
+`destination?` | T |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="unshift"></a>
 
 ###  unshift
 
-▸ **unshift**(chunk: *`any`*): `void`
+▸ **unshift**(`chunk`: any): *void*
 
-*Inherited from Readable.unshift*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[unshift](sparsefilterstream.md#unshift)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3698*
+Defined in node_modules/@types/node/base.d.ts:3698
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="wrap"></a>
 
 ###  wrap
 
-▸ **wrap**(oldStream: *`ReadableStream`*): `Readable`
+▸ **wrap**(`oldStream`: ReadableStream): *Readable*
 
-*Inherited from Readable.wrap*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[wrap](sparsefilterstream.md#wrap)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3699*
+Defined in node_modules/@types/node/base.d.ts:3699
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| oldStream | `ReadableStream` |
+Name | Type |
+------ | ------ |
+`oldStream` | ReadableStream |
 
-**Returns:** `Readable`
+**Returns:** *Readable*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(chunk: *`any`*, cb?: *`Function`*): `boolean`
+▸ **write**(`chunk`: any, `cb?`: Function): *boolean*
 
-▸ **write**(chunk: *`any`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `boolean`
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[write](sparsefilterstream.md#write)*
 
-*Inherited from Duplex.write*
-
-*Defined in /node_modules/@types/node/base.d.ts:3858*
+Defined in node_modules/@types/node/base.d.ts:3858
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`cb?` | Function |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Duplex.write*
+▸ **write**(`chunk`: any, `encoding?`: undefined | string, `cb?`: Function): *boolean*
 
-*Defined in /node_modules/@types/node/base.d.ts:3859*
+*Inherited from [SparseFilterStream](sparsefilterstream.md).[write](sparsefilterstream.md#write)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
-
-**Returns:** `boolean`
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:3859
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
 
-**Returns:** `number`
+**Returns:** *boolean*
 
 ___
 
+### `Static` listenerCount
+
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
+
+Defined in node_modules/@types/node/base.d.ts:680
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
+
+**Returns:** *number*

--- a/doc/classes/streamverifier.md
+++ b/doc/classes/streamverifier.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [StreamVerifier](../classes/streamverifier.md)
+[etcher-sdk](../README.md) › [StreamVerifier](streamverifier.md)
 
 # Class: StreamVerifier
 
 ## Hierarchy
 
-↳  [Verifier](verifier.md)
+  ↳ [Verifier](verifier.md)
 
-**↳ StreamVerifier**
+  ↳ **StreamVerifier**
 
 ## Index
 
@@ -16,10 +16,10 @@
 
 ### Properties
 
-* [checksum](streamverifier.md#checksum)
-* [size](streamverifier.md#size)
-* [source](streamverifier.md#source)
-* [defaultMaxListeners](streamverifier.md#defaultmaxlisteners)
+* [checksum](streamverifier.md#private-checksum)
+* [size](streamverifier.md#private-size)
+* [source](streamverifier.md#private-source)
+* [defaultMaxListeners](streamverifier.md#static-defaultmaxlisteners)
 
 ### Methods
 
@@ -27,7 +27,7 @@
 * [emit](streamverifier.md#emit)
 * [eventNames](streamverifier.md#eventnames)
 * [getMaxListeners](streamverifier.md#getmaxlisteners)
-* [handleEventsAndPipe](streamverifier.md#handleeventsandpipe)
+* [handleEventsAndPipe](streamverifier.md#protected-handleeventsandpipe)
 * [listenerCount](streamverifier.md#listenercount)
 * [listeners](streamverifier.md#listeners)
 * [on](streamverifier.md#on)
@@ -38,440 +38,393 @@
 * [removeListener](streamverifier.md#removelistener)
 * [run](streamverifier.md#run)
 * [setMaxListeners](streamverifier.md#setmaxlisteners)
-* [listenerCount](streamverifier.md#listenercount-1)
+* [listenerCount](streamverifier.md#static-listenercount)
 
 ### Object literals
 
 * [progress](streamverifier.md#progress)
 
----
-
 ## Constructors
-
-<a id="constructor"></a>
 
 ###  constructor
 
-⊕ **new StreamVerifier**(source: *[SourceDestination](sourcedestination.md)*, checksum: *`string`*, size: *`number`*): [StreamVerifier](streamverifier.md)
+\+ **new StreamVerifier**(`source`: [SourceDestination](sourcedestination.md), `checksum`: string, `size`: number): *[StreamVerifier](streamverifier.md)*
 
-*Defined in [source-destination/source-destination.ts:152](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L152)*
+*Defined in [lib/source-destination/source-destination.ts:152](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L152)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| source | [SourceDestination](sourcedestination.md) |
-| checksum | `string` |
-| size | `number` |
+Name | Type |
+------ | ------ |
+`source` | [SourceDestination](sourcedestination.md) |
+`checksum` | string |
+`size` | number |
 
-**Returns:** [StreamVerifier](streamverifier.md)
-
-___
+**Returns:** *[StreamVerifier](streamverifier.md)*
 
 ## Properties
 
-<a id="checksum"></a>
+### `Private` checksum
 
-### `<Private>` checksum
+• **checksum**: *string*
 
-**● checksum**: *`string`*
-
-*Defined in [source-destination/source-destination.ts:155](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L155)*
+*Defined in [lib/source-destination/source-destination.ts:155](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L155)*
 
 ___
-<a id="size"></a>
 
-### `<Private>` size
+### `Private` size
 
-**● size**: *`number`*
+• **size**: *number*
 
-*Defined in [source-destination/source-destination.ts:156](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L156)*
-
-___
-<a id="source"></a>
-
-### `<Private>` source
-
-**● source**: *[SourceDestination](sourcedestination.md)*
-
-*Defined in [source-destination/source-destination.ts:154](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L154)*
+*Defined in [lib/source-destination/source-destination.ts:156](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L156)*
 
 ___
-<a id="defaultmaxlisteners"></a>
 
-### `<Static>` defaultMaxListeners
+### `Private` source
 
-**● defaultMaxListeners**: *`number`*
+• **source**: *[SourceDestination](sourcedestination.md)*
 
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/source-destination.ts:154](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L154)*
 
 ___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="addlistener"></a>
-
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="handleeventsandpipe"></a>
 
-### `<Protected>` handleEventsAndPipe
+### `Protected` handleEventsAndPipe
 
-▸ **handleEventsAndPipe**(stream: *`ReadableStream`*, meter: *`WritableStream`*): `void`
+▸ **handleEventsAndPipe**(`stream`: ReadableStream, `meter`: WritableStream): *void*
 
-*Inherited from [Verifier](verifier.md).[handleEventsAndPipe](verifier.md#handleeventsandpipe)*
+*Inherited from [Verifier](verifier.md).[handleEventsAndPipe](verifier.md#protected-handleeventsandpipe)*
 
-*Defined in [source-destination/source-destination.ts:134](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L134)*
+*Defined in [lib/source-destination/source-destination.ts:134](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L134)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| stream | `ReadableStream` |
-| meter | `WritableStream` |
+Name | Type |
+------ | ------ |
+`stream` | ReadableStream |
+`meter` | WritableStream |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="run"></a>
 
 ###  run
 
-▸ **run**(): `Promise`<`void`>
+▸ **run**(): *Promise‹void›*
 
-*Overrides [Verifier](verifier.md).[run](verifier.md#run)*
+*Overrides [Verifier](verifier.md).[run](verifier.md#abstract-run)*
 
-*Defined in [source-destination/source-destination.ts:161](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L161)*
+*Defined in [lib/source-destination/source-destination.ts:161](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L161)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
-
-**Returns:** `this`
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `number`
+**Returns:** *this*
 
 ___
+
+### `Static` listenerCount
+
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
+
+Defined in node_modules/@types/node/base.d.ts:680
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
+
+**Returns:** *number*
 
 ## Object literals
 
-<a id="progress"></a>
-
 ###  progress
 
-**progress**: *`object`*
+### ▪ **progress**: *object*
 
 *Inherited from [Verifier](verifier.md).[progress](verifier.md#progress)*
 
-*Defined in [source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L130)*
+*Defined in [lib/source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L130)*
 
-<a id="progress.bytes"></a>
+###  bytes
 
-####  bytes
+• **bytes**: *number* = 0
 
-**● bytes**: *`number`* = 0
+*Defined in [lib/source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L130)*
 
-*Defined in [source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L130)*
+###  position
 
-___
-<a id="progress.position"></a>
+• **position**: *number* = 0
 
-####  position
+*Defined in [lib/source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L130)*
 
-**● position**: *`number`* = 0
+###  speed
 
-*Defined in [source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L130)*
+• **speed**: *number* = 0
 
-___
-<a id="progress.speed"></a>
-
-####  speed
-
-**● speed**: *`number`* = 0
-
-*Defined in [source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L130)*
-
-___
-
-___
-
+*Defined in [lib/source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L130)*

--- a/doc/classes/streamzipsource.md
+++ b/doc/classes/streamzipsource.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [StreamZipSource](../classes/streamzipsource.md)
+[etcher-sdk](../README.md) › [StreamZipSource](streamzipsource.md)
 
 # Class: StreamZipSource
 
 ## Hierarchy
 
-↳  [SourceSource](sourcesource.md)
+  ↳ [SourceSource](sourcesource.md)
 
-**↳ StreamZipSource**
+  ↳ **StreamZipSource**
 
 ## Index
 
@@ -16,19 +16,19 @@
 
 ### Properties
 
-* [entry](streamzipsource.md#entry)
-* [match](streamzipsource.md#match)
-* [source](streamzipsource.md#source)
-* [defaultMaxListeners](streamzipsource.md#defaultmaxlisteners)
-* [imageExtensions](streamzipsource.md#imageextensions)
-* [mimetype](streamzipsource.md#mimetype)
-* [requiresRandomReadableSource](streamzipsource.md#requiresrandomreadablesource)
+* [entry](streamzipsource.md#private-optional-entry)
+* [match](streamzipsource.md#private-match)
+* [source](streamzipsource.md#protected-source)
+* [defaultMaxListeners](streamzipsource.md#static-defaultmaxlisteners)
+* [imageExtensions](streamzipsource.md#static-imageextensions)
+* [mimetype](streamzipsource.md#static-optional-mimetype)
+* [requiresRandomReadableSource](streamzipsource.md#static-requiresrandomreadablesource)
 
 ### Methods
 
-* [_close](streamzipsource.md#_close)
-* [_getMetadata](streamzipsource.md#_getmetadata)
-* [_open](streamzipsource.md#_open)
+* [_close](streamzipsource.md#protected-_close)
+* [_getMetadata](streamzipsource.md#protected-_getmetadata)
+* [_open](streamzipsource.md#protected-_open)
 * [addListener](streamzipsource.md#addlistener)
 * [canCreateReadStream](streamzipsource.md#cancreatereadstream)
 * [canCreateSparseReadStream](streamzipsource.md#cancreatesparsereadstream)
@@ -45,7 +45,7 @@
 * [emit](streamzipsource.md#emit)
 * [eventNames](streamzipsource.md#eventnames)
 * [getBlocks](streamzipsource.md#getblocks)
-* [getEntry](streamzipsource.md#getentry)
+* [getEntry](streamzipsource.md#private-getentry)
 * [getInnerSource](streamzipsource.md#getinnersource)
 * [getMaxListeners](streamzipsource.md#getmaxlisteners)
 * [getMetadata](streamzipsource.md#getmetadata)
@@ -62,92 +62,86 @@
 * [removeListener](streamzipsource.md#removelistener)
 * [setMaxListeners](streamzipsource.md#setmaxlisteners)
 * [write](streamzipsource.md#write)
-* [listenerCount](streamzipsource.md#listenercount-1)
-* [register](streamzipsource.md#register)
-
----
+* [listenerCount](streamzipsource.md#static-listenercount)
+* [register](streamzipsource.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new StreamZipSource**(source: *[SourceDestination](sourcedestination.md)*, match?: *`function`*): [StreamZipSource](streamzipsource.md)
+\+ **new StreamZipSource**(`source`: [SourceDestination](sourcedestination.md), `match`: function): *[StreamZipSource](streamzipsource.md)*
 
 *Overrides [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
 
-*Defined in [source-destination/zip.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L70)*
+*Defined in [lib/source-destination/zip.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L70)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| source | [SourceDestination](sourcedestination.md) | - |
-| `Default value` match | `function` |  matchSupportedExtensions |
+▪ **source**: *[SourceDestination](sourcedestination.md)*
 
-**Returns:** [StreamZipSource](streamzipsource.md)
+▪`Default value`  **match**: *function*= matchSupportedExtensions
 
-___
+▸ (`filename`: string): *boolean*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`filename` | string |
+
+**Returns:** *[StreamZipSource](streamzipsource.md)*
 
 ## Properties
 
-<a id="entry"></a>
+### `Private` `Optional` entry
 
-### `<Private>``<Optional>` entry
+• **entry**? : *ZipStreamEntry*
 
-**● entry**: *`ZipStreamEntry`*
-
-*Defined in [source-destination/zip.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L70)*
+*Defined in [lib/source-destination/zip.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L70)*
 
 ___
-<a id="match"></a>
 
-### `<Private>` match
+### `Private` match
 
-**● match**: *`function`*
+• **match**: *function*
 
-*Defined in [source-destination/zip.ts:74](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L74)*
+*Defined in [lib/source-destination/zip.ts:74](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L74)*
 
-#### Type declaration
-▸(filename: *`string`*): `boolean`
+#### Type declaration:
+
+▸ (`filename`: string): *boolean*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| filename | `string` |
-
-**Returns:** `boolean`
+Name | Type |
+------ | ------ |
+`filename` | string |
 
 ___
-<a id="source"></a>
 
-### `<Protected>` source
+### `Protected` source
 
-**● source**: *[SourceDestination](sourcedestination.md)*
+• **source**: *[SourceDestination](sourcedestination.md)*
 
-*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#source)*
+*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
 
-*Defined in [source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L22)*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L22)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Static` defaultMaxListeners
 
-**● imageExtensions**: *`string`[]* =  [
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -160,681 +154,635 @@ ___
 		'wic',
 	]
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
-
-___
-<a id="mimetype"></a>
-
-### `<Static>``<Optional>` mimetype
-
-**● mimetype**: *`undefined` \| `string`*
-
-*Inherited from [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
-
-*Defined in [source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L244)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
-<a id="requiresrandomreadablesource"></a>
 
-### `<Static>` requiresRandomReadableSource
+### `Static` `Optional` mimetype
 
-**● requiresRandomReadableSource**: *`boolean`* = false
+▪ **mimetype**? : *undefined | string*
 
-*Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#requiresrandomreadablesource)*
+*Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
 
-*Defined in [source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L244)*
 
 ___
+
+### `Static` requiresRandomReadableSource
+
+▪ **requiresRandomReadableSource**: *boolean* = false
+
+*Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
+
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L20)*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Inherited from [SourceSource](sourcesource.md).[_close](sourcesource.md#protected-_close)*
 
-*Inherited from [SourceSource](sourcesource.md).[_close](sourcesource.md#_close)*
+*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#_close)*
+*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L30)*
 
-*Defined in [source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L30)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Overrides [SourceDestination](sourcedestination.md).[_getMetadata](sourcedestination.md#_getmetadata)*
+*Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [source-destination/zip.ts:118](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L118)*
+*Defined in [lib/source-destination/zip.ts:118](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L118)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Inherited from [SourceSource](sourcesource.md).[_open](sourcesource.md#_open)*
-
-*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#_open)*
-
-*Defined in [source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L26)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Inherited from [SourceSource](sourcesource.md).[_open](sourcesource.md#protected-_open)*
+
+*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
+
+*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L26)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/zip.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L79)*
+*Defined in [lib/source-destination/zip.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L79)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L268)*
+*Defined in [lib/source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L268)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseWriteStream](sourcedestination.md#cancreatesparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L276)*
+*Defined in [lib/source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L276)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateWriteStream](sourcedestination.md#cancreatewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L272)*
+*Defined in [lib/source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L272)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L256)*
+*Defined in [lib/source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L256)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canWrite](sourcedestination.md#canwrite)*
+*Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L260)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(_emitProgress?: *`boolean`*, start?: *`number`*, end?: *`undefined` \| `number`*): `Promise`<`ReadableStream`>
+▸ **createReadStream**(`_emitProgress`: boolean, `start`: number, `end?`: undefined | number): *Promise‹ReadableStream›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/zip.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L101)*
+*Defined in [lib/source-destination/zip.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L101)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _emitProgress | `boolean` | false |
-| `Default value` start | `number` | 0 |
-| `Optional` end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`_emitProgress` | boolean | false |
+`start` | number | 0 |
+`end?` | undefined &#124; number | - |
 
-**Returns:** `Promise`<`ReadableStream`>
+**Returns:** *Promise‹ReadableStream›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(_generateChecksums?: *`boolean`*): `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+▸ **createSparseReadStream**(`_generateChecksums`: boolean): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L317)*
+*Defined in [lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L317)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _generateChecksums | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`_generateChecksums` | boolean | false |
 
-**Returns:** `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseWriteStream](sourcedestination.md#createsparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L331)*
+*Defined in [lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L331)*
 
-**Returns:** `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+**Returns:** *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
 ___
-<a id="createverifier"></a>
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createWriteStream](sourcedestination.md#createwritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L327)*
+*Defined in [lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L327)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
-
-___
-<a id="getentry"></a>
-
-### `<Private>` getEntry
-
-▸ **getEntry**(): `Promise`<`ZipStreamEntry`>
-
-*Defined in [source-destination/zip.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L83)*
-
-**Returns:** `Promise`<`ZipStreamEntry`>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
+
+### `Private` getEntry
+
+▸ **getEntry**(): *Promise‹ZipStreamEntry›*
+
+*Defined in [lib/source-destination/zip.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L83)*
+
+**Returns:** *Promise‹ZipStreamEntry›*
+
+___
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_sourceOffset`: number): *Promise‹ReadResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[read](sourcedestination.md#read)*
+*Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L291)*
+*Defined in [lib/source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L291)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[write](sourcedestination.md#write)*
+*Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L300)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L300)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/classes/usbbootdeviceadapter.md
+++ b/doc/classes/usbbootdeviceadapter.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [UsbbootDeviceAdapter](../classes/usbbootdeviceadapter.md)
+[etcher-sdk](../README.md) › [UsbbootDeviceAdapter](usbbootdeviceadapter.md)
 
 # Class: UsbbootDeviceAdapter
 
 ## Hierarchy
 
-↳  [Adapter](adapter.md)
+  ↳ [Adapter](adapter.md)
 
-**↳ UsbbootDeviceAdapter**
+  ↳ **UsbbootDeviceAdapter**
 
 ## Index
 
@@ -16,9 +16,9 @@
 
 ### Properties
 
-* [drives](usbbootdeviceadapter.md#drives)
-* [scanner](usbbootdeviceadapter.md#scanner)
-* [defaultMaxListeners](usbbootdeviceadapter.md#defaultmaxlisteners)
+* [drives](usbbootdeviceadapter.md#private-drives)
+* [scanner](usbbootdeviceadapter.md#private-scanner)
+* [defaultMaxListeners](usbbootdeviceadapter.md#static-defaultmaxlisteners)
 
 ### Methods
 
@@ -29,8 +29,8 @@
 * [listenerCount](usbbootdeviceadapter.md#listenercount)
 * [listeners](usbbootdeviceadapter.md#listeners)
 * [on](usbbootdeviceadapter.md#on)
-* [onAttach](usbbootdeviceadapter.md#onattach)
-* [onDetach](usbbootdeviceadapter.md#ondetach)
+* [onAttach](usbbootdeviceadapter.md#private-onattach)
+* [onDetach](usbbootdeviceadapter.md#private-ondetach)
 * [once](usbbootdeviceadapter.md#once)
 * [prependListener](usbbootdeviceadapter.md#prependlistener)
 * [prependOnceListener](usbbootdeviceadapter.md#prependoncelistener)
@@ -39,404 +39,370 @@
 * [setMaxListeners](usbbootdeviceadapter.md#setmaxlisteners)
 * [start](usbbootdeviceadapter.md#start)
 * [stop](usbbootdeviceadapter.md#stop)
-* [listenerCount](usbbootdeviceadapter.md#listenercount-1)
-
----
+* [listenerCount](usbbootdeviceadapter.md#static-listenercount)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new UsbbootDeviceAdapter**(): [UsbbootDeviceAdapter](usbbootdeviceadapter.md)
+\+ **new UsbbootDeviceAdapter**(): *[UsbbootDeviceAdapter](usbbootdeviceadapter.md)*
 
-*Defined in [scanner/adapters/usbboot.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/usbboot.ts#L37)*
+*Defined in [lib/scanner/adapters/usbboot.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/usbboot.ts#L37)*
 
-**Returns:** [UsbbootDeviceAdapter](usbbootdeviceadapter.md)
-
-___
+**Returns:** *[UsbbootDeviceAdapter](usbbootdeviceadapter.md)*
 
 ## Properties
 
-<a id="drives"></a>
+### `Private` drives
 
-### `<Private>` drives
+• **drives**: *Map‹UsbbootDevice, [UsbbootDrive](usbbootdrive.md)›* = new Map()
 
-**● drives**: *`Map`<`UsbbootDevice`, [UsbbootDrive](usbbootdrive.md)>* =  new Map()
-
-*Defined in [scanner/adapters/usbboot.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/usbboot.ts#L36)*
+*Defined in [lib/scanner/adapters/usbboot.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/usbboot.ts#L36)*
 
 ___
-<a id="scanner"></a>
 
-### `<Private>` scanner
+### `Private` scanner
 
-**● scanner**: *`UsbbootScannerType`*
+• **scanner**: *UsbbootScannerType*
 
-*Defined in [scanner/adapters/usbboot.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/usbboot.ts#L37)*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/scanner/adapters/usbboot.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/usbboot.ts#L37)*
 
 ___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="addlistener"></a>
-
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
-
-**Returns:** `this`
-
-___
-<a id="onattach"></a>
-
-### `<Private>` onAttach
-
-▸ **onAttach**(device: *`UsbbootDevice`*): `void`
-
-*Defined in [scanner/adapters/usbboot.ts:61](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/usbboot.ts#L61)*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| device | `UsbbootDevice` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `void`
+**Returns:** *this*
 
 ___
-<a id="ondetach"></a>
 
-### `<Private>` onDetach
+### `Private` onAttach
 
-▸ **onDetach**(device: *`UsbbootDevice`*): `void`
+▸ **onAttach**(`device`: UsbbootDevice): *void*
 
-*Defined in [scanner/adapters/usbboot.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/usbboot.ts#L70)*
+*Defined in [lib/scanner/adapters/usbboot.ts:61](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/usbboot.ts#L61)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| device | `UsbbootDevice` |
+Name | Type |
+------ | ------ |
+`device` | UsbbootDevice |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="once"></a>
+
+### `Private` onDetach
+
+▸ **onDetach**(`device`: UsbbootDevice): *void*
+
+*Defined in [lib/scanner/adapters/usbboot.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/usbboot.ts#L70)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`device` | UsbbootDevice |
+
+**Returns:** *void*
+
+___
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="start"></a>
 
 ###  start
 
-▸ **start**(): `void`
+▸ **start**(): *void*
 
-*Overrides [Adapter](adapter.md).[start](adapter.md#start)*
+*Overrides [Adapter](adapter.md).[start](adapter.md#abstract-start)*
 
-*Defined in [scanner/adapters/usbboot.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/usbboot.ts#L53)*
+*Defined in [lib/scanner/adapters/usbboot.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/usbboot.ts#L53)*
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="stop"></a>
 
 ###  stop
 
-▸ **stop**(): `void`
+▸ **stop**(): *void*
 
-*Overrides [Adapter](adapter.md).[stop](adapter.md#stop)*
+*Overrides [Adapter](adapter.md).[stop](adapter.md#abstract-stop)*
 
-*Defined in [scanner/adapters/usbboot.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/usbboot.ts#L57)*
+*Defined in [lib/scanner/adapters/usbboot.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/usbboot.ts#L57)*
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="listenercount-1"></a>
 
-### `<Static>` listenerCount
+### `Static` listenerCount
 
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `number`
-
-___
-
+**Returns:** *number*

--- a/doc/classes/usbbootdrive.md
+++ b/doc/classes/usbbootdrive.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [UsbbootDrive](../classes/usbbootdrive.md)
+[etcher-sdk](../README.md) › [UsbbootDrive](usbbootdrive.md)
 
 # Class: UsbbootDrive
 
 ## Hierarchy
 
-↳  [SourceDestination](sourcedestination.md)
+  ↳ [SourceDestination](sourcedestination.md)
 
-**↳ UsbbootDrive**
+  ↳ **UsbbootDrive**
 
 ## Implements
 
@@ -33,15 +33,15 @@
 * [raw](usbbootdrive.md#raw)
 * [size](usbbootdrive.md#size)
 * [usbDevice](usbbootdrive.md#usbdevice)
-* [defaultMaxListeners](usbbootdrive.md#defaultmaxlisteners)
-* [imageExtensions](usbbootdrive.md#imageextensions)
-* [mimetype](usbbootdrive.md#mimetype)
+* [defaultMaxListeners](usbbootdrive.md#static-defaultmaxlisteners)
+* [imageExtensions](usbbootdrive.md#static-imageextensions)
+* [mimetype](usbbootdrive.md#static-optional-mimetype)
 
 ### Methods
 
-* [_close](usbbootdrive.md#_close)
-* [_getMetadata](usbbootdrive.md#_getmetadata)
-* [_open](usbbootdrive.md#_open)
+* [_close](usbbootdrive.md#protected-_close)
+* [_getMetadata](usbbootdrive.md#protected-_getmetadata)
+* [_open](usbbootdrive.md#protected-_open)
 * [addListener](usbbootdrive.md#addlistener)
 * [canCreateReadStream](usbbootdrive.md#cancreatereadstream)
 * [canCreateSparseReadStream](usbbootdrive.md#cancreatesparsereadstream)
@@ -74,184 +74,162 @@
 * [removeListener](usbbootdrive.md#removelistener)
 * [setMaxListeners](usbbootdrive.md#setmaxlisteners)
 * [write](usbbootdrive.md#write)
-* [listenerCount](usbbootdrive.md#listenercount-1)
-* [register](usbbootdrive.md#register)
-
----
+* [listenerCount](usbbootdrive.md#static-listenercount)
+* [register](usbbootdrive.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new UsbbootDrive**(usbDevice: *`UsbbootDevice`*): [UsbbootDrive](usbbootdrive.md)
+\+ **new UsbbootDrive**(`usbDevice`: UsbbootDevice): *[UsbbootDrive](usbbootdrive.md)*
 
-*Defined in [source-destination/usbboot.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/usbboot.ts#L35)*
+*Defined in [lib/source-destination/usbboot.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/usbboot.ts#L35)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| usbDevice | `UsbbootDevice` |
+Name | Type |
+------ | ------ |
+`usbDevice` | UsbbootDevice |
 
-**Returns:** [UsbbootDrive](usbbootdrive.md)
-
-___
+**Returns:** *[UsbbootDrive](usbbootdrive.md)*
 
 ## Properties
 
-<a id="description"></a>
-
 ###  description
 
-**● description**: *`string`* = "Compute Module"
+• **description**: *string* = "Compute Module"
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[description](../interfaces/adaptersourcedestination.md#description)*
 
-*Defined in [source-destination/usbboot.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/usbboot.ts#L30)*
+*Defined in [lib/source-destination/usbboot.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/usbboot.ts#L30)*
 
 ___
-<a id="device"></a>
 
 ###  device
 
-**● device**: *`null`* =  null
+• **device**: *null* = null
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[device](../interfaces/adaptersourcedestination.md#device)*
 
-*Defined in [source-destination/usbboot.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/usbboot.ts#L26)*
+*Defined in [lib/source-destination/usbboot.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/usbboot.ts#L26)*
 
 ___
-<a id="devicepath"></a>
 
 ###  devicePath
 
-**● devicePath**: *`null`* =  null
+• **devicePath**: *null* = null
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[devicePath](../interfaces/adaptersourcedestination.md#devicepath)*
 
-*Defined in [source-destination/usbboot.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/usbboot.ts#L27)*
+*Defined in [lib/source-destination/usbboot.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/usbboot.ts#L27)*
 
 ___
-<a id="disabled"></a>
 
 ###  disabled
 
-**● disabled**: *`boolean`* = true
+• **disabled**: *boolean* = true
 
-*Defined in [source-destination/usbboot.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/usbboot.ts#L33)*
+*Defined in [lib/source-destination/usbboot.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/usbboot.ts#L33)*
 
 ___
-<a id="displayname"></a>
 
 ###  displayName
 
-**● displayName**: *`string`* = "Initializing device"
+• **displayName**: *string* = "Initializing device"
 
-*Defined in [source-destination/usbboot.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/usbboot.ts#L25)*
+*Defined in [lib/source-destination/usbboot.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/usbboot.ts#L25)*
 
 ___
-<a id="emitsprogress"></a>
 
 ###  emitsProgress
 
-**● emitsProgress**: *`boolean`* = true
+• **emitsProgress**: *boolean* = true
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[emitsProgress](../interfaces/adaptersourcedestination.md#emitsprogress)*
 
-*Defined in [source-destination/usbboot.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/usbboot.ts#L35)*
+*Defined in [lib/source-destination/usbboot.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/usbboot.ts#L35)*
 
 ___
-<a id="icon"></a>
 
 ###  icon
 
-**● icon**: *`string`* = "loading"
+• **icon**: *string* = "loading"
 
-*Defined in [source-destination/usbboot.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/usbboot.ts#L28)*
+*Defined in [lib/source-destination/usbboot.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/usbboot.ts#L28)*
 
 ___
-<a id="isreadonly"></a>
 
 ###  isReadOnly
 
-**● isReadOnly**: *`boolean`* = false
+• **isReadOnly**: *boolean* = false
 
-*Defined in [source-destination/usbboot.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/usbboot.ts#L32)*
+*Defined in [lib/source-destination/usbboot.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/usbboot.ts#L32)*
 
 ___
-<a id="issystem"></a>
 
 ###  isSystem
 
-**● isSystem**: *`boolean`* = false
+• **isSystem**: *boolean* = false
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[isSystem](../interfaces/adaptersourcedestination.md#issystem)*
 
-*Defined in [source-destination/usbboot.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/usbboot.ts#L29)*
+*Defined in [lib/source-destination/usbboot.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/usbboot.ts#L29)*
 
 ___
-<a id="mountpoints"></a>
 
 ###  mountpoints
 
-**● mountpoints**: *`never`[]* =  []
+• **mountpoints**: *never[]* = []
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[mountpoints](../interfaces/adaptersourcedestination.md#mountpoints)*
 
-*Defined in [source-destination/usbboot.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/usbboot.ts#L31)*
+*Defined in [lib/source-destination/usbboot.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/usbboot.ts#L31)*
 
 ___
-<a id="raw"></a>
 
 ###  raw
 
-**● raw**: *`null`* =  null
+• **raw**: *null* = null
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[raw](../interfaces/adaptersourcedestination.md#raw)*
 
-*Defined in [source-destination/usbboot.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/usbboot.ts#L24)*
+*Defined in [lib/source-destination/usbboot.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/usbboot.ts#L24)*
 
 ___
-<a id="size"></a>
 
 ###  size
 
-**● size**: *`null`* =  null
+• **size**: *null* = null
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[size](../interfaces/adaptersourcedestination.md#size)*
 
-*Defined in [source-destination/usbboot.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/usbboot.ts#L34)*
+*Defined in [lib/source-destination/usbboot.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/usbboot.ts#L34)*
 
 ___
-<a id="usbdevice"></a>
 
 ###  usbDevice
 
-**● usbDevice**: *`UsbbootDevice`*
+• **usbDevice**: *UsbbootDevice*
 
-*Defined in [source-destination/usbboot.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/usbboot.ts#L37)*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[defaultMaxListeners](../interfaces/adaptersourcedestination.md#defaultmaxlisteners)*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/usbboot.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/usbboot.ts#L37)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Static` defaultMaxListeners
 
-**● imageExtensions**: *`string`[]* =  [
+▪ **defaultMaxListeners**: *number*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[defaultMaxListeners](../interfaces/adaptersourcedestination.md#static-defaultmaxlisteners)*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -264,733 +242,689 @@ ___
 		'wic',
 	]
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[imageExtensions](../interfaces/adaptersourcedestination.md#imageextensions)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[imageExtensions](../interfaces/adaptersourcedestination.md#static-imageextensions)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
-
-___
-<a id="mimetype"></a>
-
-### `<Static>``<Optional>` mimetype
-
-**● mimetype**: *`undefined` \| `string`*
-
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[mimetype](../interfaces/adaptersourcedestination.md#mimetype)*
-
-*Inherited from [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
-
-*Defined in [source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L244)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
+
+### `Static` `Optional` mimetype
+
+▪ **mimetype**? : *undefined | string*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[mimetype](../interfaces/adaptersourcedestination.md#static-optional-mimetype)*
+
+*Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
+
+*Defined in [lib/source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L244)*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[_close](../interfaces/adaptersourcedestination.md#_close)*
+*Inherited from [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#_close)*
+*Defined in [lib/source-destination/source-destination.ts:353](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L353)*
 
-*Defined in [source-destination/source-destination.ts:353](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L353)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[_getMetadata](../interfaces/adaptersourcedestination.md#_getmetadata)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[_getMetadata](sourcedestination.md#_getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:287](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L287)*
+*Defined in [lib/source-destination/source-destination.ts:287](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L287)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[_open](../interfaces/adaptersourcedestination.md#_open)*
-
-*Inherited from [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#_open)*
-
-*Defined in [source-destination/source-destination.ts:349](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L349)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
+*Inherited from [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
+
+*Defined in [lib/source-destination/source-destination.ts:349](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L349)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[addListener](../interfaces/adaptersourcedestination.md#addlistener)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canCreateReadStream](../interfaces/adaptersourcedestination.md#cancreatereadstream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/source-destination.ts:264](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L264)*
+*Defined in [lib/source-destination/source-destination.ts:264](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L264)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canCreateSparseReadStream](../interfaces/adaptersourcedestination.md#cancreatesparsereadstream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L268)*
+*Defined in [lib/source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L268)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canCreateSparseWriteStream](../interfaces/adaptersourcedestination.md#cancreatesparsewritestream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseWriteStream](sourcedestination.md#cancreatesparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L276)*
+*Defined in [lib/source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L276)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canCreateWriteStream](../interfaces/adaptersourcedestination.md#cancreatewritestream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateWriteStream](sourcedestination.md#cancreatewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L272)*
+*Defined in [lib/source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L272)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canRead](../interfaces/adaptersourcedestination.md#canread)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L256)*
+*Defined in [lib/source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L256)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[canWrite](../interfaces/adaptersourcedestination.md#canwrite)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canWrite](sourcedestination.md#canwrite)*
+*Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L260)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[close](../interfaces/adaptersourcedestination.md#close)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(_emitProgress?: *`boolean`*, _start?: *`number`*, _end?: *`undefined` \| `number`*): `Promise`<`ReadableStream`>
+▸ **createReadStream**(`_emitProgress`: boolean, `_start`: number, `_end?`: undefined | number): *Promise‹ReadableStream›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[createReadStream](../interfaces/adaptersourcedestination.md#createreadstream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Inherited from [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/source-destination.ts:309](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L309)*
+*Defined in [lib/source-destination/source-destination.ts:309](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L309)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _emitProgress | `boolean` | false |
-| `Default value` _start | `number` | 0 |
-| `Optional` _end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`_emitProgress` | boolean | false |
+`_start` | number | 0 |
+`_end?` | undefined &#124; number | - |
 
-**Returns:** `Promise`<`ReadableStream`>
+**Returns:** *Promise‹ReadableStream›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(_generateChecksums?: *`boolean`*): `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+▸ **createSparseReadStream**(`_generateChecksums`: boolean): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[createSparseReadStream](../interfaces/adaptersourcedestination.md#createsparsereadstream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L317)*
+*Defined in [lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L317)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _generateChecksums | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`_generateChecksums` | boolean | false |
 
-**Returns:** `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[createSparseWriteStream](../interfaces/adaptersourcedestination.md#createsparsewritestream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseWriteStream](sourcedestination.md#createsparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L331)*
+*Defined in [lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L331)*
 
-**Returns:** `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+**Returns:** *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
 ___
-<a id="createverifier"></a>
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[createVerifier](../interfaces/adaptersourcedestination.md#createverifier)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[createWriteStream](../interfaces/adaptersourcedestination.md#createwritestream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createWriteStream](sourcedestination.md#createwritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L327)*
+*Defined in [lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L327)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[emit](../interfaces/adaptersourcedestination.md#emit)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[eventNames](../interfaces/adaptersourcedestination.md#eventnames)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[getBlocks](../interfaces/adaptersourcedestination.md#getblocks)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[getInnerSource](../interfaces/adaptersourcedestination.md#getinnersource)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[getMaxListeners](../interfaces/adaptersourcedestination.md#getmaxlisteners)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[getMetadata](../interfaces/adaptersourcedestination.md#getmetadata)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[getPartitionTable](../interfaces/adaptersourcedestination.md#getpartitiontable)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[listenerCount](../interfaces/adaptersourcedestination.md#listenercount)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[listeners](../interfaces/adaptersourcedestination.md#listeners)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[on](../interfaces/adaptersourcedestination.md#on)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[once](../interfaces/adaptersourcedestination.md#once)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[open](../interfaces/adaptersourcedestination.md#open)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[prependListener](../interfaces/adaptersourcedestination.md#prependlistener)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[prependOnceListener](../interfaces/adaptersourcedestination.md#prependoncelistener)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_sourceOffset`: number): *Promise‹ReadResult›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[read](../interfaces/adaptersourcedestination.md#read)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[read](sourcedestination.md#read)*
+*Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L291)*
+*Defined in [lib/source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L291)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[removeAllListeners](../interfaces/adaptersourcedestination.md#removealllisteners)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[removeListener](../interfaces/adaptersourcedestination.md#removelistener)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[setMaxListeners](../interfaces/adaptersourcedestination.md#setmaxlisteners)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[write](../interfaces/adaptersourcedestination.md#write)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[write](sourcedestination.md#write)*
+*Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L300)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[listenerCount](../interfaces/adaptersourcedestination.md#listenercount-1)*
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L300)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[register](../interfaces/adaptersourcedestination.md#register)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/classes/verificationerror.md
+++ b/doc/classes/verificationerror.md
@@ -1,16 +1,16 @@
-[etcher-sdk](../README.md) > [VerificationError](../classes/verificationerror.md)
+[etcher-sdk](../README.md) › [VerificationError](verificationerror.md)
 
 # Class: VerificationError
 
 ## Hierarchy
 
- `Error`
+* [Error](notcapable.md#static-error)
 
-**↳ VerificationError**
+  ↳ **VerificationError**
 
-↳  [ChecksumVerificationError](checksumverificationerror.md)
+  ↳ [ChecksumVerificationError](checksumverificationerror.md)
 
-↳  [BlocksVerificationError](blocksverificationerror.md)
+  ↳ [BlocksVerificationError](blocksverificationerror.md)
 
 ## Index
 
@@ -19,64 +19,53 @@
 * [code](verificationerror.md#code)
 * [message](verificationerror.md#message)
 * [name](verificationerror.md#name)
-* [stack](verificationerror.md#stack)
-* [Error](verificationerror.md#error)
-
----
+* [stack](verificationerror.md#optional-stack)
+* [Error](verificationerror.md#static-error)
 
 ## Properties
 
-<a id="code"></a>
-
 ###  code
 
-**● code**: *`string`* = "EVALIDATION"
+• **code**: *string* = "EVALIDATION"
 
-*Defined in [errors.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/errors.ts#L24)*
+*Defined in [lib/errors.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/errors.ts#L24)*
 
 ___
-<a id="message"></a>
 
 ###  message
 
-**● message**: *`string`*
+• **message**: *string*
 
-*Inherited from Error.message*
+*Inherited from [NotCapable](notcapable.md).[message](notcapable.md#message)*
 
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:964*
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:974
 
 ___
-<a id="name"></a>
 
 ###  name
 
-**● name**: *`string`*
+• **name**: *string*
 
-*Inherited from Error.name*
+*Inherited from [NotCapable](notcapable.md).[name](notcapable.md#name)*
 
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:963*
-
-___
-<a id="stack"></a>
-
-### `<Optional>` stack
-
-**● stack**: *`undefined` \| `string`*
-
-*Inherited from Error.stack*
-
-*Overrides Error.stack*
-
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:965*
-
-___
-<a id="error"></a>
-
-### `<Static>` Error
-
-**● Error**: *`ErrorConstructor`*
-
-*Defined in /node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:974*
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:973
 
 ___
 
+### `Optional` stack
+
+• **stack**? : *undefined | string*
+
+*Inherited from [NotCapable](notcapable.md).[stack](notcapable.md#optional-stack)*
+
+*Overrides [NotCapable](notcapable.md).[stack](notcapable.md#optional-stack)*
+
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:975
+
+___
+
+### `Static` Error
+
+▪ **Error**: *ErrorConstructor*
+
+Defined in node_modules/typedoc/node_modules/typescript/lib/lib.es5.d.ts:984

--- a/doc/classes/verifier.md
+++ b/doc/classes/verifier.md
@@ -1,24 +1,24 @@
-[etcher-sdk](../README.md) > [Verifier](../classes/verifier.md)
+[etcher-sdk](../README.md) › [Verifier](verifier.md)
 
 # Class: Verifier
 
 ## Hierarchy
 
- `EventEmitter`
+* EventEmitter
 
-**↳ Verifier**
+  ↳ **Verifier**
 
-↳  [StreamVerifier](streamverifier.md)
+  ↳ [StreamVerifier](streamverifier.md)
 
-↳  [SparseStreamVerifier](sparsestreamverifier.md)
+  ↳ [SparseStreamVerifier](sparsestreamverifier.md)
 
-↳  [MultiDestinationVerifier](multidestinationverifier.md)
+  ↳ [MultiDestinationVerifier](multidestinationverifier.md)
 
 ## Index
 
 ### Properties
 
-* [defaultMaxListeners](verifier.md#defaultmaxlisteners)
+* [defaultMaxListeners](verifier.md#static-defaultmaxlisteners)
 
 ### Methods
 
@@ -26,7 +26,7 @@
 * [emit](verifier.md#emit)
 * [eventNames](verifier.md#eventnames)
 * [getMaxListeners](verifier.md#getmaxlisteners)
-* [handleEventsAndPipe](verifier.md#handleeventsandpipe)
+* [handleEventsAndPipe](verifier.md#protected-handleeventsandpipe)
 * [listenerCount](verifier.md#listenercount)
 * [listeners](verifier.md#listeners)
 * [on](verifier.md#on)
@@ -35,387 +35,347 @@
 * [prependOnceListener](verifier.md#prependoncelistener)
 * [removeAllListeners](verifier.md#removealllisteners)
 * [removeListener](verifier.md#removelistener)
-* [run](verifier.md#run)
+* [run](verifier.md#abstract-run)
 * [setMaxListeners](verifier.md#setmaxlisteners)
-* [listenerCount](verifier.md#listenercount-1)
+* [listenerCount](verifier.md#static-listenercount)
 
 ### Object literals
 
 * [progress](verifier.md#progress)
 
----
-
 ## Properties
 
-<a id="defaultmaxlisteners"></a>
+### `Static` defaultMaxListeners
 
-### `<Static>` defaultMaxListeners
+▪ **defaultMaxListeners**: *number*
 
-**● defaultMaxListeners**: *`number`*
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
 
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
-
-___
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="addlistener"></a>
-
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="handleeventsandpipe"></a>
 
-### `<Protected>` handleEventsAndPipe
+### `Protected` handleEventsAndPipe
 
-▸ **handleEventsAndPipe**(stream: *`ReadableStream`*, meter: *`WritableStream`*): `void`
+▸ **handleEventsAndPipe**(`stream`: ReadableStream, `meter`: WritableStream): *void*
 
-*Defined in [source-destination/source-destination.ts:134](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L134)*
+*Defined in [lib/source-destination/source-destination.ts:134](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L134)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| stream | `ReadableStream` |
-| meter | `WritableStream` |
+Name | Type |
+------ | ------ |
+`stream` | ReadableStream |
+`meter` | WritableStream |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
-
-___
-<a id="run"></a>
-
-### `<Abstract>` run
-
-▸ **run**(): `Promise`<`void`>
-
-*Defined in [source-destination/source-destination.ts:132](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L132)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
+
+### `Abstract` run
+
+▸ **run**(): *Promise‹void›*
+
+*Defined in [lib/source-destination/source-destination.ts:132](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L132)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
-
-**Returns:** `this`
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `number`
+**Returns:** *this*
 
 ___
+
+### `Static` listenerCount
+
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
+
+Defined in node_modules/@types/node/base.d.ts:680
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
+
+**Returns:** *number*
 
 ## Object literals
 
-<a id="progress"></a>
-
 ###  progress
 
-**progress**: *`object`*
+### ▪ **progress**: *object*
 
-*Defined in [source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L130)*
+*Defined in [lib/source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L130)*
 
-<a id="progress.bytes"></a>
+###  bytes
 
-####  bytes
+• **bytes**: *number* = 0
 
-**● bytes**: *`number`* = 0
+*Defined in [lib/source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L130)*
 
-*Defined in [source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L130)*
+###  position
 
-___
-<a id="progress.position"></a>
+• **position**: *number* = 0
 
-####  position
+*Defined in [lib/source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L130)*
 
-**● position**: *`number`* = 0
+###  speed
 
-*Defined in [source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L130)*
+• **speed**: *number* = 0
 
-___
-<a id="progress.speed"></a>
-
-####  speed
-
-**● speed**: *`number`* = 0
-
-*Defined in [source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L130)*
-
-___
-
-___
-
+*Defined in [lib/source-destination/source-destination.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L130)*

--- a/doc/classes/xzsource.md
+++ b/doc/classes/xzsource.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [XzSource](../classes/xzsource.md)
+[etcher-sdk](../README.md) › [XzSource](xzsource.md)
 
 # Class: XzSource
 
 ## Hierarchy
 
-↳  [CompressedSource](compressedsource.md)
+  ↳ [CompressedSource](compressedsource.md)
 
-**↳ XzSource**
+  ↳ **XzSource**
 
 ## Index
 
@@ -16,18 +16,18 @@
 
 ### Properties
 
-* [isSizeEstimated](xzsource.md#issizeestimated)
-* [source](xzsource.md#source)
-* [defaultMaxListeners](xzsource.md#defaultmaxlisteners)
-* [imageExtensions](xzsource.md#imageextensions)
-* [mimetype](xzsource.md#mimetype)
-* [requiresRandomReadableSource](xzsource.md#requiresrandomreadablesource)
+* [isSizeEstimated](xzsource.md#protected-issizeestimated)
+* [source](xzsource.md#protected-source)
+* [defaultMaxListeners](xzsource.md#static-defaultmaxlisteners)
+* [imageExtensions](xzsource.md#static-imageextensions)
+* [mimetype](xzsource.md#static-mimetype)
+* [requiresRandomReadableSource](xzsource.md#static-requiresrandomreadablesource)
 
 ### Methods
 
-* [_close](xzsource.md#_close)
-* [_getMetadata](xzsource.md#_getmetadata)
-* [_open](xzsource.md#_open)
+* [_close](xzsource.md#protected-_close)
+* [_getMetadata](xzsource.md#protected-_getmetadata)
+* [_open](xzsource.md#protected-_open)
 * [addListener](xzsource.md#addlistener)
 * [canCreateReadStream](xzsource.md#cancreatereadstream)
 * [canCreateSparseReadStream](xzsource.md#cancreatesparsereadstream)
@@ -39,7 +39,7 @@
 * [createReadStream](xzsource.md#createreadstream)
 * [createSparseReadStream](xzsource.md#createsparsereadstream)
 * [createSparseWriteStream](xzsource.md#createsparsewritestream)
-* [createTransform](xzsource.md#createtransform)
+* [createTransform](xzsource.md#protected-createtransform)
 * [createVerifier](xzsource.md#createverifier)
 * [createWriteStream](xzsource.md#createwritestream)
 * [emit](xzsource.md#emit)
@@ -49,7 +49,7 @@
 * [getMaxListeners](xzsource.md#getmaxlisteners)
 * [getMetadata](xzsource.md#getmetadata)
 * [getPartitionTable](xzsource.md#getpartitiontable)
-* [getSize](xzsource.md#getsize)
+* [getSize](xzsource.md#protected-getsize)
 * [listenerCount](xzsource.md#listenercount)
 * [listeners](xzsource.md#listeners)
 * [on](xzsource.md#on)
@@ -62,73 +62,62 @@
 * [removeListener](xzsource.md#removelistener)
 * [setMaxListeners](xzsource.md#setmaxlisteners)
 * [write](xzsource.md#write)
-* [listenerCount](xzsource.md#listenercount-1)
-* [register](xzsource.md#register)
-
----
+* [listenerCount](xzsource.md#static-listenercount)
+* [register](xzsource.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new XzSource**(source: *[SourceDestination](sourcedestination.md)*): [XzSource](xzsource.md)
+\+ **new XzSource**(`source`: [SourceDestination](sourcedestination.md)): *[XzSource](xzsource.md)*
 
 *Inherited from [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
 
-*Defined in [source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L20)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| source | [SourceDestination](sourcedestination.md) |
+Name | Type |
+------ | ------ |
+`source` | [SourceDestination](sourcedestination.md) |
 
-**Returns:** [XzSource](xzsource.md)
-
-___
+**Returns:** *[XzSource](xzsource.md)*
 
 ## Properties
 
-<a id="issizeestimated"></a>
+### `Protected` isSizeEstimated
 
-### `<Protected>` isSizeEstimated
+• **isSizeEstimated**: *boolean* = false
 
-**● isSizeEstimated**: *`boolean`* = false
+*Inherited from [CompressedSource](compressedsource.md).[isSizeEstimated](compressedsource.md#protected-issizeestimated)*
 
-*Inherited from [CompressedSource](compressedsource.md).[isSizeEstimated](compressedsource.md#issizeestimated)*
-
-*Defined in [source-destination/compressed-source.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L44)*
+*Defined in [lib/source-destination/compressed-source.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L44)*
 
 ___
-<a id="source"></a>
 
-### `<Protected>` source
+### `Protected` source
 
-**● source**: *[SourceDestination](sourcedestination.md)*
+• **source**: *[SourceDestination](sourcedestination.md)*
 
-*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#source)*
+*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
 
-*Defined in [source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L22)*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L22)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Static` defaultMaxListeners
 
-**● imageExtensions**: *`string`[]* =  [
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -141,702 +130,655 @@ ___
 		'wic',
 	]
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
-
-___
-<a id="mimetype"></a>
-
-### `<Static>` mimetype
-
-**● mimetype**: *"application/x-xz"* = "application/x-xz"
-
-*Overrides [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
-
-*Defined in [source-destination/xz.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/xz.ts#L27)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
-<a id="requiresrandomreadablesource"></a>
 
-### `<Static>` requiresRandomReadableSource
+### `Static` mimetype
 
-**● requiresRandomReadableSource**: *`boolean`* = false
+▪ **mimetype**: *"application/x-xz"* = "application/x-xz"
 
-*Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#requiresrandomreadablesource)*
+*Overrides [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
 
-*Defined in [source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/xz.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/xz.ts#L27)*
 
 ___
+
+### `Static` requiresRandomReadableSource
+
+▪ **requiresRandomReadableSource**: *boolean* = false
+
+*Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
+
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L20)*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Inherited from [SourceSource](sourcesource.md).[_close](sourcesource.md#protected-_close)*
 
-*Inherited from [SourceSource](sourcesource.md).[_close](sourcesource.md#_close)*
+*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#_close)*
+*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L30)*
 
-*Defined in [source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L30)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [CompressedSource](compressedsource.md).[_getMetadata](compressedsource.md#_getmetadata)*
+*Inherited from [CompressedSource](compressedsource.md).[_getMetadata](compressedsource.md#protected-_getmetadata)*
 
-*Overrides [SourceDestination](sourcedestination.md).[_getMetadata](sourcedestination.md#_getmetadata)*
+*Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [source-destination/compressed-source.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L84)*
+*Defined in [lib/source-destination/compressed-source.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L84)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Inherited from [SourceSource](sourcesource.md).[_open](sourcesource.md#_open)*
-
-*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#_open)*
-
-*Defined in [source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L26)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Inherited from [SourceSource](sourcesource.md).[_open](sourcesource.md#protected-_open)*
+
+*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
+
+*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L26)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
 *Inherited from [CompressedSource](compressedsource.md).[canCreateReadStream](compressedsource.md#cancreatereadstream)*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/compressed-source.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L50)*
+*Defined in [lib/source-destination/compressed-source.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L50)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L268)*
+*Defined in [lib/source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L268)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseWriteStream](sourcedestination.md#cancreatesparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L276)*
+*Defined in [lib/source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L276)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateWriteStream](sourcedestination.md#cancreatewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L272)*
+*Defined in [lib/source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L272)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L256)*
+*Defined in [lib/source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L256)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canWrite](sourcedestination.md#canwrite)*
+*Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L260)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(emitProgress?: *`boolean`*, start?: *`number`*, end?: *`undefined` \| `number`*): `Promise`<[SourceTransform](../interfaces/sourcetransform.md)>
+▸ **createReadStream**(`emitProgress`: boolean, `start`: number, `end?`: undefined | number): *Promise‹[SourceTransform](../interfaces/sourcetransform.md)›*
 
 *Inherited from [CompressedSource](compressedsource.md).[createReadStream](compressedsource.md#createreadstream)*
 
-*Overrides [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/compressed-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L54)*
+*Defined in [lib/source-destination/compressed-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L54)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` emitProgress | `boolean` | false |
-| `Default value` start | `number` | 0 |
-| `Optional` end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`emitProgress` | boolean | false |
+`start` | number | 0 |
+`end?` | undefined &#124; number | - |
 
-**Returns:** `Promise`<[SourceTransform](../interfaces/sourcetransform.md)>
+**Returns:** *Promise‹[SourceTransform](../interfaces/sourcetransform.md)›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(_generateChecksums?: *`boolean`*): `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+▸ **createSparseReadStream**(`_generateChecksums`: boolean): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L317)*
+*Defined in [lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L317)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _generateChecksums | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`_generateChecksums` | boolean | false |
 
-**Returns:** `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseWriteStream](sourcedestination.md#createsparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L331)*
+*Defined in [lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L331)*
 
-**Returns:** `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
-
-___
-<a id="createtransform"></a>
-
-### `<Protected>` createTransform
-
-▸ **createTransform**(): `Transform`
-
-*Overrides [CompressedSource](compressedsource.md).[createTransform](compressedsource.md#createtransform)*
-
-*Defined in [source-destination/xz.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/xz.ts#L29)*
-
-**Returns:** `Transform`
+**Returns:** *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
 ___
-<a id="createverifier"></a>
+
+### `Protected` createTransform
+
+▸ **createTransform**(): *Transform*
+
+*Overrides [CompressedSource](compressedsource.md).[createTransform](compressedsource.md#protected-abstract-createtransform)*
+
+*Defined in [lib/source-destination/xz.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/xz.ts#L29)*
+
+**Returns:** *Transform*
+
+___
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createWriteStream](sourcedestination.md#createwritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L327)*
+*Defined in [lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L327)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
-
-___
-<a id="getsize"></a>
-
-### `<Protected>` getSize
-
-▸ **getSize**(): `Promise`<`number` \| `undefined`>
-
-*Overrides [CompressedSource](compressedsource.md).[getSize](compressedsource.md#getsize)*
-
-*Defined in [source-destination/xz.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/xz.ts#L33)*
-
-**Returns:** `Promise`<`number` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="listenercount"></a>
+
+### `Protected` getSize
+
+▸ **getSize**(): *Promise‹number | undefined›*
+
+*Overrides [CompressedSource](compressedsource.md).[getSize](compressedsource.md#protected-getsize)*
+
+*Defined in [lib/source-destination/xz.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/xz.ts#L33)*
+
+**Returns:** *Promise‹number | undefined›*
+
+___
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_sourceOffset`: number): *Promise‹ReadResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[read](sourcedestination.md#read)*
+*Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L291)*
+*Defined in [lib/source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L291)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[write](sourcedestination.md#write)*
+*Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L300)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L300)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/classes/zipsource.md
+++ b/doc/classes/zipsource.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [ZipSource](../classes/zipsource.md)
+[etcher-sdk](../README.md) › [ZipSource](zipsource.md)
 
 # Class: ZipSource
 
 ## Hierarchy
 
-↳  [SourceSource](sourcesource.md)
+  ↳ [SourceSource](sourcesource.md)
 
-**↳ ZipSource**
+  ↳ **ZipSource**
 
 ## Index
 
@@ -16,20 +16,20 @@
 
 ### Properties
 
-* [implementation](zipsource.md#implementation)
-* [match](zipsource.md#match)
-* [preferStreamSource](zipsource.md#preferstreamsource)
-* [source](zipsource.md#source)
-* [defaultMaxListeners](zipsource.md#defaultmaxlisteners)
-* [imageExtensions](zipsource.md#imageextensions)
-* [mimetype](zipsource.md#mimetype)
-* [requiresRandomReadableSource](zipsource.md#requiresrandomreadablesource)
+* [implementation](zipsource.md#private-implementation)
+* [match](zipsource.md#private-match)
+* [preferStreamSource](zipsource.md#private-preferstreamsource)
+* [source](zipsource.md#protected-source)
+* [defaultMaxListeners](zipsource.md#static-defaultmaxlisteners)
+* [imageExtensions](zipsource.md#static-imageextensions)
+* [mimetype](zipsource.md#static-mimetype)
+* [requiresRandomReadableSource](zipsource.md#static-requiresrandomreadablesource)
 
 ### Methods
 
-* [_close](zipsource.md#_close)
-* [_getMetadata](zipsource.md#_getmetadata)
-* [_open](zipsource.md#_open)
+* [_close](zipsource.md#protected-_close)
+* [_getMetadata](zipsource.md#protected-_getmetadata)
+* [_open](zipsource.md#protected-_open)
 * [addListener](zipsource.md#addlistener)
 * [canCreateReadStream](zipsource.md#cancreatereadstream)
 * [canCreateSparseReadStream](zipsource.md#cancreatesparsereadstream)
@@ -55,7 +55,7 @@
 * [on](zipsource.md#on)
 * [once](zipsource.md#once)
 * [open](zipsource.md#open)
-* [prepare](zipsource.md#prepare)
+* [prepare](zipsource.md#private-prepare)
 * [prependListener](zipsource.md#prependlistener)
 * [prependOnceListener](zipsource.md#prependoncelistener)
 * [read](zipsource.md#read)
@@ -63,102 +63,96 @@
 * [removeListener](zipsource.md#removelistener)
 * [setMaxListeners](zipsource.md#setmaxlisteners)
 * [write](zipsource.md#write)
-* [listenerCount](zipsource.md#listenercount-1)
-* [register](zipsource.md#register)
-
----
+* [listenerCount](zipsource.md#static-listenercount)
+* [register](zipsource.md#static-register)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new ZipSource**(source: *[SourceDestination](sourcedestination.md)*, preferStreamSource?: *`boolean`*, match?: *`function`*): [ZipSource](zipsource.md)
+\+ **new ZipSource**(`source`: [SourceDestination](sourcedestination.md), `preferStreamSource`: boolean, `match`: function): *[ZipSource](zipsource.md)*
 
 *Overrides [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
 
-*Defined in [source-destination/zip.ts:350](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L350)*
+*Defined in [lib/source-destination/zip.ts:350](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L350)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| source | [SourceDestination](sourcedestination.md) | - |
-| `Default value` preferStreamSource | `boolean` | false |
-| `Default value` match | `function` |  matchSupportedExtensions |
+▪ **source**: *[SourceDestination](sourcedestination.md)*
 
-**Returns:** [ZipSource](zipsource.md)
+▪`Default value`  **preferStreamSource**: *boolean*= false
 
-___
+▪`Default value`  **match**: *function*= matchSupportedExtensions
+
+▸ (`filename`: string): *boolean*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`filename` | string |
+
+**Returns:** *[ZipSource](zipsource.md)*
 
 ## Properties
 
-<a id="implementation"></a>
+### `Private` implementation
 
-### `<Private>` implementation
+• **implementation**: *[RandomAccessZipSource](randomaccesszipsource.md) | [StreamZipSource](streamzipsource.md)*
 
-**● implementation**: *[RandomAccessZipSource](randomaccesszipsource.md) \| [StreamZipSource](streamzipsource.md)*
-
-*Defined in [source-destination/zip.ts:350](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L350)*
+*Defined in [lib/source-destination/zip.ts:350](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L350)*
 
 ___
-<a id="match"></a>
 
-### `<Private>` match
+### `Private` match
 
-**● match**: *`function`*
+• **match**: *function*
 
-*Defined in [source-destination/zip.ts:355](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L355)*
+*Defined in [lib/source-destination/zip.ts:355](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L355)*
 
-#### Type declaration
-▸(filename: *`string`*): `boolean`
+#### Type declaration:
+
+▸ (`filename`: string): *boolean*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| filename | `string` |
-
-**Returns:** `boolean`
+Name | Type |
+------ | ------ |
+`filename` | string |
 
 ___
-<a id="preferstreamsource"></a>
 
-### `<Private>` preferStreamSource
+### `Private` preferStreamSource
 
-**● preferStreamSource**: *`boolean`*
+• **preferStreamSource**: *boolean*
 
-*Defined in [source-destination/zip.ts:354](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L354)*
-
-___
-<a id="source"></a>
-
-### `<Protected>` source
-
-**● source**: *[SourceDestination](sourcedestination.md)*
-
-*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#source)*
-
-*Defined in [source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L22)*
+*Defined in [lib/source-destination/zip.ts:354](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L354)*
 
 ___
-<a id="defaultmaxlisteners"></a>
 
-### `<Static>` defaultMaxListeners
+### `Protected` source
 
-**● defaultMaxListeners**: *`number`*
+• **source**: *[SourceDestination](sourcedestination.md)*
 
-*Inherited from EventEmitter.defaultMaxListeners*
+*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
 
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L22)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Static` defaultMaxListeners
 
-**● imageExtensions**: *`string`[]* =  [
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -171,681 +165,635 @@ ___
 		'wic',
 	]
 
-*Inherited from [SourceDestination](sourcedestination.md).[imageExtensions](sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
-
-___
-<a id="mimetype"></a>
-
-### `<Static>` mimetype
-
-**● mimetype**: *"application/zip"* = "application/zip"
-
-*Overrides [SourceDestination](sourcedestination.md).[mimetype](sourcedestination.md#mimetype)*
-
-*Defined in [source-destination/zip.ts:349](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L349)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
-<a id="requiresrandomreadablesource"></a>
 
-### `<Static>` requiresRandomReadableSource
+### `Static` mimetype
 
-**● requiresRandomReadableSource**: *`boolean`* = false
+▪ **mimetype**: *"application/zip"* = "application/zip"
 
-*Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#requiresrandomreadablesource)*
+*Overrides [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-mimetype)*
 
-*Defined in [source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/zip.ts:349](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L349)*
 
 ___
+
+### `Static` requiresRandomReadableSource
+
+▪ **requiresRandomReadableSource**: *boolean* = false
+
+*Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
+
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L20)*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Inherited from [SourceSource](sourcesource.md).[_close](sourcesource.md#protected-_close)*
 
-*Inherited from [SourceSource](sourcesource.md).[_close](sourcesource.md#_close)*
+*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#_close)*
+*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L30)*
 
-*Defined in [source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L30)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Overrides [SourceDestination](sourcedestination.md).[_getMetadata](sourcedestination.md#_getmetadata)*
+*Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [source-destination/zip.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L404)*
+*Defined in [lib/source-destination/zip.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L404)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Inherited from [SourceSource](sourcesource.md).[_open](sourcesource.md#_open)*
-
-*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#_open)*
-
-*Defined in [source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-source.ts#L26)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Inherited from [SourceSource](sourcesource.md).[_open](sourcesource.md#protected-_open)*
+
+*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
+
+*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-source.ts#L26)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](sourcesource.md).[addListener](sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[addListener](../interfaces/sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateReadStream](sourcedestination.md#cancreatereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/zip.ts:373](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L373)*
+*Defined in [lib/source-destination/zip.ts:373](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L373)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Overrides [SourceDestination](sourcedestination.md).[canCreateSparseReadStream](sourcedestination.md#cancreatesparsereadstream)*
+*Overrides [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/zip.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L383)*
+*Defined in [lib/source-destination/zip.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L383)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateSparseWriteStream](sourcedestination.md#cancreatesparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L276)*
+*Defined in [lib/source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L276)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canCreateWriteStream](sourcedestination.md#cancreatewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L272)*
+*Defined in [lib/source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L272)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canRead](sourcedestination.md#canread)*
+*Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L256)*
+*Defined in [lib/source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L256)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[canWrite](sourcedestination.md#canwrite)*
+*Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L260)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[close](sourcedestination.md#close)*
+*Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(emitProgress?: *`boolean`*, start?: *`number`*, end?: *`undefined` \| `number`*): `Promise`<`ReadableStream`>
+▸ **createReadStream**(`emitProgress`: boolean, `start`: number, `end?`: undefined | number): *Promise‹ReadableStream›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createReadStream](sourcedestination.md#createreadstream)*
+*Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/zip.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L388)*
+*Defined in [lib/source-destination/zip.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L388)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` emitProgress | `boolean` | false |
-| `Default value` start | `number` | 0 |
-| `Optional` end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`emitProgress` | boolean | false |
+`start` | number | 0 |
+`end?` | undefined &#124; number | - |
 
-**Returns:** `Promise`<`ReadableStream`>
+**Returns:** *Promise‹ReadableStream›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(generateChecksums?: *`boolean`*): `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+▸ **createSparseReadStream**(`generateChecksums`: boolean): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Overrides [SourceDestination](sourcedestination.md).[createSparseReadStream](sourcedestination.md#createsparsereadstream)*
+*Overrides [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/zip.ts:397](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L397)*
+*Defined in [lib/source-destination/zip.ts:397](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L397)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` generateChecksums | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`generateChecksums` | boolean | false |
 
-**Returns:** `Promise`<[SparseReadable](../interfaces/sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createSparseWriteStream](sourcedestination.md#createsparsewritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L331)*
+*Defined in [lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L331)*
 
-**Returns:** `Promise`<[SparseWritable](../interfaces/sparsewritable.md)>
+**Returns:** *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
 ___
-<a id="createverifier"></a>
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createVerifier](sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](verifier.md)
+**Returns:** *[Verifier](verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[createWriteStream](sourcedestination.md#createwritestream)*
+*Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L327)*
+*Defined in [lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L327)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getBlocks](sourcedestination.md#getblocks)*
+*Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getInnerSource](sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[getMaxListeners](../interfaces/sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](../interfaces/metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getMetadata](sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](../interfaces/metadata.md)>
+**Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[getPartitionTable](sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listenerCount](../interfaces/sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[listeners](../interfaces/sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](sourcesource.md).[on](sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[on](../interfaces/sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](sourcesource.md).[once](sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[once](../interfaces/sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Overrides [SourceDestination](sourcedestination.md).[open](sourcedestination.md#open)*
+*Overrides [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [source-destination/zip.ts:378](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L378)*
+*Defined in [lib/source-destination/zip.ts:378](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L378)*
 
-**Returns:** `Promise`<`void`>
-
-___
-<a id="prepare"></a>
-
-### `<Private>` prepare
-
-▸ **prepare**(): `Promise`<`void`>
-
-*Defined in [source-destination/zip.ts:360](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/zip.ts#L360)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
+
+### `Private` prepare
+
+▸ **prepare**(): *Promise‹void›*
+
+*Defined in [lib/source-destination/zip.ts:360](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/zip.ts#L360)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](sourcesource.md).[prependListener](sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependListener](../interfaces/sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](sourcesource.md).[prependOnceListener](sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[prependOnceListener](../interfaces/sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_sourceOffset`: number): *Promise‹ReadResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[read](sourcedestination.md#read)*
+*Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L291)*
+*Defined in [lib/source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L291)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeAllListeners](../interfaces/sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](sourcesource.md).[removeListener](sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[removeListener](../interfaces/sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Inherited from [SourceDestination](sourcedestination.md).[write](sourcedestination.md#write)*
+*Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L300)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L300)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from [SourceDestination](sourcedestination.md).[register](sourcedestination.md#register)*
+*Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/enums/openflags.md
+++ b/doc/enums/openflags.md
@@ -1,4 +1,4 @@
-[etcher-sdk](../README.md) > [OpenFlags](../enums/openflags.md)
+[etcher-sdk](../README.md) › [OpenFlags](openflags.md)
 
 # Enumeration: OpenFlags
 
@@ -10,37 +10,28 @@
 * [ReadWrite](openflags.md#readwrite)
 * [WriteDevice](openflags.md#writedevice)
 
----
-
 ## Enumeration members
-
-<a id="read"></a>
 
 ###  Read
 
-**Read**:  =  fs.constants.O_RDONLY
+• **Read**: = fs.constants.O_RDONLY
 
-*Defined in [source-destination/file.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L47)*
+*Defined in [lib/source-destination/file.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L47)*
 
 ___
-<a id="readwrite"></a>
 
 ###  ReadWrite
 
-**ReadWrite**:  =  fs.constants.O_RDWR | fs.constants.O_CREAT
+• **ReadWrite**: = fs.constants.O_RDWR | fs.constants.O_CREAT
 
-*Defined in [source-destination/file.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L48)*
+*Defined in [lib/source-destination/file.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L48)*
 
 ___
-<a id="writedevice"></a>
 
 ###  WriteDevice
 
-**WriteDevice**:  =  fs.constants.O_RDWR |
+• **WriteDevice**: = fs.constants.O_RDWR |
 		fs.constants.O_NONBLOCK |
 		fs.constants.O_SYNC
 
-*Defined in [source-destination/file.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/file.ts#L49)*
-
-___
-
+*Defined in [lib/source-destination/file.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/file.ts#L49)*

--- a/doc/interfaces/adaptersourcedestination.md
+++ b/doc/interfaces/adaptersourcedestination.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)
+[etcher-sdk](../README.md) › [AdapterSourceDestination](adaptersourcedestination.md)
 
 # Interface: AdapterSourceDestination
 
 ## Hierarchy
 
-↳  [SourceDestination](../classes/sourcedestination.md)
+  ↳ [SourceDestination](../classes/sourcedestination.md)
 
-**↳ AdapterSourceDestination**
+  ↳ **AdapterSourceDestination**
 
 ## Implemented by
 
@@ -26,15 +26,15 @@
 * [mountpoints](adaptersourcedestination.md#mountpoints)
 * [raw](adaptersourcedestination.md#raw)
 * [size](adaptersourcedestination.md#size)
-* [defaultMaxListeners](adaptersourcedestination.md#defaultmaxlisteners)
-* [imageExtensions](adaptersourcedestination.md#imageextensions)
-* [mimetype](adaptersourcedestination.md#mimetype)
+* [defaultMaxListeners](adaptersourcedestination.md#static-defaultmaxlisteners)
+* [imageExtensions](adaptersourcedestination.md#static-imageextensions)
+* [mimetype](adaptersourcedestination.md#static-optional-mimetype)
 
 ### Methods
 
-* [_close](adaptersourcedestination.md#_close)
-* [_getMetadata](adaptersourcedestination.md#_getmetadata)
-* [_open](adaptersourcedestination.md#_open)
+* [_close](adaptersourcedestination.md#protected-_close)
+* [_getMetadata](adaptersourcedestination.md#protected-_getmetadata)
+* [_open](adaptersourcedestination.md#protected-_open)
 * [addListener](adaptersourcedestination.md#addlistener)
 * [canCreateReadStream](adaptersourcedestination.md#cancreatereadstream)
 * [canCreateSparseReadStream](adaptersourcedestination.md#cancreatesparsereadstream)
@@ -67,101 +67,88 @@
 * [removeListener](adaptersourcedestination.md#removelistener)
 * [setMaxListeners](adaptersourcedestination.md#setmaxlisteners)
 * [write](adaptersourcedestination.md#write)
-* [listenerCount](adaptersourcedestination.md#listenercount-1)
-* [register](adaptersourcedestination.md#register)
-
----
+* [listenerCount](adaptersourcedestination.md#static-listenercount)
+* [register](adaptersourcedestination.md#static-register)
 
 ## Properties
 
-<a id="description"></a>
-
 ###  description
 
-**● description**: *`string`*
+• **description**: *string*
 
-*Defined in [scanner/adapters/adapter.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/adapter.ts#L27)*
+*Defined in [lib/scanner/adapters/adapter.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/adapter.ts#L27)*
 
 ___
-<a id="device"></a>
 
 ###  device
 
-**● device**: *`string` \| `null`*
+• **device**: *string | null*
 
-*Defined in [scanner/adapters/adapter.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/adapter.ts#L24)*
+*Defined in [lib/scanner/adapters/adapter.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/adapter.ts#L24)*
 
 ___
-<a id="devicepath"></a>
 
 ###  devicePath
 
-**● devicePath**: *`string` \| `null`*
+• **devicePath**: *string | null*
 
-*Defined in [scanner/adapters/adapter.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/adapter.ts#L25)*
+*Defined in [lib/scanner/adapters/adapter.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/adapter.ts#L25)*
 
 ___
-<a id="emitsprogress"></a>
 
 ###  emitsProgress
 
-**● emitsProgress**: *`boolean`*
+• **emitsProgress**: *boolean*
 
-*Defined in [scanner/adapters/adapter.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/adapter.ts#L30)*
+*Defined in [lib/scanner/adapters/adapter.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/adapter.ts#L30)*
 
 ___
-<a id="issystem"></a>
 
 ###  isSystem
 
-**● isSystem**: *`boolean`*
+• **isSystem**: *boolean*
 
-*Defined in [scanner/adapters/adapter.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/adapter.ts#L26)*
+*Defined in [lib/scanner/adapters/adapter.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/adapter.ts#L26)*
 
 ___
-<a id="mountpoints"></a>
 
 ###  mountpoints
 
-**● mountpoints**: *`Array`<`object`>*
+• **mountpoints**: *Array‹object›*
 
-*Defined in [scanner/adapters/adapter.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/adapter.ts#L28)*
+*Defined in [lib/scanner/adapters/adapter.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/adapter.ts#L28)*
 
 ___
-<a id="raw"></a>
 
 ###  raw
 
-**● raw**: *`string` \| `null`*
+• **raw**: *string | null*
 
-*Defined in [scanner/adapters/adapter.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/adapter.ts#L23)*
+*Defined in [lib/scanner/adapters/adapter.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/adapter.ts#L23)*
 
 ___
-<a id="size"></a>
 
 ###  size
 
-**● size**: *`number` \| `null`*
+• **size**: *number | null*
 
-*Defined in [scanner/adapters/adapter.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/adapter.ts#L29)*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+*Defined in [lib/scanner/adapters/adapter.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/adapter.ts#L29)*
 
 ___
-<a id="imageextensions"></a>
 
-### `<Static>` imageExtensions
+### `Static` defaultMaxListeners
 
-**● imageExtensions**: *`string`[]* =  [
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](../classes/countingwritable.md).[defaultMaxListeners](../classes/countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
+
+___
+
+### `Static` imageExtensions
+
+▪ **imageExtensions**: *string[]* = [
 		'img',
 		'iso',
 		'bin',
@@ -174,655 +161,611 @@ ___
 		'wic',
 	]
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[imageExtensions](../classes/sourcedestination.md#imageextensions)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[imageExtensions](../classes/sourcesource.md#static-imageextensions)*
 
-*Defined in [source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L232)*
-
-___
-<a id="mimetype"></a>
-
-### `<Static>``<Optional>` mimetype
-
-**● mimetype**: *`undefined` \| `string`*
-
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[mimetype](../classes/sourcedestination.md#mimetype)*
-
-*Defined in [source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L244)*
+*Defined in [lib/source-destination/source-destination.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L232)*
 
 ___
+
+### `Static` `Optional` mimetype
+
+▪ **mimetype**? : *undefined | string*
+
+*Inherited from [SourceSource](../classes/sourcesource.md).[mimetype](../classes/sourcesource.md#static-optional-mimetype)*
+
+*Defined in [lib/source-destination/source-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L244)*
 
 ## Methods
 
-<a id="_close"></a>
+### `Protected` _close
 
-### `<Protected>` _close
+▸ **_close**(): *Promise‹void›*
 
-▸ **_close**(): `Promise`<`void`>
+*Inherited from [SourceDestination](../classes/sourcedestination.md).[_close](../classes/sourcedestination.md#protected-_close)*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[_close](../classes/sourcedestination.md#_close)*
+*Defined in [lib/source-destination/source-destination.ts:353](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L353)*
 
-*Defined in [source-destination/source-destination.ts:353](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L353)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="_getmetadata"></a>
 
-### `<Protected>` _getMetadata
+### `Protected` _getMetadata
 
-▸ **_getMetadata**(): `Promise`<[Metadata](metadata.md)>
+▸ **_getMetadata**(): *Promise‹[Metadata](metadata.md)›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[_getMetadata](../classes/sourcedestination.md#_getmetadata)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[_getMetadata](../classes/sourcesource.md#protected-_getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:287](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L287)*
+*Defined in [lib/source-destination/source-destination.ts:287](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L287)*
 
-**Returns:** `Promise`<[Metadata](metadata.md)>
-
-___
-<a id="_open"></a>
-
-### `<Protected>` _open
-
-▸ **_open**(): `Promise`<`void`>
-
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[_open](../classes/sourcedestination.md#_open)*
-
-*Defined in [source-destination/source-destination.ts:349](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L349)*
-
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹[Metadata](metadata.md)›*
 
 ___
-<a id="addlistener"></a>
+
+### `Protected` _open
+
+▸ **_open**(): *Promise‹void›*
+
+*Inherited from [SourceDestination](../classes/sourcedestination.md).[_open](../classes/sourcedestination.md#protected-_open)*
+
+*Defined in [lib/source-destination/source-destination.ts:349](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L349)*
+
+**Returns:** *Promise‹void›*
+
+___
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SourceSource](../classes/sourcesource.md).[addListener](../classes/sourcesource.md#addlistener)*
 
-*Overrides EventEmitter.addListener*
+*Overrides [SparseReadable](sparsereadable.md).[addListener](sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:683*
+Defined in node_modules/@types/node/base.d.ts:683
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="cancreatereadstream"></a>
 
 ###  canCreateReadStream
 
-▸ **canCreateReadStream**(): `Promise`<`boolean`>
+▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[canCreateReadStream](../classes/sourcedestination.md#cancreatereadstream)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[canCreateReadStream](../classes/sourcesource.md#cancreatereadstream)*
 
-*Defined in [source-destination/source-destination.ts:264](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L264)*
+*Defined in [lib/source-destination/source-destination.ts:264](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L264)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsereadstream"></a>
 
 ###  canCreateSparseReadStream
 
-▸ **canCreateSparseReadStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[canCreateSparseReadStream](../classes/sourcedestination.md#cancreatesparsereadstream)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[canCreateSparseReadStream](../classes/sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L268)*
+*Defined in [lib/source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L268)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatesparsewritestream"></a>
 
 ###  canCreateSparseWriteStream
 
-▸ **canCreateSparseWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[canCreateSparseWriteStream](../classes/sourcedestination.md#cancreatesparsewritestream)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[canCreateSparseWriteStream](../classes/sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L276)*
+*Defined in [lib/source-destination/source-destination.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L276)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="cancreatewritestream"></a>
 
 ###  canCreateWriteStream
 
-▸ **canCreateWriteStream**(): `Promise`<`boolean`>
+▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[canCreateWriteStream](../classes/sourcedestination.md#cancreatewritestream)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[canCreateWriteStream](../classes/sourcesource.md#cancreatewritestream)*
 
-*Defined in [source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L272)*
+*Defined in [lib/source-destination/source-destination.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L272)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canread"></a>
 
 ###  canRead
 
-▸ **canRead**(): `Promise`<`boolean`>
+▸ **canRead**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[canRead](../classes/sourcedestination.md#canread)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[canRead](../classes/sourcesource.md#canread)*
 
-*Defined in [source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L256)*
+*Defined in [lib/source-destination/source-destination.ts:256](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L256)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="canwrite"></a>
 
 ###  canWrite
 
-▸ **canWrite**(): `Promise`<`boolean`>
+▸ **canWrite**(): *Promise‹boolean›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[canWrite](../classes/sourcedestination.md#canwrite)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[canWrite](../classes/sourcesource.md#canwrite)*
 
-*Defined in [source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L260)*
 
-**Returns:** `Promise`<`boolean`>
+**Returns:** *Promise‹boolean›*
 
 ___
-<a id="close"></a>
 
 ###  close
 
-▸ **close**(): `Promise`<`void`>
+▸ **close**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[close](../classes/sourcedestination.md#close)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[close](../classes/sourcesource.md#close)*
 
-*Defined in [source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L342)*
+*Defined in [lib/source-destination/source-destination.ts:342](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L342)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="createreadstream"></a>
 
 ###  createReadStream
 
-▸ **createReadStream**(_emitProgress?: *`boolean`*, _start?: *`number`*, _end?: *`undefined` \| `number`*): `Promise`<`ReadableStream`>
+▸ **createReadStream**(`_emitProgress`: boolean, `_start`: number, `_end?`: undefined | number): *Promise‹ReadableStream›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[createReadStream](../classes/sourcedestination.md#createreadstream)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[createReadStream](../classes/sourcesource.md#createreadstream)*
 
-*Defined in [source-destination/source-destination.ts:309](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L309)*
+*Defined in [lib/source-destination/source-destination.ts:309](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L309)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _emitProgress | `boolean` | false |
-| `Default value` _start | `number` | 0 |
-| `Optional` _end | `undefined` \| `number` | - |
+Name | Type | Default |
+------ | ------ | ------ |
+`_emitProgress` | boolean | false |
+`_start` | number | 0 |
+`_end?` | undefined &#124; number | - |
 
-**Returns:** `Promise`<`ReadableStream`>
+**Returns:** *Promise‹ReadableStream›*
 
 ___
-<a id="createsparsereadstream"></a>
 
 ###  createSparseReadStream
 
-▸ **createSparseReadStream**(_generateChecksums?: *`boolean`*): `Promise`<[SparseReadable](sparsereadable.md)>
+▸ **createSparseReadStream**(`_generateChecksums`: boolean): *Promise‹[SparseReadable](sparsereadable.md)›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[createSparseReadStream](../classes/sourcedestination.md#createsparsereadstream)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[createSparseReadStream](../classes/sourcesource.md#createsparsereadstream)*
 
-*Defined in [source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L317)*
+*Defined in [lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L317)*
 
 **Parameters:**
 
-| Name | Type | Default value |
-| ------ | ------ | ------ |
-| `Default value` _generateChecksums | `boolean` | false |
+Name | Type | Default |
+------ | ------ | ------ |
+`_generateChecksums` | boolean | false |
 
-**Returns:** `Promise`<[SparseReadable](sparsereadable.md)>
+**Returns:** *Promise‹[SparseReadable](sparsereadable.md)›*
 
 ___
-<a id="createsparsewritestream"></a>
 
 ###  createSparseWriteStream
 
-▸ **createSparseWriteStream**(): `Promise`<[SparseWritable](sparsewritable.md)>
+▸ **createSparseWriteStream**(): *Promise‹[SparseWritable](sparsewritable.md)›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[createSparseWriteStream](../classes/sourcedestination.md#createsparsewritestream)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[createSparseWriteStream](../classes/sourcesource.md#createsparsewritestream)*
 
-*Defined in [source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L331)*
+*Defined in [lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L331)*
 
-**Returns:** `Promise`<[SparseWritable](sparsewritable.md)>
+**Returns:** *Promise‹[SparseWritable](sparsewritable.md)›*
 
 ___
-<a id="createverifier"></a>
 
 ###  createVerifier
 
-▸ **createVerifier**(checksumOrBlocks: *`string` \| [BlocksWithChecksum](blockswithchecksum.md)[]*, size?: *`undefined` \| `number`*): [Verifier](../classes/verifier.md)
+▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](../classes/verifier.md)*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[createVerifier](../classes/sourcedestination.md#createverifier)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[createVerifier](../classes/sourcesource.md#createverifier)*
 
-*Defined in [source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L357)*
+*Defined in [lib/source-destination/source-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L357)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| checksumOrBlocks | `string` \| [BlocksWithChecksum](blockswithchecksum.md)[] |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`checksumOrBlocks` | string &#124; [BlocksWithChecksum](blockswithchecksum.md)[] |
+`size?` | undefined &#124; number |
 
-**Returns:** [Verifier](../classes/verifier.md)
+**Returns:** *[Verifier](../classes/verifier.md)*
 
 ___
-<a id="createwritestream"></a>
 
 ###  createWriteStream
 
-▸ **createWriteStream**(): `Promise`<`WritableStream`>
+▸ **createWriteStream**(): *Promise‹WritableStream›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[createWriteStream](../classes/sourcedestination.md#createwritestream)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[createWriteStream](../classes/sourcesource.md#createwritestream)*
 
-*Defined in [source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L327)*
+*Defined in [lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L327)*
 
-**Returns:** `Promise`<`WritableStream`>
+**Returns:** *Promise‹WritableStream›*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SourceSource](../classes/sourcesource.md).[emit](../classes/sourcesource.md#emit)*
 
-*Overrides EventEmitter.emit*
+*Overrides [SparseReadable](sparsereadable.md).[emit](sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:693*
+Defined in node_modules/@types/node/base.d.ts:693
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](../classes/countingwritable.md).[eventNames](../classes/countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+*Overrides [SparseReadable](sparsereadable.md).[eventNames](sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
+Defined in node_modules/@types/node/base.d.ts:694
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getblocks"></a>
 
 ###  getBlocks
 
-▸ **getBlocks**(): `Promise`<[BlocksWithChecksum](blockswithchecksum.md)[]>
+▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](blockswithchecksum.md)[]›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[getBlocks](../classes/sourcedestination.md#getblocks)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[getBlocks](../classes/sourcesource.md#getblocks)*
 
-*Defined in [source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L323)*
+*Defined in [lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L323)*
 
-**Returns:** `Promise`<[BlocksWithChecksum](blockswithchecksum.md)[]>
+**Returns:** *Promise‹[BlocksWithChecksum](blockswithchecksum.md)[]›*
 
 ___
-<a id="getinnersource"></a>
 
 ###  getInnerSource
 
-▸ **getInnerSource**(): `Promise`<[SourceDestination](../classes/sourcedestination.md)>
+▸ **getInnerSource**(): *Promise‹[SourceDestination](../classes/sourcedestination.md)›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[getInnerSource](../classes/sourcedestination.md#getinnersource)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[getInnerSource](../classes/sourcesource.md#getinnersource)*
 
-*Defined in [source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L424)*
+*Defined in [lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L424)*
 
-**Returns:** `Promise`<[SourceDestination](../classes/sourcedestination.md)>
+**Returns:** *Promise‹[SourceDestination](../classes/sourcedestination.md)›*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](../classes/countingwritable.md).[getMaxListeners](../classes/countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+*Overrides [SparseReadable](sparsereadable.md).[getMaxListeners](sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
+Defined in node_modules/@types/node/base.d.ts:691
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="getmetadata"></a>
 
 ###  getMetadata
 
-▸ **getMetadata**(): `Promise`<[Metadata](metadata.md)>
+▸ **getMetadata**(): *Promise‹[Metadata](metadata.md)›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[getMetadata](../classes/sourcedestination.md#getmetadata)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[getMetadata](../classes/sourcesource.md#getmetadata)*
 
-*Defined in [source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L280)*
+*Defined in [lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L280)*
 
-**Returns:** `Promise`<[Metadata](metadata.md)>
+**Returns:** *Promise‹[Metadata](metadata.md)›*
 
 ___
-<a id="getpartitiontable"></a>
 
 ###  getPartitionTable
 
-▸ **getPartitionTable**(): `Promise`<`GetPartitionsResult` \| `undefined`>
+▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[getPartitionTable](../classes/sourcedestination.md#getpartitiontable)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[getPartitionTable](../classes/sourcesource.md#getpartitiontable)*
 
-*Defined in [source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L445)*
+*Defined in [lib/source-destination/source-destination.ts:445](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L445)*
 
-**Returns:** `Promise`<`GetPartitionsResult` \| `undefined`>
+**Returns:** *Promise‹GetPartitionsResult | undefined›*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](../classes/countingwritable.md).[listenerCount](../classes/countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
+*Overrides [SparseReadable](sparsereadable.md).[listenerCount](sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](../classes/countingwritable.md).[listeners](../classes/countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
+*Overrides [SparseReadable](sparsereadable.md).[listeners](sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SourceSource](../classes/sourcesource.md).[on](../classes/sourcesource.md#on)*
 
-*Overrides EventEmitter.on*
+*Overrides [SparseReadable](sparsereadable.md).[on](sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:684*
+Defined in node_modules/@types/node/base.d.ts:684
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SourceSource](../classes/sourcesource.md).[once](../classes/sourcesource.md#once)*
 
-*Overrides EventEmitter.once*
+*Overrides [SparseReadable](sparsereadable.md).[once](sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:685*
+Defined in node_modules/@types/node/base.d.ts:685
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="open"></a>
 
 ###  open
 
-▸ **open**(): `Promise`<`void`>
+▸ **open**(): *Promise‹void›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[open](../classes/sourcedestination.md#open)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[open](../classes/sourcesource.md#open)*
 
-*Defined in [source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L335)*
+*Defined in [lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L335)*
 
-**Returns:** `Promise`<`void`>
+**Returns:** *Promise‹void›*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SourceSource](../classes/sourcesource.md).[prependListener](../classes/sourcesource.md#prependlistener)*
 
-*Overrides EventEmitter.prependListener*
+*Overrides [SparseReadable](sparsereadable.md).[prependListener](sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:686*
+Defined in node_modules/@types/node/base.d.ts:686
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SourceSource](../classes/sourcesource.md).[prependOnceListener](../classes/sourcesource.md#prependoncelistener)*
 
-*Overrides EventEmitter.prependOnceListener*
+*Overrides [SparseReadable](sparsereadable.md).[prependOnceListener](sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:687*
+Defined in node_modules/@types/node/base.d.ts:687
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _sourceOffset: *`number`*): `Promise`<`ReadResult`>
+▸ **read**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_sourceOffset`: number): *Promise‹ReadResult›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[read](../classes/sourcedestination.md#read)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[read](../classes/sourcesource.md#read)*
 
-*Defined in [source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L291)*
+*Defined in [lib/source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L291)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _sourceOffset | `number` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_sourceOffset` | number |
 
-**Returns:** `Promise`<`ReadResult`>
+**Returns:** *Promise‹ReadResult›*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](../classes/countingwritable.md).[removeAllListeners](../classes/countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
+*Overrides [SparseReadable](sparsereadable.md).[removeAllListeners](sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SourceSource](../classes/sourcesource.md).[removeListener](../classes/sourcesource.md#removelistener)*
 
-*Overrides EventEmitter.removeListener*
+*Overrides [SparseReadable](sparsereadable.md).[removeListener](sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:688*
+Defined in node_modules/@types/node/base.d.ts:688
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](../classes/countingwritable.md).[setMaxListeners](../classes/countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
+*Overrides [SparseReadable](sparsereadable.md).[setMaxListeners](sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(_buffer: *`Buffer`*, _bufferOffset: *`number`*, _length: *`number`*, _fileOffset: *`number`*): `Promise`<`WriteResult`>
+▸ **write**(`_buffer`: Buffer, `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[write](../classes/sourcedestination.md#write)*
+*Inherited from [SourceSource](../classes/sourcesource.md).[write](../classes/sourcesource.md#write)*
 
-*Defined in [source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L300)*
-
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| _buffer | `Buffer` |
-| _bufferOffset | `number` |
-| _length | `number` |
-| _fileOffset | `number` |
-
-**Returns:** `Promise`<`WriteResult`>
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+*Defined in [lib/source-destination/source-destination.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L300)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`_buffer` | Buffer |
+`_bufferOffset` | number |
+`_length` | number |
+`_fileOffset` | number |
 
-**Returns:** `number`
+**Returns:** *Promise‹WriteResult›*
 
 ___
-<a id="register"></a>
 
-### `<Static>` register
+### `Static` listenerCount
 
-▸ **register**(Cls: *[SourceSource](../classes/sourcesource.md)*): `void`
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
-*Inherited from [SourceDestination](../classes/sourcedestination.md).[register](../classes/sourcedestination.md#register)*
+*Inherited from [CountingWritable](../classes/countingwritable.md).[listenerCount](../classes/countingwritable.md#static-listenercount)*
 
-*Defined in [source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/source-destination.ts#L250)*
+Defined in node_modules/@types/node/base.d.ts:680
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| Cls | [SourceSource](../classes/sourcesource.md) |
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
 
-**Returns:** `void`
+**Returns:** *number*
 
 ___
 
+### `Static` register
+
+▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Inherited from [SourceSource](../classes/sourcesource.md).[register](../classes/sourcesource.md#static-register)*
+
+*Defined in [lib/source-destination/source-destination.ts:250](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/source-destination.ts#L250)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`Cls` | typeof SourceSource |
+
+**Returns:** *void*

--- a/doc/interfaces/block.md
+++ b/doc/interfaces/block.md
@@ -1,10 +1,10 @@
-[etcher-sdk](../README.md) > [Block](../interfaces/block.md)
+[etcher-sdk](../README.md) › [Block](block.md)
 
 # Interface: Block
 
 ## Hierarchy
 
-**Block**
+* **Block**
 
 ## Index
 
@@ -13,26 +13,18 @@
 * [length](block.md#length)
 * [offset](block.md#offset)
 
----
-
 ## Properties
-
-<a id="length"></a>
 
 ###  length
 
-**● length**: *`number`*
+• **length**: *number*
 
-*Defined in [sparse-stream/shared.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L35)*
+*Defined in [lib/sparse-stream/shared.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L35)*
 
 ___
-<a id="offset"></a>
 
 ###  offset
 
-**● offset**: *`number`*
+• **offset**: *number*
 
-*Defined in [sparse-stream/shared.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L34)*
-
-___
-
+*Defined in [lib/sparse-stream/shared.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L34)*

--- a/doc/interfaces/blockswithchecksum.md
+++ b/doc/interfaces/blockswithchecksum.md
@@ -1,48 +1,39 @@
-[etcher-sdk](../README.md) > [BlocksWithChecksum](../interfaces/blockswithchecksum.md)
+[etcher-sdk](../README.md) › [BlocksWithChecksum](blockswithchecksum.md)
 
 # Interface: BlocksWithChecksum
 
 ## Hierarchy
 
-**BlocksWithChecksum**
+* **BlocksWithChecksum**
 
 ## Index
 
 ### Properties
 
 * [blocks](blockswithchecksum.md#blocks)
-* [checksum](blockswithchecksum.md#checksum)
-* [checksumType](blockswithchecksum.md#checksumtype)
-
----
+* [checksum](blockswithchecksum.md#optional-checksum)
+* [checksumType](blockswithchecksum.md#optional-checksumtype)
 
 ## Properties
 
-<a id="blocks"></a>
-
 ###  blocks
 
-**● blocks**: *[Block](block.md)[]*
+• **blocks**: *[Block](block.md)[]*
 
-*Defined in [sparse-stream/shared.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L41)*
-
-___
-<a id="checksum"></a>
-
-### `<Optional>` checksum
-
-**● checksum**: *`undefined` \| `string`*
-
-*Defined in [sparse-stream/shared.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L40)*
-
-___
-<a id="checksumtype"></a>
-
-### `<Optional>` checksumType
-
-**● checksumType**: *[ChecksumType](../#checksumtype)*
-
-*Defined in [sparse-stream/shared.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L39)*
+*Defined in [lib/sparse-stream/shared.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L41)*
 
 ___
 
+### `Optional` checksum
+
+• **checksum**? : *undefined | string*
+
+*Defined in [lib/sparse-stream/shared.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L40)*
+
+___
+
+### `Optional` checksumType
+
+• **checksumType**? : *[ChecksumType](../README.md#checksumtype)*
+
+*Defined in [lib/sparse-stream/shared.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L39)*

--- a/doc/interfaces/drivelistdrive.md
+++ b/doc/interfaces/drivelistdrive.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [DrivelistDrive](../interfaces/drivelistdrive.md)
+[etcher-sdk](../README.md) › [DrivelistDrive](drivelistdrive.md)
 
 # Interface: DrivelistDrive
 
 ## Hierarchy
 
- `Drive`
+* Drive
 
-**↳ DrivelistDrive**
+  ↳ **DrivelistDrive**
 
 ## Index
 
@@ -21,7 +21,7 @@
 * [displayName](drivelistdrive.md#displayname)
 * [enumerator](drivelistdrive.md#enumerator)
 * [error](drivelistdrive.md#error)
-* [icon](drivelistdrive.md#icon)
+* [icon](drivelistdrive.md#optional-icon)
 * [isCard](drivelistdrive.md#iscard)
 * [isReadOnly](drivelistdrive.md#isreadonly)
 * [isRemovable](drivelistdrive.md#isremovable)
@@ -35,246 +35,218 @@
 * [raw](drivelistdrive.md#raw)
 * [size](drivelistdrive.md#size)
 
----
-
 ## Properties
-
-<a id="blocksize"></a>
 
 ###  blockSize
 
-**● blockSize**: *`number`*
+• **blockSize**: *number*
 
-*Inherited from Drive.blockSize*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[blockSize](drivelistdrive.md#blocksize)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:6*
+Defined in node_modules/drivelist/js/index.d.ts:6
 
 ___
-<a id="bustype"></a>
 
 ###  busType
 
-**● busType**: *`string`*
+• **busType**: *string*
 
-*Inherited from Drive.busType*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[busType](drivelistdrive.md#bustype)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:7*
+Defined in node_modules/drivelist/js/index.d.ts:7
 
 ___
-<a id="busversion"></a>
 
 ###  busVersion
 
-**● busVersion**: *`null`*
+• **busVersion**: *null*
 
-*Inherited from Drive.busVersion*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[busVersion](drivelistdrive.md#busversion)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:8*
+Defined in node_modules/drivelist/js/index.d.ts:8
 
 ___
-<a id="description"></a>
 
 ###  description
 
-**● description**: *`string`*
+• **description**: *string*
 
-*Inherited from Drive.description*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[description](drivelistdrive.md#description)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:9*
+Defined in node_modules/drivelist/js/index.d.ts:9
 
 ___
-<a id="device"></a>
 
 ###  device
 
-**● device**: *`string`*
+• **device**: *string*
 
-*Inherited from Drive.device*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[device](drivelistdrive.md#device)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:10*
+Defined in node_modules/drivelist/js/index.d.ts:10
 
 ___
-<a id="devicepath"></a>
 
 ###  devicePath
 
-**● devicePath**: *`string` \| `null`*
+• **devicePath**: *string | null*
 
-*Inherited from Drive.devicePath*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[devicePath](drivelistdrive.md#devicepath)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:11*
+Defined in node_modules/drivelist/js/index.d.ts:11
 
 ___
-<a id="displayname"></a>
 
 ###  displayName
 
-**● displayName**: *`string`*
+• **displayName**: *string*
 
-*Defined in [scanner/adapters/block-device.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/block-device.ts#L52)*
+*Defined in [lib/scanner/adapters/block-device.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/block-device.ts#L52)*
 
 ___
-<a id="enumerator"></a>
 
 ###  enumerator
 
-**● enumerator**: *`string`*
+• **enumerator**: *string*
 
-*Inherited from Drive.enumerator*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[enumerator](drivelistdrive.md#enumerator)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:12*
+Defined in node_modules/drivelist/js/index.d.ts:12
 
 ___
-<a id="error"></a>
 
 ###  error
 
-**● error**: *`null`*
+• **error**: *null*
 
-*Inherited from Drive.error*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[error](drivelistdrive.md#error)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:13*
-
-___
-<a id="icon"></a>
-
-### `<Optional>` icon
-
-**● icon**: *`undefined` \| `string`*
-
-*Defined in [scanner/adapters/block-device.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/scanner/adapters/block-device.ts#L53)*
+Defined in node_modules/drivelist/js/index.d.ts:13
 
 ___
-<a id="iscard"></a>
+
+### `Optional` icon
+
+• **icon**? : *undefined | string*
+
+*Defined in [lib/scanner/adapters/block-device.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/scanner/adapters/block-device.ts#L53)*
+
+___
 
 ###  isCard
 
-**● isCard**: *`null`*
+• **isCard**: *null*
 
-*Inherited from Drive.isCard*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[isCard](drivelistdrive.md#iscard)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:14*
+Defined in node_modules/drivelist/js/index.d.ts:14
 
 ___
-<a id="isreadonly"></a>
 
 ###  isReadOnly
 
-**● isReadOnly**: *`boolean`*
+• **isReadOnly**: *boolean*
 
-*Inherited from Drive.isReadOnly*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[isReadOnly](drivelistdrive.md#isreadonly)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:15*
+Defined in node_modules/drivelist/js/index.d.ts:15
 
 ___
-<a id="isremovable"></a>
 
 ###  isRemovable
 
-**● isRemovable**: *`boolean`*
+• **isRemovable**: *boolean*
 
-*Inherited from Drive.isRemovable*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[isRemovable](drivelistdrive.md#isremovable)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:16*
+Defined in node_modules/drivelist/js/index.d.ts:16
 
 ___
-<a id="isscsi"></a>
 
 ###  isSCSI
 
-**● isSCSI**: *`boolean` \| `null`*
+• **isSCSI**: *boolean | null*
 
-*Inherited from Drive.isSCSI*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[isSCSI](drivelistdrive.md#isscsi)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:17*
+Defined in node_modules/drivelist/js/index.d.ts:17
 
 ___
-<a id="issystem"></a>
 
 ###  isSystem
 
-**● isSystem**: *`boolean`*
+• **isSystem**: *boolean*
 
-*Inherited from Drive.isSystem*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[isSystem](drivelistdrive.md#issystem)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:18*
+Defined in node_modules/drivelist/js/index.d.ts:18
 
 ___
-<a id="isuas"></a>
 
 ###  isUAS
 
-**● isUAS**: *`null`*
+• **isUAS**: *null*
 
-*Inherited from Drive.isUAS*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[isUAS](drivelistdrive.md#isuas)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:19*
+Defined in node_modules/drivelist/js/index.d.ts:19
 
 ___
-<a id="isusb"></a>
 
 ###  isUSB
 
-**● isUSB**: *`boolean` \| `null`*
+• **isUSB**: *boolean | null*
 
-*Inherited from Drive.isUSB*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[isUSB](drivelistdrive.md#isusb)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:20*
+Defined in node_modules/drivelist/js/index.d.ts:20
 
 ___
-<a id="isvirtual"></a>
 
 ###  isVirtual
 
-**● isVirtual**: *`boolean` \| `null`*
+• **isVirtual**: *boolean | null*
 
-*Inherited from Drive.isVirtual*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[isVirtual](drivelistdrive.md#isvirtual)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:21*
+Defined in node_modules/drivelist/js/index.d.ts:21
 
 ___
-<a id="logicalblocksize"></a>
 
 ###  logicalBlockSize
 
-**● logicalBlockSize**: *`number`*
+• **logicalBlockSize**: *number*
 
-*Inherited from Drive.logicalBlockSize*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[logicalBlockSize](drivelistdrive.md#logicalblocksize)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:22*
+Defined in node_modules/drivelist/js/index.d.ts:22
 
 ___
-<a id="mountpoints"></a>
 
 ###  mountpoints
 
-**● mountpoints**: *`Mountpoint`[]*
+• **mountpoints**: *Mountpoint[]*
 
-*Inherited from Drive.mountpoints*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[mountpoints](drivelistdrive.md#mountpoints)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:23*
+Defined in node_modules/drivelist/js/index.d.ts:23
 
 ___
-<a id="raw"></a>
 
 ###  raw
 
-**● raw**: *`string`*
+• **raw**: *string*
 
-*Inherited from Drive.raw*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[raw](drivelistdrive.md#raw)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:24*
+Defined in node_modules/drivelist/js/index.d.ts:24
 
 ___
-<a id="size"></a>
 
 ###  size
 
-**● size**: *`number` \| `null`*
+• **size**: *number | null*
 
-*Inherited from Drive.size*
+*Inherited from [DrivelistDrive](drivelistdrive.md).[size](drivelistdrive.md#size)*
 
-*Defined in /node_modules/drivelist/js/index.d.ts:25*
-
-___
-
+Defined in node_modules/drivelist/js/index.d.ts:25

--- a/doc/interfaces/execresult.md
+++ b/doc/interfaces/execresult.md
@@ -1,10 +1,10 @@
-[etcher-sdk](../README.md) > [ExecResult](../interfaces/execresult.md)
+[etcher-sdk](../README.md) › [ExecResult](execresult.md)
 
 # Interface: ExecResult
 
 ## Hierarchy
 
-**ExecResult**
+* **ExecResult**
 
 ## Index
 
@@ -13,26 +13,18 @@
 * [stderr](execresult.md#stderr)
 * [stdout](execresult.md#stdout)
 
----
-
 ## Properties
-
-<a id="stderr"></a>
 
 ###  stderr
 
-**● stderr**: *`string`*
+• **stderr**: *string*
 
-*Defined in [diskpart.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/diskpart.ts#L33)*
+*Defined in [lib/diskpart.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/diskpart.ts#L33)*
 
 ___
-<a id="stdout"></a>
 
 ###  stdout
 
-**● stdout**: *`string`*
+• **stdout**: *string*
 
-*Defined in [diskpart.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/diskpart.ts#L32)*
-
-___
-
+*Defined in [lib/diskpart.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/diskpart.ts#L32)*

--- a/doc/interfaces/metadata.md
+++ b/doc/interfaces/metadata.md
@@ -1,198 +1,174 @@
-[etcher-sdk](../README.md) > [Metadata](../interfaces/metadata.md)
+[etcher-sdk](../README.md) › [Metadata](metadata.md)
 
 # Interface: Metadata
 
 ## Hierarchy
 
-**Metadata**
+* **Metadata**
 
 ## Index
 
 ### Properties
 
-* [blockMap](metadata.md#blockmap)
-* [blockmappedSize](metadata.md#blockmappedsize)
-* [blocks](metadata.md#blocks)
-* [bytesToZeroOutFromTheBeginning](metadata.md#bytestozerooutfromthebeginning)
-* [checksum](metadata.md#checksum)
-* [checksumType](metadata.md#checksumtype)
-* [compressedSize](metadata.md#compressedsize)
-* [instructions](metadata.md#instructions)
-* [isEtch](metadata.md#isetch)
-* [isSizeEstimated](metadata.md#issizeestimated)
-* [logo](metadata.md#logo)
-* [name](metadata.md#name)
-* [recommendedDriveSize](metadata.md#recommendeddrivesize)
-* [releaseNotesUrl](metadata.md#releasenotesurl)
-* [size](metadata.md#size)
-* [supportUrl](metadata.md#supporturl)
-* [url](metadata.md#url)
-* [version](metadata.md#version)
-
----
+* [blockMap](metadata.md#optional-blockmap)
+* [blockmappedSize](metadata.md#optional-blockmappedsize)
+* [blocks](metadata.md#optional-blocks)
+* [bytesToZeroOutFromTheBeginning](metadata.md#optional-bytestozerooutfromthebeginning)
+* [checksum](metadata.md#optional-checksum)
+* [checksumType](metadata.md#optional-checksumtype)
+* [compressedSize](metadata.md#optional-compressedsize)
+* [instructions](metadata.md#optional-instructions)
+* [isEtch](metadata.md#optional-isetch)
+* [isSizeEstimated](metadata.md#optional-issizeestimated)
+* [logo](metadata.md#optional-logo)
+* [name](metadata.md#optional-name)
+* [recommendedDriveSize](metadata.md#optional-recommendeddrivesize)
+* [releaseNotesUrl](metadata.md#optional-releasenotesurl)
+* [size](metadata.md#optional-size)
+* [supportUrl](metadata.md#optional-supporturl)
+* [url](metadata.md#optional-url)
+* [version](metadata.md#optional-version)
 
 ## Properties
 
-<a id="blockmap"></a>
+### `Optional` blockMap
 
-### `<Optional>` blockMap
+• **blockMap**? : *BlockMap*
 
-**● blockMap**: *`BlockMap`*
-
-*Defined in [source-destination/metadata.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L27)*
+*Defined in [lib/source-destination/metadata.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L27)*
 
 ___
-<a id="blockmappedsize"></a>
 
-### `<Optional>` blockmappedSize
+### `Optional` blockmappedSize
 
-**● blockmappedSize**: *`undefined` \| `number`*
+• **blockmappedSize**? : *undefined | number*
 
-*Defined in [source-destination/metadata.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L25)*
-
-___
-<a id="blocks"></a>
-
-### `<Optional>` blocks
-
-**● blocks**: *[BlocksWithChecksum](blockswithchecksum.md)[]*
-
-*Defined in [source-destination/metadata.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L28)*
-
-___
-<a id="bytestozerooutfromthebeginning"></a>
-
-### `<Optional>` bytesToZeroOutFromTheBeginning
-
-**● bytesToZeroOutFromTheBeginning**: *`undefined` \| `number`*
-
-*Defined in [source-destination/metadata.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L31)*
-
-___
-<a id="checksum"></a>
-
-### `<Optional>` checksum
-
-**● checksum**: *`undefined` \| `string`*
-
-*Defined in [source-destination/metadata.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L32)*
-
-___
-<a id="checksumtype"></a>
-
-### `<Optional>` checksumType
-
-**● checksumType**: *`undefined` \| `string`*
-
-*Defined in [source-destination/metadata.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L33)*
-
-___
-<a id="compressedsize"></a>
-
-### `<Optional>` compressedSize
-
-**● compressedSize**: *`undefined` \| `number`*
-
-*Defined in [source-destination/metadata.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L24)*
-
-___
-<a id="instructions"></a>
-
-### `<Optional>` instructions
-
-**● instructions**: *`undefined` \| `string`*
-
-*Defined in [source-destination/metadata.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L29)*
-
-___
-<a id="isetch"></a>
-
-### `<Optional>` isEtch
-
-**● isEtch**: *`undefined` \| `false` \| `true`*
-
-*Defined in [source-destination/metadata.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L39)*
-
-___
-<a id="issizeestimated"></a>
-
-### `<Optional>` isSizeEstimated
-
-**● isSizeEstimated**: *`undefined` \| `false` \| `true`*
-
-*Defined in [source-destination/metadata.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L23)*
-
-___
-<a id="logo"></a>
-
-### `<Optional>` logo
-
-**● logo**: *`undefined` \| `string`*
-
-*Defined in [source-destination/metadata.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L30)*
-
-___
-<a id="name"></a>
-
-### `<Optional>` name
-
-**● name**: *`undefined` \| `string`*
-
-*Defined in [source-destination/metadata.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L26)*
-
-___
-<a id="recommendeddrivesize"></a>
-
-### `<Optional>` recommendedDriveSize
-
-**● recommendedDriveSize**: *`undefined` \| `number`*
-
-*Defined in [source-destination/metadata.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L34)*
-
-___
-<a id="releasenotesurl"></a>
-
-### `<Optional>` releaseNotesUrl
-
-**● releaseNotesUrl**: *`undefined` \| `string`*
-
-*Defined in [source-destination/metadata.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L35)*
-
-___
-<a id="size"></a>
-
-### `<Optional>` size
-
-**● size**: *`undefined` \| `number`*
-
-*Defined in [source-destination/metadata.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L22)*
-
-___
-<a id="supporturl"></a>
-
-### `<Optional>` supportUrl
-
-**● supportUrl**: *`undefined` \| `string`*
-
-*Defined in [source-destination/metadata.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L36)*
-
-___
-<a id="url"></a>
-
-### `<Optional>` url
-
-**● url**: *`undefined` \| `string`*
-
-*Defined in [source-destination/metadata.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L37)*
-
-___
-<a id="version"></a>
-
-### `<Optional>` version
-
-**● version**: *`undefined` \| `string`*
-
-*Defined in [source-destination/metadata.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/metadata.ts#L38)*
+*Defined in [lib/source-destination/metadata.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L25)*
 
 ___
 
+### `Optional` blocks
+
+• **blocks**? : *[BlocksWithChecksum](blockswithchecksum.md)[]*
+
+*Defined in [lib/source-destination/metadata.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L28)*
+
+___
+
+### `Optional` bytesToZeroOutFromTheBeginning
+
+• **bytesToZeroOutFromTheBeginning**? : *undefined | number*
+
+*Defined in [lib/source-destination/metadata.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L31)*
+
+___
+
+### `Optional` checksum
+
+• **checksum**? : *undefined | string*
+
+*Defined in [lib/source-destination/metadata.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L32)*
+
+___
+
+### `Optional` checksumType
+
+• **checksumType**? : *undefined | string*
+
+*Defined in [lib/source-destination/metadata.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L33)*
+
+___
+
+### `Optional` compressedSize
+
+• **compressedSize**? : *undefined | number*
+
+*Defined in [lib/source-destination/metadata.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L24)*
+
+___
+
+### `Optional` instructions
+
+• **instructions**? : *undefined | string*
+
+*Defined in [lib/source-destination/metadata.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L29)*
+
+___
+
+### `Optional` isEtch
+
+• **isEtch**? : *undefined | false | true*
+
+*Defined in [lib/source-destination/metadata.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L39)*
+
+___
+
+### `Optional` isSizeEstimated
+
+• **isSizeEstimated**? : *undefined | false | true*
+
+*Defined in [lib/source-destination/metadata.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L23)*
+
+___
+
+### `Optional` logo
+
+• **logo**? : *undefined | string*
+
+*Defined in [lib/source-destination/metadata.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L30)*
+
+___
+
+### `Optional` name
+
+• **name**? : *undefined | string*
+
+*Defined in [lib/source-destination/metadata.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L26)*
+
+___
+
+### `Optional` recommendedDriveSize
+
+• **recommendedDriveSize**? : *undefined | number*
+
+*Defined in [lib/source-destination/metadata.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L34)*
+
+___
+
+### `Optional` releaseNotesUrl
+
+• **releaseNotesUrl**? : *undefined | string*
+
+*Defined in [lib/source-destination/metadata.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L35)*
+
+___
+
+### `Optional` size
+
+• **size**? : *undefined | number*
+
+*Defined in [lib/source-destination/metadata.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L22)*
+
+___
+
+### `Optional` supportUrl
+
+• **supportUrl**? : *undefined | string*
+
+*Defined in [lib/source-destination/metadata.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L36)*
+
+___
+
+### `Optional` url
+
+• **url**? : *undefined | string*
+
+*Defined in [lib/source-destination/metadata.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L37)*
+
+___
+
+### `Optional` version
+
+• **version**? : *undefined | string*
+
+*Defined in [lib/source-destination/metadata.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/metadata.ts#L38)*

--- a/doc/interfaces/multidestinationprogress.md
+++ b/doc/interfaces/multidestinationprogress.md
@@ -1,224 +1,200 @@
-[etcher-sdk](../README.md) > [MultiDestinationProgress](../interfaces/multidestinationprogress.md)
+[etcher-sdk](../README.md) › [MultiDestinationProgress](multidestinationprogress.md)
 
 # Interface: MultiDestinationProgress
 
 ## Hierarchy
 
- [MultiDestinationState](multidestinationstate.md)
+* [MultiDestinationState](multidestinationstate.md)
 
-**↳ MultiDestinationProgress**
+  ↳ **MultiDestinationProgress**
 
 ## Index
 
 ### Properties
 
 * [active](multidestinationprogress.md#active)
-* [blockmappedSize](multidestinationprogress.md#blockmappedsize)
+* [blockmappedSize](multidestinationprogress.md#optional-blockmappedsize)
 * [bytes](multidestinationprogress.md#bytes)
-* [compressedSize](multidestinationprogress.md#compressedsize)
-* [eta](multidestinationprogress.md#eta)
+* [compressedSize](multidestinationprogress.md#optional-compressedsize)
+* [eta](multidestinationprogress.md#optional-eta)
 * [failed](multidestinationprogress.md#failed)
 * [flashing](multidestinationprogress.md#flashing)
-* [percentage](multidestinationprogress.md#percentage)
+* [percentage](multidestinationprogress.md#optional-percentage)
 * [position](multidestinationprogress.md#position)
-* [rootStreamPosition](multidestinationprogress.md#rootstreamposition)
-* [rootStreamSpeed](multidestinationprogress.md#rootstreamspeed)
-* [size](multidestinationprogress.md#size)
-* [sparse](multidestinationprogress.md#sparse)
+* [rootStreamPosition](multidestinationprogress.md#optional-rootstreamposition)
+* [rootStreamSpeed](multidestinationprogress.md#optional-rootstreamspeed)
+* [size](multidestinationprogress.md#optional-size)
+* [sparse](multidestinationprogress.md#optional-sparse)
 * [speed](multidestinationprogress.md#speed)
 * [successful](multidestinationprogress.md#successful)
 * [totalSpeed](multidestinationprogress.md#totalspeed)
 * [type](multidestinationprogress.md#type)
 * [verifying](multidestinationprogress.md#verifying)
 
----
-
 ## Properties
-
-<a id="active"></a>
 
 ###  active
 
-**● active**: *`number`*
+• **active**: *number*
 
 *Inherited from [MultiDestinationState](multidestinationstate.md).[active](multidestinationstate.md#active)*
 
-*Defined in [multi-write.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L37)*
+*Defined in [lib/multi-write.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L37)*
 
 ___
-<a id="blockmappedsize"></a>
 
-### `<Optional>` blockmappedSize
+### `Optional` blockmappedSize
 
-**● blockmappedSize**: *`undefined` \| `number`*
+• **blockmappedSize**? : *undefined | number*
 
-*Inherited from [MultiDestinationState](multidestinationstate.md).[blockmappedSize](multidestinationstate.md#blockmappedsize)*
+*Inherited from [MultiDestinationState](multidestinationstate.md).[blockmappedSize](multidestinationstate.md#optional-blockmappedsize)*
 
-*Defined in [multi-write.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L45)*
+*Defined in [lib/multi-write.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L45)*
 
 ___
-<a id="bytes"></a>
 
 ###  bytes
 
-**● bytes**: *`number`*
+• **bytes**: *number*
 
-*Defined in [multi-write.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L52)*
-
-___
-<a id="compressedsize"></a>
-
-### `<Optional>` compressedSize
-
-**● compressedSize**: *`undefined` \| `number`*
-
-*Inherited from [MultiDestinationState](multidestinationstate.md).[compressedSize](multidestinationstate.md#compressedsize)*
-
-*Defined in [multi-write.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L44)*
+*Defined in [lib/multi-write.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L52)*
 
 ___
-<a id="eta"></a>
 
-### `<Optional>` eta
+### `Optional` compressedSize
 
-**● eta**: *`undefined` \| `number`*
+• **compressedSize**? : *undefined | number*
 
-*Defined in [multi-write.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L57)*
+*Inherited from [MultiDestinationState](multidestinationstate.md).[compressedSize](multidestinationstate.md#optional-compressedsize)*
+
+*Defined in [lib/multi-write.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L44)*
 
 ___
-<a id="failed"></a>
+
+### `Optional` eta
+
+• **eta**? : *undefined | number*
+
+*Defined in [lib/multi-write.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L57)*
+
+___
 
 ###  failed
 
-**● failed**: *`number`*
+• **failed**: *number*
 
 *Inherited from [MultiDestinationState](multidestinationstate.md).[failed](multidestinationstate.md#failed)*
 
-*Defined in [multi-write.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L40)*
+*Defined in [lib/multi-write.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L40)*
 
 ___
-<a id="flashing"></a>
 
 ###  flashing
 
-**● flashing**: *`number`*
+• **flashing**: *number*
 
 *Inherited from [MultiDestinationState](multidestinationstate.md).[flashing](multidestinationstate.md#flashing)*
 
-*Defined in [multi-write.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L38)*
+*Defined in [lib/multi-write.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L38)*
 
 ___
-<a id="percentage"></a>
 
-### `<Optional>` percentage
+### `Optional` percentage
 
-**● percentage**: *`undefined` \| `number`*
+• **percentage**? : *undefined | number*
 
-*Defined in [multi-write.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L56)*
+*Defined in [lib/multi-write.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L56)*
 
 ___
-<a id="position"></a>
 
 ###  position
 
-**● position**: *`number`*
+• **position**: *number*
 
-*Defined in [multi-write.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L53)*
-
-___
-<a id="rootstreamposition"></a>
-
-### `<Optional>` rootStreamPosition
-
-**● rootStreamPosition**: *`undefined` \| `number`*
-
-*Inherited from [MultiDestinationState](multidestinationstate.md).[rootStreamPosition](multidestinationstate.md#rootstreamposition)*
-
-*Defined in [multi-write.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L47)*
+*Defined in [lib/multi-write.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L53)*
 
 ___
-<a id="rootstreamspeed"></a>
 
-### `<Optional>` rootStreamSpeed
+### `Optional` rootStreamPosition
 
-**● rootStreamSpeed**: *`undefined` \| `number`*
+• **rootStreamPosition**? : *undefined | number*
 
-*Inherited from [MultiDestinationState](multidestinationstate.md).[rootStreamSpeed](multidestinationstate.md#rootstreamspeed)*
+*Inherited from [MultiDestinationState](multidestinationstate.md).[rootStreamPosition](multidestinationstate.md#optional-rootstreamposition)*
 
-*Defined in [multi-write.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L48)*
-
-___
-<a id="size"></a>
-
-### `<Optional>` size
-
-**● size**: *`undefined` \| `number`*
-
-*Inherited from [MultiDestinationState](multidestinationstate.md).[size](multidestinationstate.md#size)*
-
-*Defined in [multi-write.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L43)*
+*Defined in [lib/multi-write.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L47)*
 
 ___
-<a id="sparse"></a>
 
-### `<Optional>` sparse
+### `Optional` rootStreamSpeed
 
-**● sparse**: *`undefined` \| `false` \| `true`*
+• **rootStreamSpeed**? : *undefined | number*
 
-*Inherited from [MultiDestinationState](multidestinationstate.md).[sparse](multidestinationstate.md#sparse)*
+*Inherited from [MultiDestinationState](multidestinationstate.md).[rootStreamSpeed](multidestinationstate.md#optional-rootstreamspeed)*
 
-*Defined in [multi-write.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L46)*
+*Defined in [lib/multi-write.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L48)*
 
 ___
-<a id="speed"></a>
+
+### `Optional` size
+
+• **size**? : *undefined | number*
+
+*Inherited from [MultiDestinationState](multidestinationstate.md).[size](multidestinationstate.md#optional-size)*
+
+*Defined in [lib/multi-write.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L43)*
+
+___
+
+### `Optional` sparse
+
+• **sparse**? : *undefined | false | true*
+
+*Inherited from [MultiDestinationState](multidestinationstate.md).[sparse](multidestinationstate.md#optional-sparse)*
+
+*Defined in [lib/multi-write.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L46)*
+
+___
 
 ###  speed
 
-**● speed**: *`number`*
+• **speed**: *number*
 
-*Defined in [multi-write.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L54)*
+*Defined in [lib/multi-write.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L54)*
 
 ___
-<a id="successful"></a>
 
 ###  successful
 
-**● successful**: *`number`*
+• **successful**: *number*
 
 *Inherited from [MultiDestinationState](multidestinationstate.md).[successful](multidestinationstate.md#successful)*
 
-*Defined in [multi-write.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L41)*
+*Defined in [lib/multi-write.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L41)*
 
 ___
-<a id="totalspeed"></a>
 
 ###  totalSpeed
 
-**● totalSpeed**: *`number`*
+• **totalSpeed**: *number*
 
-*Defined in [multi-write.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L55)*
+*Defined in [lib/multi-write.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L55)*
 
 ___
-<a id="type"></a>
 
 ###  type
 
-**● type**: *[WriteStep](../#writestep)*
+• **type**: *[WriteStep](../README.md#writestep)*
 
 *Inherited from [MultiDestinationState](multidestinationstate.md).[type](multidestinationstate.md#type)*
 
-*Defined in [multi-write.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L42)*
+*Defined in [lib/multi-write.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L42)*
 
 ___
-<a id="verifying"></a>
 
 ###  verifying
 
-**● verifying**: *`number`*
+• **verifying**: *number*
 
 *Inherited from [MultiDestinationState](multidestinationstate.md).[verifying](multidestinationstate.md#verifying)*
 
-*Defined in [multi-write.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L39)*
-
-___
-
+*Defined in [lib/multi-write.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L39)*

--- a/doc/interfaces/multidestinationstate.md
+++ b/doc/interfaces/multidestinationstate.md
@@ -1,140 +1,122 @@
-[etcher-sdk](../README.md) > [MultiDestinationState](../interfaces/multidestinationstate.md)
+[etcher-sdk](../README.md) › [MultiDestinationState](multidestinationstate.md)
 
 # Interface: MultiDestinationState
 
 ## Hierarchy
 
-**MultiDestinationState**
+* **MultiDestinationState**
 
-↳  [MultiDestinationProgress](multidestinationprogress.md)
+  ↳ [MultiDestinationProgress](multidestinationprogress.md)
 
 ## Index
 
 ### Properties
 
 * [active](multidestinationstate.md#active)
-* [blockmappedSize](multidestinationstate.md#blockmappedsize)
-* [compressedSize](multidestinationstate.md#compressedsize)
+* [blockmappedSize](multidestinationstate.md#optional-blockmappedsize)
+* [compressedSize](multidestinationstate.md#optional-compressedsize)
 * [failed](multidestinationstate.md#failed)
 * [flashing](multidestinationstate.md#flashing)
-* [rootStreamPosition](multidestinationstate.md#rootstreamposition)
-* [rootStreamSpeed](multidestinationstate.md#rootstreamspeed)
-* [size](multidestinationstate.md#size)
-* [sparse](multidestinationstate.md#sparse)
+* [rootStreamPosition](multidestinationstate.md#optional-rootstreamposition)
+* [rootStreamSpeed](multidestinationstate.md#optional-rootstreamspeed)
+* [size](multidestinationstate.md#optional-size)
+* [sparse](multidestinationstate.md#optional-sparse)
 * [successful](multidestinationstate.md#successful)
 * [type](multidestinationstate.md#type)
 * [verifying](multidestinationstate.md#verifying)
 
----
-
 ## Properties
-
-<a id="active"></a>
 
 ###  active
 
-**● active**: *`number`*
+• **active**: *number*
 
-*Defined in [multi-write.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L37)*
-
-___
-<a id="blockmappedsize"></a>
-
-### `<Optional>` blockmappedSize
-
-**● blockmappedSize**: *`undefined` \| `number`*
-
-*Defined in [multi-write.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L45)*
+*Defined in [lib/multi-write.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L37)*
 
 ___
-<a id="compressedsize"></a>
 
-### `<Optional>` compressedSize
+### `Optional` blockmappedSize
 
-**● compressedSize**: *`undefined` \| `number`*
+• **blockmappedSize**? : *undefined | number*
 
-*Defined in [multi-write.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L44)*
+*Defined in [lib/multi-write.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L45)*
 
 ___
-<a id="failed"></a>
+
+### `Optional` compressedSize
+
+• **compressedSize**? : *undefined | number*
+
+*Defined in [lib/multi-write.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L44)*
+
+___
 
 ###  failed
 
-**● failed**: *`number`*
+• **failed**: *number*
 
-*Defined in [multi-write.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L40)*
+*Defined in [lib/multi-write.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L40)*
 
 ___
-<a id="flashing"></a>
 
 ###  flashing
 
-**● flashing**: *`number`*
+• **flashing**: *number*
 
-*Defined in [multi-write.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L38)*
-
-___
-<a id="rootstreamposition"></a>
-
-### `<Optional>` rootStreamPosition
-
-**● rootStreamPosition**: *`undefined` \| `number`*
-
-*Defined in [multi-write.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L47)*
+*Defined in [lib/multi-write.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L38)*
 
 ___
-<a id="rootstreamspeed"></a>
 
-### `<Optional>` rootStreamSpeed
+### `Optional` rootStreamPosition
 
-**● rootStreamSpeed**: *`undefined` \| `number`*
+• **rootStreamPosition**? : *undefined | number*
 
-*Defined in [multi-write.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L48)*
-
-___
-<a id="size"></a>
-
-### `<Optional>` size
-
-**● size**: *`undefined` \| `number`*
-
-*Defined in [multi-write.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L43)*
+*Defined in [lib/multi-write.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L47)*
 
 ___
-<a id="sparse"></a>
 
-### `<Optional>` sparse
+### `Optional` rootStreamSpeed
 
-**● sparse**: *`undefined` \| `false` \| `true`*
+• **rootStreamSpeed**? : *undefined | number*
 
-*Defined in [multi-write.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L46)*
+*Defined in [lib/multi-write.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L48)*
 
 ___
-<a id="successful"></a>
+
+### `Optional` size
+
+• **size**? : *undefined | number*
+
+*Defined in [lib/multi-write.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L43)*
+
+___
+
+### `Optional` sparse
+
+• **sparse**? : *undefined | false | true*
+
+*Defined in [lib/multi-write.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L46)*
+
+___
 
 ###  successful
 
-**● successful**: *`number`*
+• **successful**: *number*
 
-*Defined in [multi-write.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L41)*
+*Defined in [lib/multi-write.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L41)*
 
 ___
-<a id="type"></a>
 
 ###  type
 
-**● type**: *[WriteStep](../#writestep)*
+• **type**: *[WriteStep](../README.md#writestep)*
 
-*Defined in [multi-write.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L42)*
+*Defined in [lib/multi-write.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L42)*
 
 ___
-<a id="verifying"></a>
 
 ###  verifying
 
-**● verifying**: *`number`*
+• **verifying**: *number*
 
-*Defined in [multi-write.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L39)*
-
-___
-
+*Defined in [lib/multi-write.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L39)*

--- a/doc/interfaces/operation.md
+++ b/doc/interfaces/operation.md
@@ -1,10 +1,10 @@
-[etcher-sdk](../README.md) > [Operation](../interfaces/operation.md)
+[etcher-sdk](../README.md) › [Operation](operation.md)
 
 # Interface: Operation
 
 ## Hierarchy
 
-**Operation**
+* **Operation**
 
 ## Index
 
@@ -13,26 +13,18 @@
 * [command](operation.md#command)
 * [when](operation.md#when)
 
----
-
 ## Properties
-
-<a id="command"></a>
 
 ###  command
 
-**● command**: *[OperationCommand](../#operationcommand)*
+• **command**: *[OperationCommand](../README.md#operationcommand)*
 
-*Defined in [source-destination/configured-source/configure.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configure.ts#L31)*
+*Defined in [lib/source-destination/configured-source/configure.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configure.ts#L31)*
 
 ___
-<a id="when"></a>
 
 ###  when
 
-**● when**: *`any`*
+• **when**: *any*
 
-*Defined in [source-destination/configured-source/configure.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/configure.ts#L32)*
-
-___
-
+*Defined in [lib/source-destination/configured-source/configure.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/configure.ts#L32)*

--- a/doc/interfaces/pipesourcetodestinationsresult.md
+++ b/doc/interfaces/pipesourcetodestinationsresult.md
@@ -1,10 +1,10 @@
-[etcher-sdk](../README.md) > [PipeSourceToDestinationsResult](../interfaces/pipesourcetodestinationsresult.md)
+[etcher-sdk](../README.md) › [PipeSourceToDestinationsResult](pipesourcetodestinationsresult.md)
 
 # Interface: PipeSourceToDestinationsResult
 
 ## Hierarchy
 
-**PipeSourceToDestinationsResult**
+* **PipeSourceToDestinationsResult**
 
 ## Index
 
@@ -13,26 +13,18 @@
 * [bytesWritten](pipesourcetodestinationsresult.md#byteswritten)
 * [failures](pipesourcetodestinationsresult.md#failures)
 
----
-
 ## Properties
-
-<a id="byteswritten"></a>
 
 ###  bytesWritten
 
-**● bytesWritten**: *`number`*
+• **bytesWritten**: *number*
 
-*Defined in [multi-write.ts:69](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L69)*
+*Defined in [lib/multi-write.ts:69](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L69)*
 
 ___
-<a id="failures"></a>
 
 ###  failures
 
-**● failures**: *`Map`<[SourceDestination](../classes/sourcedestination.md), `Error`>*
+• **failures**: *Map‹[SourceDestination](../classes/sourcedestination.md), [Error](../classes/notcapable.md#static-error)›*
 
-*Defined in [multi-write.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/multi-write.ts#L68)*
-
-___
-
+*Defined in [lib/multi-write.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/multi-write.ts#L68)*

--- a/doc/interfaces/progressevent.md
+++ b/doc/interfaces/progressevent.md
@@ -1,10 +1,10 @@
-[etcher-sdk](../README.md) > [ProgressEvent](../interfaces/progressevent.md)
+[etcher-sdk](../README.md) › [ProgressEvent](progressevent.md)
 
 # Interface: ProgressEvent
 
 ## Hierarchy
 
-**ProgressEvent**
+* **ProgressEvent**
 
 ## Index
 
@@ -14,35 +14,26 @@
 * [position](progressevent.md#position)
 * [speed](progressevent.md#speed)
 
----
-
 ## Properties
-
-<a id="bytes"></a>
 
 ###  bytes
 
-**● bytes**: *`number`*
+• **bytes**: *number*
 
-*Defined in [source-destination/progress.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/progress.ts#L29)*
+*Defined in [lib/source-destination/progress.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/progress.ts#L29)*
 
 ___
-<a id="position"></a>
 
 ###  position
 
-**● position**: *`number`*
+• **position**: *number*
 
-*Defined in [source-destination/progress.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/progress.ts#L28)*
+*Defined in [lib/source-destination/progress.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/progress.ts#L28)*
 
 ___
-<a id="speed"></a>
 
 ###  speed
 
-**● speed**: *`number`*
+• **speed**: *number*
 
-*Defined in [source-destination/progress.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/progress.ts#L30)*
-
-___
-
+*Defined in [lib/source-destination/progress.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/progress.ts#L30)*

--- a/doc/interfaces/sourcetransform.md
+++ b/doc/interfaces/sourcetransform.md
@@ -1,17 +1,17 @@
-[etcher-sdk](../README.md) > [SourceTransform](../interfaces/sourcetransform.md)
+[etcher-sdk](../README.md) › [SourceTransform](sourcetransform.md)
 
 # Interface: SourceTransform
 
 ## Hierarchy
 
- `Transform`
+* Transform
 
-**↳ SourceTransform**
+  ↳ **SourceTransform**
 
 ## Implements
 
-* `ReadableStream`
-* `Writable`
+* ReadableStream
+* Writable
 
 ## Index
 
@@ -24,7 +24,7 @@
 * [readable](sourcetransform.md#readable)
 * [sourceStream](sourcetransform.md#sourcestream)
 * [writable](sourcetransform.md#writable)
-* [defaultMaxListeners](sourcetransform.md#defaultmaxlisteners)
+* [defaultMaxListeners](sourcetransform.md#static-defaultmaxlisteners)
 
 ### Methods
 
@@ -57,1315 +57,1360 @@
 * [unshift](sourcetransform.md#unshift)
 * [wrap](sourcetransform.md#wrap)
 * [write](sourcetransform.md#write)
-* [listenerCount](sourcetransform.md#listenercount-1)
-
----
+* [listenerCount](sourcetransform.md#static-listenercount)
 
 ## Constructors
 
-<a id="constructor"></a>
-
 ###  constructor
 
-⊕ **new SourceTransform**(opts?: *`TransformOptions`*): [SourceTransform](sourcetransform.md)
+\+ **new SourceTransform**(`opts?`: TransformOptions): *[SourceTransform](sourcetransform.md)*
 
-*Inherited from Transform.__constructor*
+*Inherited from [SourceTransform](sourcetransform.md).[constructor](sourcetransform.md#constructor)*
 
-*Overrides Duplex.__constructor*
+*Overrides void*
 
-*Defined in /node_modules/@types/node/base.d.ts:3871*
+Defined in node_modules/@types/node/base.d.ts:3871
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` opts | `TransformOptions` |
+Name | Type |
+------ | ------ |
+`opts?` | TransformOptions |
 
-**Returns:** [SourceTransform](sourcetransform.md)
-
-___
+**Returns:** *[SourceTransform](sourcetransform.md)*
 
 ## Properties
 
-<a id="readable"></a>
-
 ###  readable
 
-**● readable**: *`boolean`*
+• **readable**: *boolean*
 
-*Inherited from Readable.readable*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[readable](../classes/sparsefilterstream.md#readable)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3688*
+Defined in node_modules/@types/node/base.d.ts:3688
 
 ___
-<a id="sourcestream"></a>
 
 ###  sourceStream
 
-**● sourceStream**: *`ReadableStream`*
+• **sourceStream**: *ReadableStream*
 
-*Defined in [source-destination/compressed-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/compressed-source.ts#L26)*
+*Defined in [lib/source-destination/compressed-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/compressed-source.ts#L26)*
 
 ___
-<a id="writable"></a>
 
 ###  writable
 
-**● writable**: *`boolean`*
+• **writable**: *boolean*
 
-*Inherited from Duplex.writable*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[writable](../classes/sparsefilterstream.md#writable)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3855*
-
-___
-<a id="defaultmaxlisteners"></a>
-
-### `<Static>` defaultMaxListeners
-
-**● defaultMaxListeners**: *`number`*
-
-*Inherited from EventEmitter.defaultMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:681*
+Defined in node_modules/@types/node/base.d.ts:3855
 
 ___
+
+### `Static` defaultMaxListeners
+
+▪ **defaultMaxListeners**: *number*
+
+*Inherited from [CountingWritable](../classes/countingwritable.md).[defaultMaxListeners](../classes/countingwritable.md#static-defaultmaxlisteners)*
+
+Defined in node_modules/@types/node/base.d.ts:681
 
 ## Methods
 
-<a id="_read"></a>
-
 ###  _read
 
-▸ **_read**(size: *`number`*): `void`
+▸ **_read**(`size`: number): *void*
 
-*Inherited from Readable._read*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[_read](../classes/sparsefilterstream.md#_read)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3690*
+Defined in node_modules/@types/node/base.d.ts:3690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| size | `number` |
+Name | Type |
+------ | ------ |
+`size` | number |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="_transform"></a>
 
 ###  _transform
 
-▸ **_transform**(chunk: *`any`*, encoding: *`string`*, callback: *`Function`*): `void`
+▸ **_transform**(`chunk`: any, `encoding`: string, `callback`: Function): *void*
 
-*Inherited from Transform._transform*
+*Inherited from [SourceTransform](sourcetransform.md).[_transform](sourcetransform.md#_transform)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3873*
+Defined in node_modules/@types/node/base.d.ts:3873
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| encoding | `string` |
-| callback | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding` | string |
+`callback` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="_write"></a>
 
 ###  _write
 
-▸ **_write**(chunk: *`any`*, encoding: *`string`*, callback: *`Function`*): `void`
+▸ **_write**(`chunk`: any, `encoding`: string, `callback`: Function): *void*
 
-*Inherited from Duplex._write*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[_write](../classes/sparsefilterstream.md#_write)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3857*
+Defined in node_modules/@types/node/base.d.ts:3857
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| encoding | `string` |
-| callback | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding` | string |
+`callback` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="addlistener"></a>
 
 ###  addListener
 
-▸ **addListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string, `listener`: Function): *this*
 
-▸ **addListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[addListener](../classes/sparsefilterstream.md#addlistener)*
 
-▸ **addListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](../classes/sourcesource.md).[addListener](../classes/sourcesource.md#addlistener)*
 
-▸ **addListener**(event: *"end"*, listener: *`function`*): `this`
+Defined in node_modules/@types/node/base.d.ts:3711
 
-▸ **addListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **addListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3711*
-
-Event emitter The defined events on documents including:
-
-1.  close
-2.  data
-3.  end
-4.  readable
-5.  error
+Event emitter
+The defined events on documents including:
+  1. close
+  2. data
+  3. end
+  4. readable
+  5. error
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.addListener*
+▸ **addListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.addListener*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[addListener](../classes/sparsefilterstream.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3712*
+*Overrides [SourceSource](../classes/sourcesource.md).[addListener](../classes/sourcesource.md#addlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3713*
+Defined in node_modules/@types/node/base.d.ts:3712
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.addListener*
+▸ (): *void*
 
-*Overrides EventEmitter.addListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3714*
+▸ **addListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[addListener](../classes/sparsefilterstream.md#addlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](../classes/sourcesource.md).[addListener](../classes/sourcesource.md#addlistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3715*
+Defined in node_modules/@types/node/base.d.ts:3713
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.addListener*
-
-*Overrides EventEmitter.addListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3716*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **addListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[addListener](../classes/sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[addListener](../classes/sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3714
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[addListener](../classes/sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[addListener](../classes/sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3715
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **addListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[addListener](../classes/sparsefilterstream.md#addlistener)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[addListener](../classes/sourcesource.md#addlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3716
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](../classes/notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](../classes/notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-▸ **emit**(event: *"close"*): `boolean`
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[emit](../classes/sparsefilterstream.md#emit)*
 
-▸ **emit**(event: *"data"*, chunk: *`Buffer` \| `string`*): `boolean`
+*Overrides [SourceSource](../classes/sourcesource.md).[emit](../classes/sourcesource.md#emit)*
 
-▸ **emit**(event: *"end"*): `boolean`
-
-▸ **emit**(event: *"readable"*): `boolean`
-
-▸ **emit**(event: *"error"*, err: *`Error`*): `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3718*
+Defined in node_modules/@types/node/base.d.ts:3718
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "close"): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[emit](../classes/sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3719*
+*Overrides [SourceSource](../classes/sourcesource.md).[emit](../classes/sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-
-**Returns:** `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3720*
+Defined in node_modules/@types/node/base.d.ts:3719
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| chunk | `Buffer` \| `string` |
+Name | Type |
+------ | ------ |
+`event` | "close" |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "data", `chunk`: Buffer | string): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[emit](../classes/sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3721*
+*Overrides [SourceSource](../classes/sourcesource.md).[emit](../classes/sourcesource.md#emit)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-
-**Returns:** `boolean`
-
-*Inherited from Readable.emit*
-
-*Overrides EventEmitter.emit*
-
-*Defined in /node_modules/@types/node/base.d.ts:3722*
+Defined in node_modules/@types/node/base.d.ts:3720
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
+Name | Type |
+------ | ------ |
+`event` | "data" |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Readable.emit*
+▸ **emit**(`event`: "end"): *boolean*
 
-*Overrides EventEmitter.emit*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[emit](../classes/sparsefilterstream.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3723*
+*Overrides [SourceSource](../classes/sourcesource.md).[emit](../classes/sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3721
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| err | `Error` |
+Name | Type |
+------ | ------ |
+`event` | "end" |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "readable"): *boolean*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[emit](../classes/sparsefilterstream.md#emit)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[emit](../classes/sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3722
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "readable" |
+
+**Returns:** *boolean*
+
+▸ **emit**(`event`: "error", `err`: [Error](../classes/notcapable.md#static-error)): *boolean*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[emit](../classes/sparsefilterstream.md#emit)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[emit](../classes/sourcesource.md#emit)*
+
+Defined in node_modules/@types/node/base.d.ts:3723
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`event` | "error" |
+`err` | [Error](../classes/notcapable.md#static-error) |
+
+**Returns:** *boolean*
 
 ___
-<a id="end"></a>
 
 ###  end
 
-▸ **end**(cb?: *`Function`*): `void`
+▸ **end**(`cb?`: Function): *void*
 
-▸ **end**(chunk: *`any`*, cb?: *`Function`*): `void`
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[end](../classes/sparsefilterstream.md#end)*
 
-▸ **end**(chunk: *`any`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `void`
-
-*Inherited from Duplex.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:3861*
+Defined in node_modules/@types/node/base.d.ts:3861
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
 
-*Inherited from Duplex.end*
+▸ **end**(`chunk`: any, `cb?`: Function): *void*
 
-*Defined in /node_modules/@types/node/base.d.ts:3862*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[end](../classes/sparsefilterstream.md#end)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` cb | `Function` |
-
-**Returns:** `void`
-
-*Inherited from Duplex.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:3863*
+Defined in node_modules/@types/node/base.d.ts:3862
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
+
+▸ **end**(`chunk`: any, `encoding?`: undefined | string, `cb?`: Function): *void*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[end](../classes/sparsefilterstream.md#end)*
+
+Defined in node_modules/@types/node/base.d.ts:3863
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
+
+**Returns:** *void*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [CountingWritable](../classes/countingwritable.md).[eventNames](../classes/countingwritable.md#eventnames)*
 
-*Overrides EventEmitter.eventNames*
+Defined in node_modules/@types/node/base.d.ts:694
 
-*Defined in /node_modules/@types/node/base.d.ts:694*
-
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [CountingWritable](../classes/countingwritable.md).[getMaxListeners](../classes/countingwritable.md#getmaxlisteners)*
 
-*Overrides EventEmitter.getMaxListeners*
+Defined in node_modules/@types/node/base.d.ts:691
 
-*Defined in /node_modules/@types/node/base.d.ts:691*
-
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="ispaused"></a>
 
 ###  isPaused
 
-▸ **isPaused**(): `boolean`
+▸ **isPaused**(): *boolean*
 
-*Inherited from Readable.isPaused*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[isPaused](../classes/sparsefilterstream.md#ispaused)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3695*
+Defined in node_modules/@types/node/base.d.ts:3695
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [CountingWritable](../classes/countingwritable.md).[listenerCount](../classes/countingwritable.md#static-listenercount)*
 
-*Overrides EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:695*
+Defined in node_modules/@types/node/base.d.ts:695
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [CountingWritable](../classes/countingwritable.md).[listeners](../classes/countingwritable.md#listeners)*
 
-*Overrides EventEmitter.listeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:692*
+Defined in node_modules/@types/node/base.d.ts:692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string, `listener`: Function): *this*
 
-▸ **on**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[on](../classes/sparsefilterstream.md#on)*
 
-▸ **on**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](../classes/sourcesource.md).[on](../classes/sourcesource.md#on)*
 
-▸ **on**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **on**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3725*
+Defined in node_modules/@types/node/base.d.ts:3725
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.on*
+▸ **on**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.on*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[on](../classes/sparsefilterstream.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3726*
+*Overrides [SourceSource](../classes/sourcesource.md).[on](../classes/sourcesource.md#on)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3727*
+Defined in node_modules/@types/node/base.d.ts:3726
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.on*
+▸ (): *void*
 
-*Overrides EventEmitter.on*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3728*
+▸ **on**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[on](../classes/sparsefilterstream.md#on)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](../classes/sourcesource.md).[on](../classes/sourcesource.md#on)*
 
-**Returns:** `this`
-
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3729*
+Defined in node_modules/@types/node/base.d.ts:3727
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.on*
-
-*Overrides EventEmitter.on*
-
-*Defined in /node_modules/@types/node/base.d.ts:3730*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **on**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[on](../classes/sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[on](../classes/sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3728
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **on**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[on](../classes/sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[on](../classes/sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3729
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **on**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[on](../classes/sparsefilterstream.md#on)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[on](../classes/sourcesource.md#on)*
+
+Defined in node_modules/@types/node/base.d.ts:3730
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](../classes/notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](../classes/notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string, `listener`: Function): *this*
 
-▸ **once**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[once](../classes/sparsefilterstream.md#once)*
 
-▸ **once**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](../classes/sourcesource.md).[once](../classes/sourcesource.md#once)*
 
-▸ **once**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **once**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3732*
+Defined in node_modules/@types/node/base.d.ts:3732
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.once*
+▸ **once**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.once*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[once](../classes/sparsefilterstream.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3733*
+*Overrides [SourceSource](../classes/sourcesource.md).[once](../classes/sourcesource.md#once)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3734*
+Defined in node_modules/@types/node/base.d.ts:3733
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.once*
+▸ (): *void*
 
-*Overrides EventEmitter.once*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3735*
+▸ **once**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[once](../classes/sparsefilterstream.md#once)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](../classes/sourcesource.md).[once](../classes/sourcesource.md#once)*
 
-**Returns:** `this`
-
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3736*
+Defined in node_modules/@types/node/base.d.ts:3734
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.once*
-
-*Overrides EventEmitter.once*
-
-*Defined in /node_modules/@types/node/base.d.ts:3737*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **once**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[once](../classes/sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[once](../classes/sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3735
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **once**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[once](../classes/sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[once](../classes/sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3736
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **once**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[once](../classes/sparsefilterstream.md#once)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[once](../classes/sourcesource.md#once)*
+
+Defined in node_modules/@types/node/base.d.ts:3737
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](../classes/notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](../classes/notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="pause"></a>
 
 ###  pause
 
-▸ **pause**(): `this`
+▸ **pause**(): *this*
 
-*Inherited from Readable.pause*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[pause](../classes/sparsefilterstream.md#pause)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3693*
+Defined in node_modules/@types/node/base.d.ts:3693
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="pipe"></a>
 
 ###  pipe
 
-▸ **pipe**<`T`>(destination: *`T`*, options?: *`undefined` \| `object`*): `T`
+▸ **pipe**<**T**>(`destination`: T, `options?`: undefined | object): *T*
 
-*Inherited from Readable.pipe*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[pipe](../classes/sparsefilterstream.md#pipe)*
 
-*Overrides internal.pipe*
+*Overrides [CountingWritable](../classes/countingwritable.md).[pipe](../classes/countingwritable.md#pipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3696*
+Defined in node_modules/@types/node/base.d.ts:3696
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| destination | `T` |
-| `Optional` options | `undefined` \| `object` |
+Name | Type |
+------ | ------ |
+`destination` | T |
+`options?` | undefined &#124; object |
 
-**Returns:** `T`
+**Returns:** *T*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[prependListener](../classes/sparsefilterstream.md#prependlistener)*
 
-▸ **prependListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](../classes/sourcesource.md).[prependListener](../classes/sourcesource.md#prependlistener)*
 
-▸ **prependListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **prependListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3739*
+Defined in node_modules/@types/node/base.d.ts:3739
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.prependListener*
+▸ **prependListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependListener*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[prependListener](../classes/sparsefilterstream.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3740*
+*Overrides [SourceSource](../classes/sourcesource.md).[prependListener](../classes/sourcesource.md#prependlistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3741*
+Defined in node_modules/@types/node/base.d.ts:3740
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3742*
+▸ **prependListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[prependListener](../classes/sparsefilterstream.md#prependlistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](../classes/sourcesource.md).[prependListener](../classes/sourcesource.md#prependlistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3743*
+Defined in node_modules/@types/node/base.d.ts:3741
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependListener*
-
-*Overrides EventEmitter.prependListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3744*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[prependListener](../classes/sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[prependListener](../classes/sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3742
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[prependListener](../classes/sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[prependListener](../classes/sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3743
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[prependListener](../classes/sparsefilterstream.md#prependlistener)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[prependListener](../classes/sourcesource.md#prependlistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3744
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](../classes/notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](../classes/notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string, `listener`: Function): *this*
 
-▸ **prependOnceListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[prependOnceListener](../classes/sparsefilterstream.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](../classes/sourcesource.md).[prependOnceListener](../classes/sourcesource.md#prependoncelistener)*
 
-▸ **prependOnceListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **prependOnceListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3746*
+Defined in node_modules/@types/node/base.d.ts:3746
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.prependOnceListener*
+▸ **prependOnceListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.prependOnceListener*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[prependOnceListener](../classes/sparsefilterstream.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3747*
+*Overrides [SourceSource](../classes/sourcesource.md).[prependOnceListener](../classes/sourcesource.md#prependoncelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3748*
+Defined in node_modules/@types/node/base.d.ts:3747
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependOnceListener*
+▸ (): *void*
 
-*Overrides EventEmitter.prependOnceListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3749*
+▸ **prependOnceListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[prependOnceListener](../classes/sparsefilterstream.md#prependoncelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](../classes/sourcesource.md).[prependOnceListener](../classes/sourcesource.md#prependoncelistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3750*
+Defined in node_modules/@types/node/base.d.ts:3748
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.prependOnceListener*
-
-*Overrides EventEmitter.prependOnceListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3751*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[prependOnceListener](../classes/sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[prependOnceListener](../classes/sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3749
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[prependOnceListener](../classes/sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[prependOnceListener](../classes/sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3750
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **prependOnceListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[prependOnceListener](../classes/sparsefilterstream.md#prependoncelistener)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[prependOnceListener](../classes/sourcesource.md#prependoncelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3751
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](../classes/notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](../classes/notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="push"></a>
 
 ###  push
 
-▸ **push**(chunk: *`any`*, encoding?: *`undefined` \| `string`*): `boolean`
+▸ **push**(`chunk`: any, `encoding?`: undefined | string): *boolean*
 
-*Inherited from Readable.push*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[push](../classes/sparsefilterstream.md#push)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3700*
+Defined in node_modules/@types/node/base.d.ts:3700
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(size?: *`undefined` \| `number`*): `any`
+▸ **read**(`size?`: undefined | number): *any*
 
-*Inherited from Readable.read*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[read](../classes/sparsefilterstream.md#read)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3691*
+Defined in node_modules/@types/node/base.d.ts:3691
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`size?` | undefined &#124; number |
 
-**Returns:** `any`
+**Returns:** *any*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [CountingWritable](../classes/countingwritable.md).[removeAllListeners](../classes/countingwritable.md#removealllisteners)*
 
-*Overrides EventEmitter.removeAllListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:689*
+Defined in node_modules/@types/node/base.d.ts:689
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string, `listener`: Function): *this*
 
-▸ **removeListener**(event: *"close"*, listener: *`function`*): `this`
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[removeListener](../classes/sparsefilterstream.md#removelistener)*
 
-▸ **removeListener**(event: *"data"*, listener: *`function`*): `this`
+*Overrides [SourceSource](../classes/sourcesource.md).[removeListener](../classes/sourcesource.md#removelistener)*
 
-▸ **removeListener**(event: *"end"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"readable"*, listener: *`function`*): `this`
-
-▸ **removeListener**(event: *"error"*, listener: *`function`*): `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3753*
+Defined in node_modules/@types/node/base.d.ts:3753
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
-*Inherited from Readable.removeListener*
+▸ **removeListener**(`event`: "close", `listener`: function): *this*
 
-*Overrides EventEmitter.removeListener*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[removeListener](../classes/sparsefilterstream.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3754*
+*Overrides [SourceSource](../classes/sourcesource.md).[removeListener](../classes/sourcesource.md#removelistener)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| event | "close" |
-| listener | `function` |
-
-**Returns:** `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3755*
+Defined in node_modules/@types/node/base.d.ts:3754
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "data" |
-| listener | `function` |
+▪ **event**: *"close"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.removeListener*
+▸ (): *void*
 
-*Overrides EventEmitter.removeListener*
+**Returns:** *this*
 
-*Defined in /node_modules/@types/node/base.d.ts:3756*
+▸ **removeListener**(`event`: "data", `listener`: function): *this*
 
-**Parameters:**
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[removeListener](../classes/sparsefilterstream.md#removelistener)*
 
-| Name | Type |
-| ------ | ------ |
-| event | "end" |
-| listener | `function` |
+*Overrides [SourceSource](../classes/sourcesource.md).[removeListener](../classes/sourcesource.md#removelistener)*
 
-**Returns:** `this`
-
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3757*
+Defined in node_modules/@types/node/base.d.ts:3755
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "readable" |
-| listener | `function` |
+▪ **event**: *"data"*
 
-**Returns:** `this`
+▪ **listener**: *function*
 
-*Inherited from Readable.removeListener*
-
-*Overrides EventEmitter.removeListener*
-
-*Defined in /node_modules/@types/node/base.d.ts:3758*
+▸ (`chunk`: Buffer | string): *void*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | "error" |
-| listener | `function` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer &#124; string |
 
-**Returns:** `this`
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "end", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[removeListener](../classes/sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[removeListener](../classes/sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3756
+
+**Parameters:**
+
+▪ **event**: *"end"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "readable", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[removeListener](../classes/sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[removeListener](../classes/sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3757
+
+**Parameters:**
+
+▪ **event**: *"readable"*
+
+▪ **listener**: *function*
+
+▸ (): *void*
+
+**Returns:** *this*
+
+▸ **removeListener**(`event`: "error", `listener`: function): *this*
+
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[removeListener](../classes/sparsefilterstream.md#removelistener)*
+
+*Overrides [SourceSource](../classes/sourcesource.md).[removeListener](../classes/sourcesource.md#removelistener)*
+
+Defined in node_modules/@types/node/base.d.ts:3758
+
+**Parameters:**
+
+▪ **event**: *"error"*
+
+▪ **listener**: *function*
+
+▸ (`err`: [Error](../classes/notcapable.md#static-error)): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err` | [Error](../classes/notcapable.md#static-error) |
+
+**Returns:** *this*
 
 ___
-<a id="resume"></a>
 
 ###  resume
 
-▸ **resume**(): `this`
+▸ **resume**(): *this*
 
-*Inherited from Readable.resume*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[resume](../classes/sparsefilterstream.md#resume)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3694*
+Defined in node_modules/@types/node/base.d.ts:3694
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setdefaultencoding"></a>
 
 ###  setDefaultEncoding
 
-▸ **setDefaultEncoding**(encoding: *`string`*): `this`
+▸ **setDefaultEncoding**(`encoding`: string): *this*
 
-*Inherited from Duplex.setDefaultEncoding*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[setDefaultEncoding](../classes/sparsefilterstream.md#setdefaultencoding)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3860*
+Defined in node_modules/@types/node/base.d.ts:3860
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| encoding | `string` |
+Name | Type |
+------ | ------ |
+`encoding` | string |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setencoding"></a>
 
 ###  setEncoding
 
-▸ **setEncoding**(encoding: *`string`*): `void`
+▸ **setEncoding**(`encoding`: string): *void*
 
-*Inherited from Readable.setEncoding*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[setEncoding](../classes/sparsefilterstream.md#setencoding)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3692*
+Defined in node_modules/@types/node/base.d.ts:3692
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| encoding | `string` |
+Name | Type |
+------ | ------ |
+`encoding` | string |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [CountingWritable](../classes/countingwritable.md).[setMaxListeners](../classes/countingwritable.md#setmaxlisteners)*
 
-*Overrides EventEmitter.setMaxListeners*
-
-*Defined in /node_modules/@types/node/base.d.ts:690*
+Defined in node_modules/@types/node/base.d.ts:690
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="unpipe"></a>
 
 ###  unpipe
 
-▸ **unpipe**<`T`>(destination?: *[T]()*): `void`
+▸ **unpipe**<**T**>(`destination?`: T): *void*
 
-*Inherited from Readable.unpipe*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[unpipe](../classes/sparsefilterstream.md#unpipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3697*
+Defined in node_modules/@types/node/base.d.ts:3697
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` destination | [T]() |
+Name | Type |
+------ | ------ |
+`destination?` | T |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="unshift"></a>
 
 ###  unshift
 
-▸ **unshift**(chunk: *`any`*): `void`
+▸ **unshift**(`chunk`: any): *void*
 
-*Inherited from Readable.unshift*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[unshift](../classes/sparsefilterstream.md#unshift)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3698*
+Defined in node_modules/@types/node/base.d.ts:3698
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="wrap"></a>
 
 ###  wrap
 
-▸ **wrap**(oldStream: *`ReadableStream`*): `Readable`
+▸ **wrap**(`oldStream`: ReadableStream): *Readable*
 
-*Inherited from Readable.wrap*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[wrap](../classes/sparsefilterstream.md#wrap)*
 
-*Defined in /node_modules/@types/node/base.d.ts:3699*
+Defined in node_modules/@types/node/base.d.ts:3699
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| oldStream | `ReadableStream` |
+Name | Type |
+------ | ------ |
+`oldStream` | ReadableStream |
 
-**Returns:** `Readable`
+**Returns:** *Readable*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(chunk: *`any`*, cb?: *`Function`*): `boolean`
+▸ **write**(`chunk`: any, `cb?`: Function): *boolean*
 
-▸ **write**(chunk: *`any`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `boolean`
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[write](../classes/sparsefilterstream.md#write)*
 
-*Inherited from Duplex.write*
-
-*Defined in /node_modules/@types/node/base.d.ts:3858*
+Defined in node_modules/@types/node/base.d.ts:3858
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`cb?` | Function |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from Duplex.write*
+▸ **write**(`chunk`: any, `encoding?`: undefined | string, `cb?`: Function): *boolean*
 
-*Defined in /node_modules/@types/node/base.d.ts:3859*
+*Inherited from [SparseFilterStream](../classes/sparsefilterstream.md).[write](../classes/sparsefilterstream.md#write)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| chunk | `any` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
-
-**Returns:** `boolean`
-
-___
-<a id="listenercount-1"></a>
-
-### `<Static>` listenerCount
-
-▸ **listenerCount**(emitter: *`EventEmitter`*, event: *`string` \| `symbol`*): `number`
-
-*Inherited from EventEmitter.listenerCount*
-
-*Defined in /node_modules/@types/node/base.d.ts:680*
+Defined in node_modules/@types/node/base.d.ts:3859
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| emitter | `EventEmitter` |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`chunk` | any |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
 
-**Returns:** `number`
+**Returns:** *boolean*
 
 ___
 
+### `Static` listenerCount
+
+▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
+
+*Inherited from [CountingWritable](../classes/countingwritable.md).[listenerCount](../classes/countingwritable.md#static-listenercount)*
+
+Defined in node_modules/@types/node/base.d.ts:680
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`emitter` | EventEmitter |
+`event` | string &#124; symbol |
+
+**Returns:** *number*

--- a/doc/interfaces/sparsereadable.md
+++ b/doc/interfaces/sparsereadable.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [SparseReadable](../interfaces/sparsereadable.md)
+[etcher-sdk](../README.md) › [SparseReadable](sparsereadable.md)
 
 # Interface: SparseReadable
 
 ## Hierarchy
 
- `ReadableStream`
+* ReadableStream
 
-**↳ SparseReadable**
+  ↳ **SparseReadable**
 
 ## Implemented by
 
@@ -46,464 +46,432 @@
 * [unshift](sparsereadable.md#unshift)
 * [wrap](sparsereadable.md#wrap)
 
----
-
 ## Properties
-
-<a id="blocks"></a>
 
 ###  blocks
 
-**● blocks**: *[BlocksWithChecksum](blockswithchecksum.md)[]*
+• **blocks**: *[BlocksWithChecksum](blockswithchecksum.md)[]*
 
-*Defined in [sparse-stream/shared.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L50)*
+*Defined in [lib/sparse-stream/shared.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L50)*
 
 ___
-<a id="readable"></a>
 
 ###  readable
 
-**● readable**: *`boolean`*
+• **readable**: *boolean*
 
-*Inherited from ReadableStream.readable*
+*Inherited from [SparseReadable](sparsereadable.md).[readable](sparsereadable.md#readable)*
 
-*Defined in /node_modules/@types/node/base.d.ts:353*
-
-___
+Defined in node_modules/@types/node/base.d.ts:353
 
 ## Methods
 
-<a id="addlistener"></a>
-
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SparseReadable](sparsereadable.md).[addListener](sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:336*
+Defined in node_modules/@types/node/base.d.ts:336
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SparseReadable](sparsereadable.md).[emit](sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:344*
+Defined in node_modules/@types/node/base.d.ts:344
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [SparseReadable](sparsereadable.md).[eventNames](sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:349*
+Defined in node_modules/@types/node/base.d.ts:349
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [SparseReadable](sparsereadable.md).[getMaxListeners](sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:342*
+Defined in node_modules/@types/node/base.d.ts:342
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="ispaused"></a>
 
 ###  isPaused
 
-▸ **isPaused**(): `boolean`
+▸ **isPaused**(): *boolean*
 
-*Inherited from ReadableStream.isPaused*
+*Inherited from [SparseReadable](sparsereadable.md).[isPaused](sparsereadable.md#ispaused)*
 
-*Defined in /node_modules/@types/node/base.d.ts:358*
+Defined in node_modules/@types/node/base.d.ts:358
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [SparseReadable](sparsereadable.md).[listenerCount](sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:345*
+Defined in node_modules/@types/node/base.d.ts:345
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [SparseReadable](sparsereadable.md).[listeners](sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:343*
+Defined in node_modules/@types/node/base.d.ts:343
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SparseReadable](sparsereadable.md).[on](sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:337*
+Defined in node_modules/@types/node/base.d.ts:337
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SparseReadable](sparsereadable.md).[once](sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:338*
+Defined in node_modules/@types/node/base.d.ts:338
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="pause"></a>
 
 ###  pause
 
-▸ **pause**(): `this`
+▸ **pause**(): *this*
 
-*Inherited from ReadableStream.pause*
+*Inherited from [SparseReadable](sparsereadable.md).[pause](sparsereadable.md#pause)*
 
-*Defined in /node_modules/@types/node/base.d.ts:356*
+Defined in node_modules/@types/node/base.d.ts:356
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="pipe"></a>
 
 ###  pipe
 
-▸ **pipe**<`T`>(destination: *`T`*, options?: *`undefined` \| `object`*): `T`
+▸ **pipe**<**T**>(`destination`: T, `options?`: undefined | object): *T*
 
-*Inherited from ReadableStream.pipe*
+*Inherited from [SparseReadable](sparsereadable.md).[pipe](sparsereadable.md#pipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:359*
+Defined in node_modules/@types/node/base.d.ts:359
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| destination | `T` |
-| `Optional` options | `undefined` \| `object` |
+Name | Type |
+------ | ------ |
+`destination` | T |
+`options?` | undefined &#124; object |
 
-**Returns:** `T`
+**Returns:** *T*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SparseReadable](sparsereadable.md).[prependListener](sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:347*
+Defined in node_modules/@types/node/base.d.ts:347
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SparseReadable](sparsereadable.md).[prependOnceListener](sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:348*
+Defined in node_modules/@types/node/base.d.ts:348
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="push"></a>
 
 ###  push
 
-▸ **push**(chunk: *[SparseStreamChunk](sparsestreamchunk.md)*): `boolean`
+▸ **push**(`chunk`: [SparseStreamChunk](sparsestreamchunk.md)): *boolean*
 
-*Defined in [sparse-stream/shared.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L51)*
+*Defined in [lib/sparse-stream/shared.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L51)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | [SparseStreamChunk](sparsestreamchunk.md) |
+Name | Type |
+------ | ------ |
+`chunk` | [SparseStreamChunk](sparsestreamchunk.md) |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="read"></a>
 
 ###  read
 
-▸ **read**(size?: *`undefined` \| `number`*): `string` \| `Buffer`
+▸ **read**(`size?`: undefined | number): *string | Buffer*
 
-*Inherited from ReadableStream.read*
+*Inherited from [SparseReadable](sparsereadable.md).[read](sparsereadable.md#read)*
 
-*Defined in /node_modules/@types/node/base.d.ts:354*
+Defined in node_modules/@types/node/base.d.ts:354
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` size | `undefined` \| `number` |
+Name | Type |
+------ | ------ |
+`size?` | undefined &#124; number |
 
-**Returns:** `string` \| `Buffer`
+**Returns:** *string | Buffer*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [SparseReadable](sparsereadable.md).[removeAllListeners](sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:340*
+Defined in node_modules/@types/node/base.d.ts:340
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SparseReadable](sparsereadable.md).[removeListener](sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:339*
+Defined in node_modules/@types/node/base.d.ts:339
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="resume"></a>
 
 ###  resume
 
-▸ **resume**(): `this`
+▸ **resume**(): *this*
 
-*Inherited from ReadableStream.resume*
+*Inherited from [SparseReadable](sparsereadable.md).[resume](sparsereadable.md#resume)*
 
-*Defined in /node_modules/@types/node/base.d.ts:357*
+Defined in node_modules/@types/node/base.d.ts:357
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setencoding"></a>
 
 ###  setEncoding
 
-▸ **setEncoding**(encoding: *`string` \| `null`*): `void`
+▸ **setEncoding**(`encoding`: string | null): *void*
 
-*Inherited from ReadableStream.setEncoding*
+*Inherited from [SparseReadable](sparsereadable.md).[setEncoding](sparsereadable.md#setencoding)*
 
-*Defined in /node_modules/@types/node/base.d.ts:355*
+Defined in node_modules/@types/node/base.d.ts:355
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| encoding | `string` \| `null` |
+Name | Type |
+------ | ------ |
+`encoding` | string &#124; null |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [SparseReadable](sparsereadable.md).[setMaxListeners](sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:341*
+Defined in node_modules/@types/node/base.d.ts:341
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="unpipe"></a>
 
 ###  unpipe
 
-▸ **unpipe**<`T`>(destination?: *[T]()*): `void`
+▸ **unpipe**<**T**>(`destination?`: T): *void*
 
-*Inherited from ReadableStream.unpipe*
+*Inherited from [SparseReadable](sparsereadable.md).[unpipe](sparsereadable.md#unpipe)*
 
-*Defined in /node_modules/@types/node/base.d.ts:360*
+Defined in node_modules/@types/node/base.d.ts:360
 
 **Type parameters:**
 
-#### T :  `WritableStream`
+▪ **T**: *WritableStream*
+
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` destination | [T]() |
+Name | Type |
+------ | ------ |
+`destination?` | T |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="unshift"></a>
 
 ###  unshift
 
-▸ **unshift**(chunk: *`string`*): `void`
+▸ **unshift**(`chunk`: string): *void*
 
-▸ **unshift**(chunk: *`Buffer`*): `void`
+*Inherited from [SparseReadable](sparsereadable.md).[unshift](sparsereadable.md#unshift)*
 
-*Inherited from ReadableStream.unshift*
-
-*Defined in /node_modules/@types/node/base.d.ts:361*
+Defined in node_modules/@types/node/base.d.ts:361
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `string` |
+Name | Type |
+------ | ------ |
+`chunk` | string |
 
-**Returns:** `void`
+**Returns:** *void*
 
-*Inherited from ReadableStream.unshift*
+▸ **unshift**(`chunk`: Buffer): *void*
 
-*Defined in /node_modules/@types/node/base.d.ts:362*
+*Inherited from [SparseReadable](sparsereadable.md).[unshift](sparsereadable.md#unshift)*
+
+Defined in node_modules/@types/node/base.d.ts:362
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | `Buffer` |
+Name | Type |
+------ | ------ |
+`chunk` | Buffer |
 
-**Returns:** `void`
+**Returns:** *void*
 
 ___
-<a id="wrap"></a>
 
 ###  wrap
 
-▸ **wrap**(oldStream: *`ReadableStream`*): `ReadableStream`
+▸ **wrap**(`oldStream`: ReadableStream): *ReadableStream*
 
-*Inherited from ReadableStream.wrap*
+*Inherited from [SparseReadable](sparsereadable.md).[wrap](sparsereadable.md#wrap)*
 
-*Defined in /node_modules/@types/node/base.d.ts:363*
+Defined in node_modules/@types/node/base.d.ts:363
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| oldStream | `ReadableStream` |
+Name | Type |
+------ | ------ |
+`oldStream` | ReadableStream |
 
-**Returns:** `ReadableStream`
-
-___
-
+**Returns:** *ReadableStream*

--- a/doc/interfaces/sparsereaderstate.md
+++ b/doc/interfaces/sparsereaderstate.md
@@ -1,48 +1,39 @@
-[etcher-sdk](../README.md) > [SparseReaderState](../interfaces/sparsereaderstate.md)
+[etcher-sdk](../README.md) › [SparseReaderState](sparsereaderstate.md)
 
 # Interface: SparseReaderState
 
 ## Hierarchy
 
-**SparseReaderState**
+* **SparseReaderState**
 
 ## Index
 
 ### Properties
 
 * [block](sparsereaderstate.md#block)
-* [hasher](sparsereaderstate.md#hasher)
+* [hasher](sparsereaderstate.md#optional-hasher)
 * [subBlock](sparsereaderstate.md#subblock)
-
----
 
 ## Properties
 
-<a id="block"></a>
-
 ###  block
 
-**● block**: *[BlocksWithChecksum](blockswithchecksum.md)*
+• **block**: *[BlocksWithChecksum](blockswithchecksum.md)*
 
-*Defined in [sparse-stream/shared.ts:81](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L81)*
-
-___
-<a id="hasher"></a>
-
-### `<Optional>` hasher
-
-**● hasher**: *[AnyHasher](../#anyhasher)*
-
-*Defined in [sparse-stream/shared.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L83)*
+*Defined in [lib/sparse-stream/shared.ts:81](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L81)*
 
 ___
-<a id="subblock"></a>
+
+### `Optional` hasher
+
+• **hasher**? : *[AnyHasher](../README.md#anyhasher)*
+
+*Defined in [lib/sparse-stream/shared.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L83)*
+
+___
 
 ###  subBlock
 
-**● subBlock**: *[Block](block.md)*
+• **subBlock**: *[Block](block.md)*
 
-*Defined in [sparse-stream/shared.ts:82](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L82)*
-
-___
-
+*Defined in [lib/sparse-stream/shared.ts:82](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L82)*

--- a/doc/interfaces/sparsestreamchunk.md
+++ b/doc/interfaces/sparsestreamchunk.md
@@ -1,10 +1,10 @@
-[etcher-sdk](../README.md) > [SparseStreamChunk](../interfaces/sparsestreamchunk.md)
+[etcher-sdk](../README.md) › [SparseStreamChunk](sparsestreamchunk.md)
 
 # Interface: SparseStreamChunk
 
 ## Hierarchy
 
-**SparseStreamChunk**
+* **SparseStreamChunk**
 
 ## Index
 
@@ -13,26 +13,18 @@
 * [buffer](sparsestreamchunk.md#buffer)
 * [position](sparsestreamchunk.md#position)
 
----
-
 ## Properties
-
-<a id="buffer"></a>
 
 ###  buffer
 
-**● buffer**: *`Buffer`*
+• **buffer**: *Buffer*
 
-*Defined in [sparse-stream/shared.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L45)*
+*Defined in [lib/sparse-stream/shared.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L45)*
 
 ___
-<a id="position"></a>
 
 ###  position
 
-**● position**: *`number`*
+• **position**: *number*
 
-*Defined in [sparse-stream/shared.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/shared.ts#L46)*
-
-___
-
+*Defined in [lib/sparse-stream/shared.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/shared.ts#L46)*

--- a/doc/interfaces/sparsewritable.md
+++ b/doc/interfaces/sparsewritable.md
@@ -1,12 +1,12 @@
-[etcher-sdk](../README.md) > [SparseWritable](../interfaces/sparsewritable.md)
+[etcher-sdk](../README.md) › [SparseWritable](sparsewritable.md)
 
 # Interface: SparseWritable
 
 ## Hierarchy
 
- `WritableStream`
+* WritableStream
 
-**↳ SparseWritable**
+  ↳ **SparseWritable**
 
 ## Implemented by
 
@@ -37,384 +37,366 @@
 * [setMaxListeners](sparsewritable.md#setmaxlisteners)
 * [write](sparsewritable.md#write)
 
----
-
 ## Properties
-
-<a id="writable"></a>
 
 ###  writable
 
-**● writable**: *`boolean`*
+• **writable**: *boolean*
 
-*Inherited from WritableStream.writable*
+*Inherited from [SparseWritable](sparsewritable.md).[writable](sparsewritable.md#writable)*
 
-*Defined in /node_modules/@types/node/base.d.ts:367*
-
-___
+Defined in node_modules/@types/node/base.d.ts:367
 
 ## Methods
 
-<a id="_write"></a>
-
 ###  _write
 
-▸ **_write**(chunk: *[SparseStreamChunk](sparsestreamchunk.md)*, encoding: *`string`*, callback: *`function`*): `void`
+▸ **_write**(`chunk`: [SparseStreamChunk](sparsestreamchunk.md), `encoding`: string, `callback`: function): *void*
 
-*Defined in [sparse-stream/sparse-write-stream.ts:12](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/sparse-stream/sparse-write-stream.ts#L12)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:12](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/sparse-stream/sparse-write-stream.ts#L12)*
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| chunk | [SparseStreamChunk](sparsestreamchunk.md) |
-| encoding | `string` |
-| callback | `function` |
+▪ **chunk**: *[SparseStreamChunk](sparsestreamchunk.md)*
 
-**Returns:** `void`
+▪ **encoding**: *string*
+
+▪ **callback**: *function*
+
+▸ (`err?`: [Error](../classes/notcapable.md#static-error) | void): *void*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`err?` | [Error](../classes/notcapable.md#static-error) &#124; void |
+
+**Returns:** *void*
 
 ___
-<a id="addlistener"></a>
 
 ###  addListener
 
-▸ **addListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **addListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.addListener*
+*Inherited from [SparseReadable](sparsereadable.md).[addListener](sparsereadable.md#addlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:336*
+Defined in node_modules/@types/node/base.d.ts:336
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="emit"></a>
 
 ###  emit
 
-▸ **emit**(event: *`string` \| `symbol`*, ...args: *`any`[]*): `boolean`
+▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
-*Inherited from EventEmitter.emit*
+*Inherited from [SparseReadable](sparsereadable.md).[emit](sparsereadable.md#emit)*
 
-*Defined in /node_modules/@types/node/base.d.ts:344*
+Defined in node_modules/@types/node/base.d.ts:344
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| `Rest` args | `any`[] |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`...args` | any[] |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
 ___
-<a id="end"></a>
 
 ###  end
 
-▸ **end**(cb?: *`Function`*): `void`
+▸ **end**(`cb?`: Function): *void*
 
-▸ **end**(buffer: *`Buffer`*, cb?: *`Function`*): `void`
+*Inherited from [SparseWritable](sparsewritable.md).[end](sparsewritable.md#end)*
 
-▸ **end**(str: *`string`*, cb?: *`Function`*): `void`
-
-▸ **end**(str: *`string`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `void`
-
-*Inherited from WritableStream.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:370*
+Defined in node_modules/@types/node/base.d.ts:370
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
 
-*Inherited from WritableStream.end*
+▸ **end**(`buffer`: Buffer, `cb?`: Function): *void*
 
-*Defined in /node_modules/@types/node/base.d.ts:371*
+*Inherited from [SparseWritable](sparsewritable.md).[end](sparsewritable.md#end)*
 
-**Parameters:**
-
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` |
-| `Optional` cb | `Function` |
-
-**Returns:** `void`
-
-*Inherited from WritableStream.end*
-
-*Defined in /node_modules/@types/node/base.d.ts:372*
+Defined in node_modules/@types/node/base.d.ts:371
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| str | `string` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
 
-*Inherited from WritableStream.end*
+▸ **end**(`str`: string, `cb?`: Function): *void*
 
-*Defined in /node_modules/@types/node/base.d.ts:373*
+*Inherited from [SparseWritable](sparsewritable.md).[end](sparsewritable.md#end)*
+
+Defined in node_modules/@types/node/base.d.ts:372
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| str | `string` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`str` | string |
+`cb?` | Function |
 
-**Returns:** `void`
+**Returns:** *void*
+
+▸ **end**(`str`: string, `encoding?`: undefined | string, `cb?`: Function): *void*
+
+*Inherited from [SparseWritable](sparsewritable.md).[end](sparsewritable.md#end)*
+
+Defined in node_modules/@types/node/base.d.ts:373
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`str` | string |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
+
+**Returns:** *void*
 
 ___
-<a id="eventnames"></a>
 
 ###  eventNames
 
-▸ **eventNames**(): (`string` \| `symbol`)[]
+▸ **eventNames**(): *string | symbol[]*
 
-*Inherited from EventEmitter.eventNames*
+*Inherited from [SparseReadable](sparsereadable.md).[eventNames](sparsereadable.md#eventnames)*
 
-*Defined in /node_modules/@types/node/base.d.ts:349*
+Defined in node_modules/@types/node/base.d.ts:349
 
-**Returns:** (`string` \| `symbol`)[]
+**Returns:** *string | symbol[]*
 
 ___
-<a id="getmaxlisteners"></a>
 
 ###  getMaxListeners
 
-▸ **getMaxListeners**(): `number`
+▸ **getMaxListeners**(): *number*
 
-*Inherited from EventEmitter.getMaxListeners*
+*Inherited from [SparseReadable](sparsereadable.md).[getMaxListeners](sparsereadable.md#getmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:342*
+Defined in node_modules/@types/node/base.d.ts:342
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listenercount"></a>
 
 ###  listenerCount
 
-▸ **listenerCount**(type: *`string` \| `symbol`*): `number`
+▸ **listenerCount**(`type`: string | symbol): *number*
 
-*Inherited from EventEmitter.listenerCount*
+*Inherited from [SparseReadable](sparsereadable.md).[listenerCount](sparsereadable.md#listenercount)*
 
-*Defined in /node_modules/@types/node/base.d.ts:345*
+Defined in node_modules/@types/node/base.d.ts:345
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| type | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`type` | string &#124; symbol |
 
-**Returns:** `number`
+**Returns:** *number*
 
 ___
-<a id="listeners"></a>
 
 ###  listeners
 
-▸ **listeners**(event: *`string` \| `symbol`*): `Function`[]
+▸ **listeners**(`event`: string | symbol): *Function[]*
 
-*Inherited from EventEmitter.listeners*
+*Inherited from [SparseReadable](sparsereadable.md).[listeners](sparsereadable.md#listeners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:343*
+Defined in node_modules/@types/node/base.d.ts:343
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
 
-**Returns:** `Function`[]
+**Returns:** *Function[]*
 
 ___
-<a id="on"></a>
 
 ###  on
 
-▸ **on**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **on**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.on*
+*Inherited from [SparseReadable](sparsereadable.md).[on](sparsereadable.md#on)*
 
-*Defined in /node_modules/@types/node/base.d.ts:337*
+Defined in node_modules/@types/node/base.d.ts:337
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="once"></a>
 
 ###  once
 
-▸ **once**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **once**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.once*
+*Inherited from [SparseReadable](sparsereadable.md).[once](sparsereadable.md#once)*
 
-*Defined in /node_modules/@types/node/base.d.ts:338*
+Defined in node_modules/@types/node/base.d.ts:338
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependlistener"></a>
 
 ###  prependListener
 
-▸ **prependListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependListener*
+*Inherited from [SparseReadable](sparsereadable.md).[prependListener](sparsereadable.md#prependlistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:347*
+Defined in node_modules/@types/node/base.d.ts:347
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="prependoncelistener"></a>
 
 ###  prependOnceListener
 
-▸ **prependOnceListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **prependOnceListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.prependOnceListener*
+*Inherited from [SparseReadable](sparsereadable.md).[prependOnceListener](sparsereadable.md#prependoncelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:348*
+Defined in node_modules/@types/node/base.d.ts:348
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removealllisteners"></a>
 
 ###  removeAllListeners
 
-▸ **removeAllListeners**(event?: *`string` \| `symbol`*): `this`
+▸ **removeAllListeners**(`event?`: string | symbol): *this*
 
-*Inherited from EventEmitter.removeAllListeners*
+*Inherited from [SparseReadable](sparsereadable.md).[removeAllListeners](sparsereadable.md#removealllisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:340*
+Defined in node_modules/@types/node/base.d.ts:340
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| `Optional` event | `string` \| `symbol` |
+Name | Type |
+------ | ------ |
+`event?` | string &#124; symbol |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="removelistener"></a>
 
 ###  removeListener
 
-▸ **removeListener**(event: *`string` \| `symbol`*, listener: *`Function`*): `this`
+▸ **removeListener**(`event`: string | symbol, `listener`: Function): *this*
 
-*Inherited from EventEmitter.removeListener*
+*Inherited from [SparseReadable](sparsereadable.md).[removeListener](sparsereadable.md#removelistener)*
 
-*Defined in /node_modules/@types/node/base.d.ts:339*
+Defined in node_modules/@types/node/base.d.ts:339
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| event | `string` \| `symbol` |
-| listener | `Function` |
+Name | Type |
+------ | ------ |
+`event` | string &#124; symbol |
+`listener` | Function |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="setmaxlisteners"></a>
 
 ###  setMaxListeners
 
-▸ **setMaxListeners**(n: *`number`*): `this`
+▸ **setMaxListeners**(`n`: number): *this*
 
-*Inherited from EventEmitter.setMaxListeners*
+*Inherited from [SparseReadable](sparsereadable.md).[setMaxListeners](sparsereadable.md#setmaxlisteners)*
 
-*Defined in /node_modules/@types/node/base.d.ts:341*
+Defined in node_modules/@types/node/base.d.ts:341
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| n | `number` |
+Name | Type |
+------ | ------ |
+`n` | number |
 
-**Returns:** `this`
+**Returns:** *this*
 
 ___
-<a id="write"></a>
 
 ###  write
 
-▸ **write**(buffer: *`Buffer` \| `string`*, cb?: *`Function`*): `boolean`
+▸ **write**(`buffer`: Buffer | string, `cb?`: Function): *boolean*
 
-▸ **write**(str: *`string`*, encoding?: *`undefined` \| `string`*, cb?: *`Function`*): `boolean`
+*Inherited from [SparseWritable](sparsewritable.md).[write](sparsewritable.md#write)*
 
-*Inherited from WritableStream.write*
-
-*Defined in /node_modules/@types/node/base.d.ts:368*
+Defined in node_modules/@types/node/base.d.ts:368
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| buffer | `Buffer` \| `string` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`buffer` | Buffer &#124; string |
+`cb?` | Function |
 
-**Returns:** `boolean`
+**Returns:** *boolean*
 
-*Inherited from WritableStream.write*
+▸ **write**(`str`: string, `encoding?`: undefined | string, `cb?`: Function): *boolean*
 
-*Defined in /node_modules/@types/node/base.d.ts:369*
+*Inherited from [SparseWritable](sparsewritable.md).[write](sparsewritable.md#write)*
+
+Defined in node_modules/@types/node/base.d.ts:369
 
 **Parameters:**
 
-| Name | Type |
-| ------ | ------ |
-| str | `string` |
-| `Optional` encoding | `undefined` \| `string` |
-| `Optional` cb | `Function` |
+Name | Type |
+------ | ------ |
+`str` | string |
+`encoding?` | undefined &#124; string |
+`cb?` | Function |
 
-**Returns:** `boolean`
-
-___
-
+**Returns:** *boolean*

--- a/doc/interfaces/tmpfileresult.md
+++ b/doc/interfaces/tmpfileresult.md
@@ -1,38 +1,30 @@
-[etcher-sdk](../README.md) > [TmpFileResult](../interfaces/tmpfileresult.md)
+[etcher-sdk](../README.md) › [TmpFileResult](tmpfileresult.md)
 
 # Interface: TmpFileResult
 
 ## Hierarchy
 
-**TmpFileResult**
+* **TmpFileResult**
 
 ## Index
 
 ### Properties
 
-* [fd](tmpfileresult.md#fd)
+* [fd](tmpfileresult.md#optional-fd)
 * [path](tmpfileresult.md#path)
-
----
 
 ## Properties
 
-<a id="fd"></a>
+### `Optional` fd
 
-### `<Optional>` fd
+• **fd**? : *undefined | number*
 
-**● fd**: *`undefined` \| `number`*
-
-*Defined in [tmp.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/tmp.ts#L34)*
+*Defined in [lib/tmp.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/tmp.ts#L34)*
 
 ___
-<a id="path"></a>
 
 ###  path
 
-**● path**: *`string`*
+• **path**: *string*
 
-*Defined in [tmp.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/tmp.ts#L33)*
-
-___
-
+*Defined in [lib/tmp.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/tmp.ts#L33)*

--- a/doc/interfaces/wificonfig.md
+++ b/doc/interfaces/wificonfig.md
@@ -1,78 +1,66 @@
-[etcher-sdk](../README.md) > [WifiConfig](../interfaces/wificonfig.md)
+[etcher-sdk](../README.md) › [WifiConfig](wificonfig.md)
 
 # Interface: WifiConfig
 
 ## Hierarchy
 
-**WifiConfig**
+* **WifiConfig**
 
 ## Index
 
 ### Properties
 
-* [gateway](wificonfig.md#gateway)
-* [ip](wificonfig.md#ip)
-* [netmask](wificonfig.md#netmask)
-* [routeMetric](wificonfig.md#routemetric)
-* [wifiKey](wificonfig.md#wifikey)
+* [gateway](wificonfig.md#optional-gateway)
+* [ip](wificonfig.md#optional-ip)
+* [netmask](wificonfig.md#optional-netmask)
+* [routeMetric](wificonfig.md#optional-routemetric)
+* [wifiKey](wificonfig.md#optional-wifikey)
 * [wifiSsid](wificonfig.md#wifissid)
-
----
 
 ## Properties
 
-<a id="gateway"></a>
+### `Optional` gateway
 
-### `<Optional>` gateway
+• **gateway**? : *undefined | string*
 
-**● gateway**: *`undefined` \| `string`*
-
-*Defined in [source-destination/configured-source/operations/configure.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/operations/configure.ts#L38)*
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/operations/configure.ts#L38)*
 
 ___
-<a id="ip"></a>
 
-### `<Optional>` ip
+### `Optional` ip
 
-**● ip**: *`undefined` \| `string`*
+• **ip**? : *undefined | string*
 
-*Defined in [source-destination/configured-source/operations/configure.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/operations/configure.ts#L36)*
-
-___
-<a id="netmask"></a>
-
-### `<Optional>` netmask
-
-**● netmask**: *`undefined` \| `string`*
-
-*Defined in [source-destination/configured-source/operations/configure.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/operations/configure.ts#L37)*
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/operations/configure.ts#L36)*
 
 ___
-<a id="routemetric"></a>
 
-### `<Optional>` routeMetric
+### `Optional` netmask
 
-**● routeMetric**: *`number` \| `string`*
+• **netmask**? : *undefined | string*
 
-*Defined in [source-destination/configured-source/operations/configure.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/operations/configure.ts#L35)*
-
-___
-<a id="wifikey"></a>
-
-### `<Optional>` wifiKey
-
-**● wifiKey**: *`undefined` \| `string`*
-
-*Defined in [source-destination/configured-source/operations/configure.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/operations/configure.ts#L34)*
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/operations/configure.ts#L37)*
 
 ___
-<a id="wifissid"></a>
+
+### `Optional` routeMetric
+
+• **routeMetric**? : *number | string*
+
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/operations/configure.ts#L35)*
+
+___
+
+### `Optional` wifiKey
+
+• **wifiKey**? : *undefined | string*
+
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/operations/configure.ts#L34)*
+
+___
 
 ###  wifiSsid
 
-**● wifiSsid**: *`string`*
+• **wifiSsid**: *string*
 
-*Defined in [source-destination/configured-source/operations/configure.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/6429a60/lib/source-destination/configured-source/operations/configure.ts#L33)*
-
-___
-
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2f08b24/lib/source-destination/configured-source/operations/configure.ts#L33)*

--- a/package.json
+++ b/package.json
@@ -94,8 +94,8 @@
     "rimraf": "^2.6.2",
     "sinon": "^6.1.3",
     "ts-node": "^7.0.1",
-    "typedoc": "^0.14.2",
-    "typedoc-plugin-markdown": "^1.2.0",
+    "typedoc": "^0.16.11",
+    "typedoc-plugin-markdown": "^2.2.17",
     "typescript": "^3.0.3",
     "yargs": "^11.0.0"
   }


### PR DESCRIPTION
This is necessary to use newer typescript features (eg optional chaining), the main change that affects us is https://github.com/TypeStrong/typedoc/releases/tag/v0.16.0
> With `--mode file`, all declarations are now considered exported.

But changing to `--mode modules` massively changed the structure of the docs which I assumed was undesirable but I can make that change if you want 