### PR TITLE
upgrade lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "zip-part-stream": "^1.0.3"
   },
   "devDependencies": {
-    "@balena/lint": "^5.2.1",
+    "@balena/lint": "^5.4.0",
     "@types/bluebird": "^3.5.23",
     "@types/chai": "^4.1.4",
     "@types/cli-spinner": "^0.2.0",


### PR DESCRIPTION
Lint was breaking my tests...it would say `module "ts-lint"` not found. When I upgraded `@balena/lint`, the tests ran fine.

Change-type: patch