### PR TITLE
Beagle bone

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -50,6 +50,8 @@
 * [StreamLimiter](classes/streamlimiter.md)
 * [StreamVerifier](classes/streamverifier.md)
 * [StreamZipSource](classes/streamzipsource.md)
+* [UsbBBbootDeviceAdapter](classes/usbbbbootdeviceadapter.md)
+* [UsbBBbootDrive](classes/usbbbbootdrive.md)
 * [UsbbootDeviceAdapter](classes/usbbootdeviceadapter.md)
 * [UsbbootDrive](classes/usbbootdrive.md)
 * [VerificationError](classes/verificationerror.md)
@@ -220,7 +222,7 @@
 
 Ƭ **AnyHasher**: *Hash | XXHash | XXHash64*
 
-*Defined in [lib/sparse-stream/shared.ts:61](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L61)*
+*Defined in [lib/sparse-stream/shared.ts:61](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L61)*
 
 ___
 
@@ -228,7 +230,7 @@ ___
 
 Ƭ **ChecksumType**: *"crc32" | "sha1" | "sha256" | "xxhash32" | "xxhash64"*
 
-*Defined in [lib/sparse-stream/shared.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L25)*
+*Defined in [lib/sparse-stream/shared.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L25)*
 
 ___
 
@@ -236,7 +238,7 @@ ___
 
 Ƭ **ConfigureFunction**: *function*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L45)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L45)*
 
 #### Type declaration:
 
@@ -254,7 +256,7 @@ ___
 
 Ƭ **Constructor**: *object*
 
-*Defined in [lib/source-destination/progress.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/progress.ts#L24)*
+*Defined in [lib/source-destination/progress.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/progress.ts#L24)*
 
 #### Type declaration:
 
@@ -264,7 +266,7 @@ ___
 
 Ƭ **ImageJSON**: *[Dictionary](interfaces/dictionary.md)‹object›*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L36)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L36)*
 
 ___
 
@@ -272,7 +274,7 @@ ___
 
 Ƭ **Name**: *"balena" | "resin"*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L29)*
+*Defined in [lib/source-destination/balena-s3-source.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L29)*
 
 ___
 
@@ -280,7 +282,7 @@ ___
 
 Ƭ **OnFailFunction**: *function*
 
-*Defined in [lib/multi-write.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L70)*
+*Defined in [lib/multi-write.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L70)*
 
 #### Type declaration:
 
@@ -299,7 +301,7 @@ ___
 
 Ƭ **OnProgressFunction**: *function*
 
-*Defined in [lib/multi-write.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L75)*
+*Defined in [lib/multi-write.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L75)*
 
 #### Type declaration:
 
@@ -317,7 +319,7 @@ ___
 
 Ƭ **Partition**: *number | object*
 
-*Defined in [lib/source-destination/configured-source/configure.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configure.ts#L27)*
+*Defined in [lib/source-destination/configured-source/configure.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configure.ts#L27)*
 
 ___
 
@@ -325,7 +327,7 @@ ___
 
 Ƭ **WriteStep**: *"decompressing" | "flashing" | "verifying" | "finished"*
 
-*Defined in [lib/multi-write.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L43)*
+*Defined in [lib/multi-write.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L43)*
 
 ___
 
@@ -333,7 +335,7 @@ ___
 
 Ƭ **XXHash**: *typeof xxhash*
 
-*Defined in [lib/lazy.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/lazy.ts#L22)*
+*Defined in [lib/lazy.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/lazy.ts#L22)*
 
 ## Variables
 
@@ -341,7 +343,7 @@ ___
 
 • **BITS**: *64 | 32* = arch === 'x64' || arch === 'aarch64' ? 64 : 32
 
-*Defined in [lib/source-destination/source-destination.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L45)*
+*Defined in [lib/source-destination/source-destination.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L45)*
 
 ___
 
@@ -349,7 +351,7 @@ ___
 
 • **CHUNK_SIZE**: *number* = 1024 ** 2
 
-*Defined in [lib/constants.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/constants.ts#L20)*
+*Defined in [lib/constants.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/constants.ts#L20)*
 
 ___
 
@@ -357,7 +359,7 @@ ___
 
 • **DECOMPRESSED_IMAGE_PREFIX**: *"decompressed-image-"* = "decompressed-image-"
 
-*Defined in [lib/multi-write.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L45)*
+*Defined in [lib/multi-write.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L45)*
 
 ___
 
@@ -365,7 +367,7 @@ ___
 
 • **DEFAULT_ALIGNMENT**: *512* = 512
 
-*Defined in [lib/constants.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/constants.ts#L24)*
+*Defined in [lib/constants.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/constants.ts#L24)*
 
 ___
 
@@ -373,7 +375,7 @@ ___
 
 • **DISKPART_DELAY**: *2000* = 2000
 
-*Defined in [lib/diskpart.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/diskpart.ts#L28)*
+*Defined in [lib/diskpart.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/diskpart.ts#L28)*
 
 ___
 
@@ -381,7 +383,7 @@ ___
 
 • **DISKPART_RETRIES**: *5* = 5
 
-*Defined in [lib/diskpart.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/diskpart.ts#L29)*
+*Defined in [lib/diskpart.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/diskpart.ts#L29)*
 
 ___
 
@@ -389,7 +391,7 @@ ___
 
 • **DriverlessDeviceAdapter**: *undefined | [DriverlessDeviceAdapter$](classes/driverlessdeviceadapter_.md)* = platform === 'win32' ? DriverlessDeviceAdapter$ : undefined
 
-*Defined in [lib/scanner/adapters/driverless.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/driverless.ts#L104)*
+*Defined in [lib/scanner/adapters/driverless.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/driverless.ts#L104)*
 
 ___
 
@@ -397,7 +399,7 @@ ___
 
 • **ESR_IMAGES_PREFIX**: *"esr-images"* = "esr-images"
 
-*Defined in [lib/source-destination/balena-s3-source.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L31)*
+*Defined in [lib/source-destination/balena-s3-source.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L31)*
 
 ___
 
@@ -405,7 +407,7 @@ ___
 
 • **IMAGES_PREFIX**: *"images"* = "images"
 
-*Defined in [lib/source-destination/balena-s3-source.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L32)*
+*Defined in [lib/source-destination/balena-s3-source.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L32)*
 
 ___
 
@@ -413,7 +415,7 @@ ___
 
 • **ISIZE_LENGTH**: *4* = 4
 
-*Defined in [lib/source-destination/gzip.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/gzip.ts#L23)*
+*Defined in [lib/source-destination/gzip.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/gzip.ts#L23)*
 
 ___
 
@@ -421,7 +423,7 @@ ___
 
 • **MBR_LAST_PRIMARY_PARTITION**: *4* = 4
 
-*Defined in [lib/source-destination/configured-source/configure.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configure.ts#L52)*
+*Defined in [lib/source-destination/configured-source/configure.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configure.ts#L52)*
 
 ___
 
@@ -429,7 +431,7 @@ ___
 
 • **NO_MATCHING_FILE_MSG**: *"Can't find a matching file in this zip archive"* = "Can't find a matching file in this zip archive"
 
-*Defined in [lib/constants.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/constants.ts#L21)*
+*Defined in [lib/constants.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/constants.ts#L21)*
 
 ___
 
@@ -437,7 +439,7 @@ ___
 
 • **PATTERN**: *RegExp‹›* = /PHYSICALDRIVE(\d+)/i
 
-*Defined in [lib/diskpart.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/diskpart.ts#L30)*
+*Defined in [lib/diskpart.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/diskpart.ts#L30)*
 
 ___
 
@@ -445,7 +447,7 @@ ___
 
 • **PRELOADED_IMAGES_PREFIX**: *"preloaded-images"* = "preloaded-images"
 
-*Defined in [lib/source-destination/balena-s3-source.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L33)*
+*Defined in [lib/source-destination/balena-s3-source.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L33)*
 
 ___
 
@@ -453,7 +455,7 @@ ___
 
 • **PROGRESS_EMISSION_INTERVAL**: *number* = 1000 / 4
 
-*Defined in [lib/constants.ts:17](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/constants.ts#L17)*
+*Defined in [lib/constants.ts:17](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/constants.ts#L17)*
 
 ___
 
@@ -465,7 +467,7 @@ ___
 	'bytesRead',
 )
 
-*Defined in [lib/block-read-stream.ts:122](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-read-stream.ts#L122)*
+*Defined in [lib/block-read-stream.ts:122](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-read-stream.ts#L122)*
 
 ___
 
@@ -477,7 +479,7 @@ ___
 	'bytesWritten',
 )
 
-*Defined in [lib/block-write-stream.ts:113](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-write-stream.ts#L113)*
+*Defined in [lib/block-write-stream.ts:113](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-write-stream.ts#L113)*
 
 ___
 
@@ -489,7 +491,7 @@ ___
 	'bytesWritten',
 )
 
-*Defined in [lib/source-destination/source-destination.ts:76](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L76)*
+*Defined in [lib/source-destination/source-destination.ts:76](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L76)*
 
 ___
 
@@ -501,7 +503,7 @@ ___
 	'position',
 )
 
-*Defined in [lib/sparse-stream/sparse-transform-stream.ts:85](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-transform-stream.ts#L85)*
+*Defined in [lib/sparse-stream/sparse-transform-stream.ts:85](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-transform-stream.ts#L85)*
 
 ___
 
@@ -513,7 +515,7 @@ ___
 	'position',
 )
 
-*Defined in [lib/sparse-stream/sparse-write-stream.ts:137](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-write-stream.ts#L137)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:137](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-write-stream.ts#L137)*
 
 ___
 
@@ -525,7 +527,7 @@ ___
 	'position',
 )
 
-*Defined in [lib/source-destination/progress.ts:117](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/progress.ts#L117)*
+*Defined in [lib/source-destination/progress.ts:117](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/progress.ts#L117)*
 
 ___
 
@@ -537,7 +539,7 @@ ___
 	'bytesWritten',
 )
 
-*Defined in [lib/source-destination/file.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L36)*
+*Defined in [lib/source-destination/file.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L36)*
 
 ___
 
@@ -545,7 +547,7 @@ ___
 
 • **READ_TRIES**: *5* = 5
 
-*Defined in [lib/source-destination/file.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L42)*
+*Defined in [lib/source-destination/file.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L42)*
 
 ___
 
@@ -553,7 +555,7 @@ ___
 
 • **RETRY_BASE_TIMEOUT**: *100* = 100
 
-*Defined in [lib/constants.ts:19](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/constants.ts#L19)*
+*Defined in [lib/constants.ts:19](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/constants.ts#L19)*
 
 ___
 
@@ -561,9 +563,9 @@ ___
 
 • **RWMutex**: *[RWMutex](README.md#rwmutex)*
 
-*Defined in [lib/aligned-lockable-buffer.ts:2](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/aligned-lockable-buffer.ts#L2)*
+*Defined in [lib/aligned-lockable-buffer.ts:2](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/aligned-lockable-buffer.ts#L2)*
 
-*Defined in [lib/diskpart.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/diskpart.ts#L21)*
+*Defined in [lib/diskpart.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/diskpart.ts#L21)*
 
 ___
 
@@ -571,9 +573,9 @@ ___
 
 • **SCAN_INTERVAL**: *1000* = 1000
 
-*Defined in [lib/scanner/adapters/block-device.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L26)*
+*Defined in [lib/scanner/adapters/block-device.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L26)*
 
-*Defined in [lib/scanner/adapters/driverless.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/driverless.ts#L25)*
+*Defined in [lib/scanner/adapters/driverless.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/driverless.ts#L25)*
 
 ___
 
@@ -581,7 +583,7 @@ ___
 
 • **SPEED_WINDOW**: *2* = 2
 
-*Defined in [lib/constants.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/constants.ts#L18)*
+*Defined in [lib/constants.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/constants.ts#L18)*
 
 ___
 
@@ -589,7 +591,7 @@ ___
 
 • **TMP_DIR**: *string* = join(tmpdir(), 'etcher')
 
-*Defined in [lib/tmp.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/tmp.ts#L24)*
+*Defined in [lib/tmp.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/tmp.ts#L24)*
 
 ___
 
@@ -597,7 +599,7 @@ ___
 
 • **TMP_RANDOM_BYTES**: *6* = 6
 
-*Defined in [lib/tmp.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/tmp.ts#L23)*
+*Defined in [lib/tmp.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/tmp.ts#L23)*
 
 ___
 
@@ -605,7 +607,7 @@ ___
 
 • **TRIES**: *5* = 5
 
-*Defined in [lib/tmp.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/tmp.ts#L25)*
+*Defined in [lib/tmp.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/tmp.ts#L25)*
 
 ___
 
@@ -613,7 +615,7 @@ ___
 
 • **UNMOUNT_ON_SUCCESS_TIMEOUT_MS**: *2000* = 2000
 
-*Defined in [lib/source-destination/block-device.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L42)*
+*Defined in [lib/source-destination/block-device.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L42)*
 
 **`summary`** Time, in milliseconds, to wait before unmounting on success
 
@@ -631,7 +633,7 @@ ___
 	'Linux File-Stor Gadget Media',
 ]
 
-*Defined in [lib/scanner/adapters/block-device.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L27)*
+*Defined in [lib/scanner/adapters/block-device.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L27)*
 
 ___
 
@@ -639,7 +641,7 @@ ___
 
 • **WIN32_FIRST_BYTES_TO_KEEP**: *number* = 64 * 1024
 
-*Defined in [lib/source-destination/block-device.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L43)*
+*Defined in [lib/source-destination/block-device.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L43)*
 
 ___
 
@@ -647,7 +649,7 @@ ___
 
 • **XXHASH_SEED**: *1163150152* = 1163150152
 
-*Defined in [lib/constants.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/constants.ts#L23)*
+*Defined in [lib/constants.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/constants.ts#L23)*
 
 ___
 
@@ -655,15 +657,15 @@ ___
 
 • **debug**: *IDebugger* = debug_('etcher-sdk:scanner')
 
-*Defined in [lib/diskpart.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/diskpart.ts#L26)*
+*Defined in [lib/diskpart.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/diskpart.ts#L26)*
 
-*Defined in [lib/block-write-stream.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-write-stream.ts#L28)*
+*Defined in [lib/block-write-stream.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-write-stream.ts#L28)*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L43)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L43)*
 
-*Defined in [lib/scanner/adapters/block-device.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L24)*
+*Defined in [lib/scanner/adapters/block-device.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L24)*
 
-*Defined in [lib/scanner/scanner.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/scanner.ts#L22)*
+*Defined in [lib/scanner/scanner.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/scanner.ts#L22)*
 
 ___
 
@@ -671,7 +673,7 @@ ___
 
 • **diskpartMutex**: *[RWMutex](README.md#rwmutex)‹›* = new RWMutex()
 
-*Defined in [lib/diskpart.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/diskpart.ts#L60)*
+*Defined in [lib/diskpart.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/diskpart.ts#L60)*
 
 ___
 
@@ -681,7 +683,7 @@ ___
 	() => require('cyclic-32') as typeof import('cyclic-32'),
 )
 
-*Defined in [lib/lazy.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/lazy.ts#L40)*
+*Defined in [lib/lazy.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/lazy.ts#L40)*
 
 #### Type declaration:
 
@@ -699,7 +701,7 @@ ___
 	}
 })
 
-*Defined in [lib/lazy.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/lazy.ts#L24)*
+*Defined in [lib/lazy.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/lazy.ts#L24)*
 
 #### Type declaration:
 
@@ -713,7 +715,7 @@ ___
 	promisify((require('mountutils') as typeof import('mountutils')).unmountDisk),
 )
 
-*Defined in [lib/lazy.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/lazy.ts#L36)*
+*Defined in [lib/lazy.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/lazy.ts#L36)*
 
 #### Type declaration:
 
@@ -727,7 +729,7 @@ ___
 	() => require('xxhash') as typeof import('xxhash'),
 )
 
-*Defined in [lib/lazy.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/lazy.ts#L32)*
+*Defined in [lib/lazy.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/lazy.ts#L32)*
 
 #### Type declaration:
 
@@ -739,7 +741,7 @@ ___
 
 • **parseFileIndexAsync**: *function* = promisify(parseFileIndex)
 
-*Defined in [lib/source-destination/xz.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/xz.ts#L25)*
+*Defined in [lib/source-destination/xz.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/xz.ts#L25)*
 
 #### Type declaration:
 
@@ -757,7 +759,7 @@ ___
 
 • **readEndMarker**: *[Buffer](interfaces/alignedlockablebuffer.md#buffer)‹›* = Buffer.from(`not the correct data ${Math.random()}`)
 
-*Defined in [lib/source-destination/file.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L43)*
+*Defined in [lib/source-destination/file.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L43)*
 
 ___
 
@@ -765,7 +767,7 @@ ___
 
 • **unbzip2Stream**: *[unbzip2Stream](README.md#unbzip2stream)*
 
-*Defined in [lib/source-destination/bzip2.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/bzip2.ts#L18)*
+*Defined in [lib/source-destination/bzip2.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/bzip2.ts#L18)*
 
 ___
 
@@ -773,7 +775,7 @@ ___
 
 • **zlib**: *"zlib"*
 
-*Defined in [lib/stream-limiter.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/stream-limiter.ts#L18)*
+*Defined in [lib/stream-limiter.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/stream-limiter.ts#L18)*
 
 ## Functions
 
@@ -781,7 +783,7 @@ ___
 
 ▸ **alignedLockableBufferSlice**(`this`: [AlignedLockableBuffer](interfaces/alignedlockablebuffer.md), `start?`: undefined | number, `end?`: undefined | number): *[AlignedLockableBuffer](interfaces/alignedlockablebuffer.md)‹›*
 
-*Defined in [lib/aligned-lockable-buffer.ts:11](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/aligned-lockable-buffer.ts#L11)*
+*Defined in [lib/aligned-lockable-buffer.ts:11](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/aligned-lockable-buffer.ts#L11)*
 
 **Parameters:**
 
@@ -799,7 +801,7 @@ ___
 
 ▸ **asCallback**‹**T**›(`promise`: Promise‹T›, `callback`: function): *Promise‹void›*
 
-*Defined in [lib/utils.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/utils.ts#L102)*
+*Defined in [lib/utils.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/utils.ts#L102)*
 
 **Type parameters:**
 
@@ -828,7 +830,7 @@ ___
 
 ▸ **attachMutex**(`buf`: [Buffer](interfaces/alignedlockablebuffer.md#buffer), `alignment`: number, `lock`: function, `rlock`: function): *[AlignedLockableBuffer](interfaces/alignedlockablebuffer.md)*
 
-*Defined in [lib/aligned-lockable-buffer.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/aligned-lockable-buffer.ts#L20)*
+*Defined in [lib/aligned-lockable-buffer.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/aligned-lockable-buffer.ts#L20)*
 
 **Parameters:**
 
@@ -852,7 +854,7 @@ ___
 
 ▸ **blockmapToBlocks**(`blockmap`: BlockMap): *[BlocksWithChecksum](interfaces/blockswithchecksum.md)[]*
 
-*Defined in [lib/source-destination/zip.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L49)*
+*Defined in [lib/source-destination/zip.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L49)*
 
 **Parameters:**
 
@@ -868,7 +870,7 @@ ___
 
 ▸ **blocksLength**(`blocks`: [BlocksWithChecksum](interfaces/blockswithchecksum.md)[]): *number*
 
-*Defined in [lib/sparse-stream/shared.ts:125](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L125)*
+*Defined in [lib/sparse-stream/shared.ts:125](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L125)*
 
 **Parameters:**
 
@@ -884,7 +886,7 @@ ___
 
 ▸ **blocksVerificationErrorMessage**(`blocksWithChecksum`: [BlocksWithChecksum](interfaces/blockswithchecksum.md), `checksum`: string): *string*
 
-*Defined in [lib/errors.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/errors.ts#L38)*
+*Defined in [lib/errors.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/errors.ts#L38)*
 
 **Parameters:**
 
@@ -901,7 +903,7 @@ ___
 
 ▸ **clean**(`device`: string): *Promise‹void›*
 
-*Defined in [lib/diskpart.ts:100](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/diskpart.ts#L100)*
+*Defined in [lib/diskpart.ts:100](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/diskpart.ts#L100)*
 
 **`summary`** Clean a device's partition tables
 
@@ -924,7 +926,7 @@ ___
 
 ▸ **cleanupTmpFiles**(`olderThan`: number, `prefix`: string): *Promise‹void›*
 
-*Defined in [lib/tmp.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/tmp.ts#L39)*
+*Defined in [lib/tmp.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/tmp.ts#L39)*
 
 **Parameters:**
 
@@ -941,7 +943,7 @@ ___
 
 ▸ **configure**(`disk`: Disk, `partition`: number | undefined, `config`: [Dictionary](interfaces/dictionary.md)‹any›): *Promise‹void›*
 
-*Defined in [lib/source-destination/configured-source/operations/configure.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/operations/configure.ts#L101)*
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/operations/configure.ts#L101)*
 
 **Parameters:**
 
@@ -959,7 +961,7 @@ ___
 
 ▸ **copy**(`diskFrom`: Disk, `partitionFrom`: number | undefined, `pathFrom`: string, `diskTo`: Disk, `partitionTo`: number | undefined, `pathTo`: string): *Promise‹void›*
 
-*Defined in [lib/source-destination/configured-source/operations/copy.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/operations/copy.ts#L38)*
+*Defined in [lib/source-destination/configured-source/operations/copy.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/operations/copy.ts#L38)*
 
 **Parameters:**
 
@@ -980,7 +982,7 @@ ___
 
 ▸ **copyFile**(`sourceFs`: typeof Fs, `sourcePath`: string, `destinationFs`: typeof Fs, `destinationPath`: string): *Promise‹void›*
 
-*Defined in [lib/source-destination/configured-source/operations/copy.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/operations/copy.ts#L21)*
+*Defined in [lib/source-destination/configured-source/operations/copy.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/operations/copy.ts#L21)*
 
 **Parameters:**
 
@@ -999,7 +1001,7 @@ ___
 
 ▸ **createBuffer**(`size`: number, `alignment`: number): *[AlignedLockableBuffer](interfaces/alignedlockablebuffer.md)*
 
-*Defined in [lib/aligned-lockable-buffer.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/aligned-lockable-buffer.ts#L34)*
+*Defined in [lib/aligned-lockable-buffer.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/aligned-lockable-buffer.ts#L34)*
 
 **Parameters:**
 
@@ -1016,7 +1018,7 @@ ___
 
 ▸ **createCompleteOnProgress**(`onProgress`: function, `sourceMetadata`: [Metadata](interfaces/metadata.md), `state`: [MultiDestinationState](interfaces/multidestinationstate.md), `sparse`: boolean): *$onProgress[]*
 
-*Defined in [lib/multi-write.ts:216](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L216)*
+*Defined in [lib/multi-write.ts:216](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L216)*
 
 **Parameters:**
 
@@ -1044,7 +1046,7 @@ ___
 
 ▸ **createHasher**(`checksumType?`: [ChecksumType](README.md#checksumtype)): *undefined | [AnyHasher](README.md#anyhasher)*
 
-*Defined in [lib/sparse-stream/shared.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L63)*
+*Defined in [lib/sparse-stream/shared.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L63)*
 
 **Parameters:**
 
@@ -1060,7 +1062,7 @@ ___
 
 ▸ **createNetworkConfigFiles**(`networks`: any[]): *object*
 
-*Defined in [lib/source-destination/configured-source/operations/configure.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/operations/configure.ts#L86)*
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/operations/configure.ts#L86)*
 
 **Parameters:**
 
@@ -1084,7 +1086,7 @@ ___
 
 ▸ **createSparseReaderStateIterator**(`blocks`: [BlocksWithChecksum](interfaces/blockswithchecksum.md)[], `verify`: boolean, `generateChecksums`: boolean): *Iterator‹[SparseReaderState](interfaces/sparsereaderstate.md)›*
 
-*Defined in [lib/sparse-stream/shared.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L83)*
+*Defined in [lib/sparse-stream/shared.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L83)*
 
 **Parameters:**
 
@@ -1102,7 +1104,7 @@ ___
 
 ▸ **createTmpRoot**(): *Promise‹void›*
 
-*Defined in [lib/tmp.ts:66](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/tmp.ts#L66)*
+*Defined in [lib/tmp.ts:66](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/tmp.ts#L66)*
 
 **Returns:** *Promise‹void›*
 
@@ -1112,7 +1114,7 @@ ___
 
 ▸ **decompressThenFlash**(`__namedParameters`: object): *Promise‹[PipeSourceToDestinationsResult](interfaces/pipesourcetodestinationsresult.md)›*
 
-*Defined in [lib/multi-write.ts:109](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L109)*
+*Defined in [lib/multi-write.ts:109](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L109)*
 
 **Parameters:**
 
@@ -1140,7 +1142,7 @@ ___
 
 ▸ **defaultEnoughSpaceForDecompression**(`free`: number, `imageSize?`: undefined | number): *boolean*
 
-*Defined in [lib/multi-write.ts:103](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L103)*
+*Defined in [lib/multi-write.ts:103](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L103)*
 
 **Parameters:**
 
@@ -1157,7 +1159,7 @@ ___
 
 ▸ **delay**(`ms`: number): *Promise‹void›*
 
-*Defined in [lib/utils.ts:128](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/utils.ts#L128)*
+*Defined in [lib/utils.ts:128](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/utils.ts#L128)*
 
 **Parameters:**
 
@@ -1173,7 +1175,7 @@ ___
 
 ▸ **difference**‹**T**›(`setA`: Set‹T›, `setB`: Set‹T›): *Set‹T›*
 
-*Defined in [lib/utils.ts:94](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/utils.ts#L94)*
+*Defined in [lib/utils.ts:94](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/utils.ts#L94)*
 
 **Type parameters:**
 
@@ -1194,7 +1196,7 @@ ___
 
 ▸ **driveKey**(`drive`: $Drive): *string*
 
-*Defined in [lib/scanner/adapters/block-device.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L46)*
+*Defined in [lib/scanner/adapters/block-device.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L46)*
 
 **Parameters:**
 
@@ -1210,7 +1212,7 @@ ___
 
 ▸ **every**‹**T**›(`things`: Iterable‹T›): *boolean*
 
-*Defined in [lib/utils.ts:168](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/utils.ts#L168)*
+*Defined in [lib/utils.ts:168](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/utils.ts#L168)*
 
 **Type parameters:**
 
@@ -1230,7 +1232,7 @@ ___
 
 ▸ **execFileAsync**(`command`: string, `args`: string[], `options`: ExecFileOptions): *Promise‹[ExecResult](interfaces/execresult.md)›*
 
-*Defined in [lib/diskpart.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/diskpart.ts#L37)*
+*Defined in [lib/diskpart.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/diskpart.ts#L37)*
 
 **Parameters:**
 
@@ -1248,7 +1250,7 @@ ___
 
 ▸ **freeSpace**(): *Promise‹number›*
 
-*Defined in [lib/tmp.ts:140](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/tmp.ts#L140)*
+*Defined in [lib/tmp.ts:140](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/tmp.ts#L140)*
 
 **Returns:** *Promise‹number›*
 
@@ -1258,7 +1260,7 @@ ___
 
 ▸ **fromCallback**‹**T**›(`fn`: function): *Promise‹T›*
 
-*Defined in [lib/utils.ts:114](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/utils.ts#L114)*
+*Defined in [lib/utils.ts:114](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/utils.ts#L114)*
 
 **Type parameters:**
 
@@ -1291,7 +1293,7 @@ ___
 
 ▸ **getAlignment**(...`devices`: [SourceDestination](classes/sourcedestination.md)[]): *number | undefined*
 
-*Defined in [lib/multi-write.ts:372](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L372)*
+*Defined in [lib/multi-write.ts:372](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L372)*
 
 **Parameters:**
 
@@ -1307,7 +1309,7 @@ ___
 
 ▸ **getDiskDeviceType**(`disk`: Disk): *Promise‹[DeviceTypeJSON](interfaces/devicetypejson.md) | undefined›*
 
-*Defined in [lib/source-destination/configured-source/configure.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configure.ts#L83)*
+*Defined in [lib/source-destination/configured-source/configure.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configure.ts#L83)*
 
 **Parameters:**
 
@@ -1323,7 +1325,7 @@ ___
 
 ▸ **getEta**(`current`: number, `total`: number, `speed`: number): *number | undefined*
 
-*Defined in [lib/multi-write.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L83)*
+*Defined in [lib/multi-write.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L83)*
 
 **Parameters:**
 
@@ -1341,7 +1343,7 @@ ___
 
 ▸ **getFileStreamFromZipStream**(`zipStream`: ReadableStream, `match`: function): *Promise‹ZipStreamEntry›*
 
-*Defined in [lib/zip.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/zip.ts#L21)*
+*Defined in [lib/zip.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/zip.ts#L21)*
 
 **Parameters:**
 
@@ -1365,7 +1367,7 @@ ___
 
 ▸ **getRootStream**(`stream`: ReadableStream): *ReadableStream*
 
-*Defined in [lib/source-destination/compressed-source.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/compressed-source.ts#L35)*
+*Defined in [lib/source-destination/compressed-source.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L35)*
 
 **Parameters:**
 
@@ -1381,7 +1383,7 @@ ___
 
 ▸ **isAlignedLockableBuffer**(`buffer`: [Buffer](interfaces/alignedlockablebuffer.md#buffer)): *buffer is AlignedLockableBuffer*
 
-*Defined in [lib/aligned-lockable-buffer.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/aligned-lockable-buffer.ts#L47)*
+*Defined in [lib/aligned-lockable-buffer.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/aligned-lockable-buffer.ts#L47)*
 
 **Parameters:**
 
@@ -1397,7 +1399,7 @@ ___
 
 ▸ **isSourceTransform**(`stream`: any): *stream is SourceTransform*
 
-*Defined in [lib/source-destination/compressed-source.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/compressed-source.ts#L31)*
+*Defined in [lib/source-destination/compressed-source.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L31)*
 
 **Parameters:**
 
@@ -1413,7 +1415,7 @@ ___
 
 ▸ **isTransientError**(`error`: ErrnoException): *boolean*
 
-*Defined in [lib/errors.ts:66](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/errors.ts#L66)*
+*Defined in [lib/errors.ts:66](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/errors.ts#L66)*
 
 **`summary`** Determine whether an error is considered a
 transient occurrence, and the operation should be retried
@@ -1436,7 +1438,7 @@ ___
 
 ▸ **isWorthDecompressing**(`filename`: string): *boolean*
 
-*Defined in [lib/multi-write.ts:91](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L91)*
+*Defined in [lib/multi-write.ts:91](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L91)*
 
 **Parameters:**
 
@@ -1452,7 +1454,7 @@ ___
 
 ▸ **isntNull**‹**T**›(`x`: T | null): *x is Exclude<T, null>*
 
-*Defined in [lib/source-destination/multi-destination.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L35)*
+*Defined in [lib/source-destination/multi-destination.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L35)*
 
 **Type parameters:**
 
@@ -1472,7 +1474,7 @@ ___
 
 ▸ **looksLikeComputeModule**(`description`: string): *boolean*
 
-*Defined in [lib/scanner/adapters/block-device.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L37)*
+*Defined in [lib/scanner/adapters/block-device.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L37)*
 
 **Parameters:**
 
@@ -1488,7 +1490,7 @@ ___
 
 ▸ **makeClassEmitProgressEvents**‹**T**›(`Cls`: T, `attribute`: string, `positionAttribute`: string, `interval`: number): *(Anonymous class) & T*
 
-*Defined in [lib/source-destination/progress.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/progress.ts#L33)*
+*Defined in [lib/source-destination/progress.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/progress.ts#L33)*
 
 **Type parameters:**
 
@@ -1511,7 +1513,7 @@ ___
 
 ▸ **matchSupportedExtensions**(`filename`: string): *boolean*
 
-*Defined in [lib/source-destination/zip.ts:64](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L64)*
+*Defined in [lib/source-destination/zip.ts:64](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L64)*
 
 **Parameters:**
 
@@ -1527,7 +1529,7 @@ ___
 
 ▸ **maxBy**‹**T**›(`things`: Iterable‹T›, `iteratee`: function): *T | undefined*
 
-*Defined in [lib/utils.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/utils.ts#L150)*
+*Defined in [lib/utils.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/utils.ts#L150)*
 
 **Type parameters:**
 
@@ -1555,7 +1557,7 @@ ___
 
 ▸ **minBy**‹**T**›(`things`: Iterable‹T›, `iteratee`: function): *T | undefined*
 
-*Defined in [lib/utils.ts:134](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/utils.ts#L134)*
+*Defined in [lib/utils.ts:134](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/utils.ts#L134)*
 
 **Type parameters:**
 
@@ -1583,7 +1585,7 @@ ___
 
 ▸ **nmWifiConfig**(`index`: number, `options`: [WifiConfig](interfaces/wificonfig.md)): *string*
 
-*Defined in [lib/source-destination/configured-source/operations/configure.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/operations/configure.ts#L33)*
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/operations/configure.ts#L33)*
 
 **Parameters:**
 
@@ -1600,7 +1602,7 @@ ___
 
 ▸ **normalizePartition**(`partition`: [Partition](README.md#partition)): *number*
 
-*Defined in [lib/source-destination/configured-source/configure.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configure.ts#L67)*
+*Defined in [lib/source-destination/configured-source/configure.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configure.ts#L67)*
 
 **Parameters:**
 
@@ -1616,7 +1618,7 @@ ___
 
 ▸ **notUndefined**‹**T**›(`x`: T | undefined): *x is T*
 
-*Defined in [lib/multi-write.ts:368](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L368)*
+*Defined in [lib/multi-write.ts:368](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L368)*
 
 **Type parameters:**
 
@@ -1636,7 +1638,7 @@ ___
 
 ▸ **once**‹**T**›(`fn`: function): *function*
 
-*Defined in [lib/utils.ts:177](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/utils.ts#L177)*
+*Defined in [lib/utils.ts:177](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/utils.ts#L177)*
 
 **Type parameters:**
 
@@ -1658,7 +1660,7 @@ ___
 
 ▸ **pad**(`num`: number): *string*
 
-*Defined in [lib/source-destination/configured-source/operations/configure.ts:97](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/operations/configure.ts#L97)*
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:97](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/operations/configure.ts#L97)*
 
 **Parameters:**
 
@@ -1674,7 +1676,7 @@ ___
 
 ▸ **pipeRegularSourceToDestination**(`source`: [SourceDestination](classes/sourcedestination.md), `sourceMetadata`: [Metadata](interfaces/metadata.md), `destination`: [MultiDestination](classes/multidestination.md), `verify`: boolean, `numBuffers`: number, `updateState`: function, `onFail`: function, `onProgress`: function, `onRootStreamProgress`: function): *Promise‹void›*
 
-*Defined in [lib/multi-write.ts:379](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L379)*
+*Defined in [lib/multi-write.ts:379](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L379)*
 
 **Parameters:**
 
@@ -1736,7 +1738,7 @@ ___
 
 ▸ **pipeSourceToDestinations**(`__namedParameters`: object): *Promise‹[PipeSourceToDestinationsResult](interfaces/pipesourcetodestinationsresult.md)›*
 
-*Defined in [lib/multi-write.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L276)*
+*Defined in [lib/multi-write.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L276)*
 
 **Parameters:**
 
@@ -1759,7 +1761,7 @@ ___
 
 ▸ **pipeSparseSourceToDestination**(`source`: [SourceDestination](classes/sourcedestination.md), `destination`: [MultiDestination](classes/multidestination.md), `verify`: boolean, `numBuffers`: number, `updateState`: function, `onFail`: function, `onProgress`: function, `onRootStreamProgress`: function): *Promise‹void›*
 
-*Defined in [lib/multi-write.ts:483](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L483)*
+*Defined in [lib/multi-write.ts:483](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L483)*
 
 **Parameters:**
 
@@ -1819,7 +1821,7 @@ ___
 
 ▸ **randomFilePath**(`prefix`: string, `postfix`: string): *string*
 
-*Defined in [lib/tmp.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/tmp.ts#L27)*
+*Defined in [lib/tmp.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/tmp.ts#L27)*
 
 **Parameters:**
 
@@ -1836,7 +1838,7 @@ ___
 
 ▸ **retryOnTransientError**‹**T**›(`fn`: function, `maxRetries`: number, `baseDelay`: number): *Promise‹T›*
 
-*Defined in [lib/errors.ts:77](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/errors.ts#L77)*
+*Defined in [lib/errors.ts:77](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/errors.ts#L77)*
 
 **Type parameters:**
 
@@ -1860,7 +1862,7 @@ ___
 
 ▸ **runDiskpart**(`commands`: string[]): *Promise‹void›*
 
-*Defined in [lib/diskpart.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/diskpart.ts#L75)*
+*Defined in [lib/diskpart.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/diskpart.ts#L75)*
 
 **`summary`** Run a diskpart script
 
@@ -1878,7 +1880,7 @@ ___
 
 ▸ **runVerifier**(`verifier`: [Verifier](classes/verifier.md), `onFail`: function, `onProgress`: function): *Promise‹void›*
 
-*Defined in [lib/multi-write.ts:523](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L523)*
+*Defined in [lib/multi-write.ts:523](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L523)*
 
 **Parameters:**
 
@@ -1912,7 +1914,7 @@ ___
 
 ▸ **shouldRunOperation**(`options`: [Dictionary](interfaces/dictionary.md)‹any›, `operation`: [CopyOperation](interfaces/copyoperation.md)): *boolean*
 
-*Defined in [lib/source-destination/configured-source/configure.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configure.ts#L54)*
+*Defined in [lib/source-destination/configured-source/configure.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configure.ts#L54)*
 
 **Parameters:**
 
@@ -1929,7 +1931,7 @@ ___
 
 ▸ **sparseStreamToBuffer**(`stream`: ReadableStream): *Promise‹[Buffer](interfaces/alignedlockablebuffer.md#buffer)›*
 
-*Defined in [lib/utils.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/utils.ts#L53)*
+*Defined in [lib/utils.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/utils.ts#L53)*
 
 **Parameters:**
 
@@ -1945,7 +1947,7 @@ ___
 
 ▸ **streamToBuffer**(`stream`: ReadableStream): *Promise‹[Buffer](interfaces/alignedlockablebuffer.md#buffer)›*
 
-*Defined in [lib/utils.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/utils.ts#L24)*
+*Defined in [lib/utils.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/utils.ts#L24)*
 
 **Parameters:**
 
@@ -1961,7 +1963,7 @@ ___
 
 ▸ **sumBy**‹**T**›(`things`: Iterable‹T›, `iteratee`: function): *number*
 
-*Defined in [lib/utils.ts:157](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/utils.ts#L157)*
+*Defined in [lib/utils.ts:157](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/utils.ts#L157)*
 
 **Type parameters:**
 
@@ -1989,7 +1991,7 @@ ___
 
 ▸ **tmpFile**(`__namedParameters`: object): *Promise‹[TmpFileResult](interfaces/tmpfileresult.md)›*
 
-*Defined in [lib/tmp.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/tmp.ts#L84)*
+*Defined in [lib/tmp.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/tmp.ts#L84)*
 
 **Parameters:**
 
@@ -2009,7 +2011,7 @@ ___
 
 ▸ **verifyOrGenerateChecksum**(`hasher`: [AnyHasher](README.md#anyhasher) | undefined, `blocks`: [BlocksWithChecksum](interfaces/blockswithchecksum.md), `verify`: boolean, `generateChecksums`: boolean): *void*
 
-*Defined in [lib/sparse-stream/shared.ts:109](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L109)*
+*Defined in [lib/sparse-stream/shared.ts:109](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L109)*
 
 **Parameters:**
 
@@ -2028,7 +2030,7 @@ ___
 
 ▸ **withDiskpartMutex**‹**T**›(`fn`: function): *Promise‹T›*
 
-*Defined in [lib/diskpart.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/diskpart.ts#L62)*
+*Defined in [lib/diskpart.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/diskpart.ts#L62)*
 
 **Type parameters:**
 
@@ -2048,7 +2050,7 @@ ___
 
 ▸ **withTmpFile**‹**T**›(`options`: [TmpFileOptions](interfaces/tmpfileoptions.md), `fn`: function): *Promise‹T›*
 
-*Defined in [lib/tmp.ts:117](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/tmp.ts#L117)*
+*Defined in [lib/tmp.ts:117](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/tmp.ts#L117)*
 
 **Type parameters:**
 

--- a/doc/classes/adapter.md
+++ b/doc/classes/adapter.md
@@ -10,6 +10,8 @@
 
   ↳ [BlockDeviceAdapter](blockdeviceadapter.md)
 
+  ↳ [UsbBBbootDeviceAdapter](usbbbbootdeviceadapter.md)
+
   ↳ [UsbbootDeviceAdapter](usbbootdeviceadapter.md)
 
   ↳ [DriverlessDeviceAdapter$](driverlessdeviceadapter_.md)
@@ -402,7 +404,7 @@ ___
 
 ▸ **start**(): *void*
 
-*Defined in [lib/scanner/adapters/adapter.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/adapter.ts#L34)*
+*Defined in [lib/scanner/adapters/adapter.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/adapter.ts#L34)*
 
 **Returns:** *void*
 
@@ -412,7 +414,7 @@ ___
 
 ▸ **stop**(): *void*
 
-*Defined in [lib/scanner/adapters/adapter.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/adapter.ts#L35)*
+*Defined in [lib/scanner/adapters/adapter.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/adapter.ts#L35)*
 
 **Returns:** *void*
 

--- a/doc/classes/alignedreadablestate.md
+++ b/doc/classes/alignedreadablestate.md
@@ -30,7 +30,7 @@
 
 \+ **new AlignedReadableState**(`bufferSize`: number, `alignment`: number, `numBuffers`: number): *[AlignedReadableState](alignedreadablestate.md)*
 
-*Defined in [lib/aligned-lockable-buffer.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/aligned-lockable-buffer.ts#L55)*
+*Defined in [lib/aligned-lockable-buffer.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/aligned-lockable-buffer.ts#L55)*
 
 **Parameters:**
 
@@ -48,7 +48,7 @@ Name | Type |
 
 • **alignment**: *number*
 
-*Defined in [lib/aligned-lockable-buffer.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/aligned-lockable-buffer.ts#L59)*
+*Defined in [lib/aligned-lockable-buffer.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/aligned-lockable-buffer.ts#L59)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • **bufferSize**: *number*
 
-*Defined in [lib/aligned-lockable-buffer.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/aligned-lockable-buffer.ts#L58)*
+*Defined in [lib/aligned-lockable-buffer.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/aligned-lockable-buffer.ts#L58)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • **buffers**: *[AlignedLockableBuffer](../interfaces/alignedlockablebuffer.md)[]*
 
-*Defined in [lib/aligned-lockable-buffer.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/aligned-lockable-buffer.ts#L54)*
+*Defined in [lib/aligned-lockable-buffer.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/aligned-lockable-buffer.ts#L54)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 • **currentBufferIndex**: *number* = 0
 
-*Defined in [lib/aligned-lockable-buffer.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/aligned-lockable-buffer.ts#L55)*
+*Defined in [lib/aligned-lockable-buffer.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/aligned-lockable-buffer.ts#L55)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 • **numBuffers**: *number*
 
-*Defined in [lib/aligned-lockable-buffer.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/aligned-lockable-buffer.ts#L60)*
+*Defined in [lib/aligned-lockable-buffer.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/aligned-lockable-buffer.ts#L60)*
 
 ## Methods
 
@@ -88,6 +88,6 @@ ___
 
 ▸ **getCurrentBuffer**(): *[AlignedLockableBuffer](../interfaces/alignedlockablebuffer.md)*
 
-*Defined in [lib/aligned-lockable-buffer.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/aligned-lockable-buffer.ts#L65)*
+*Defined in [lib/aligned-lockable-buffer.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/aligned-lockable-buffer.ts#L65)*
 
 **Returns:** *[AlignedLockableBuffer](../interfaces/alignedlockablebuffer.md)*

--- a/doc/classes/balenas3compressedsource.md
+++ b/doc/classes/balenas3compressedsource.md
@@ -108,7 +108,7 @@
 
 *Overrides [BalenaS3SourceBase](balenas3sourcebase.md).[constructor](balenas3sourcebase.md#constructor)*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L71)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L71)*
 
 **Parameters:**
 
@@ -131,7 +131,7 @@ Name | Type |
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[axiosInstance](balenas3sourcebase.md#protected-axiosinstance)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L58)*
+*Defined in [lib/source-destination/balena-s3-source.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L58)*
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[bucket](balenas3sourcebase.md#readonly-bucket)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L53)*
+*Defined in [lib/source-destination/balena-s3-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L53)*
 
 ___
 
@@ -151,7 +151,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[buildId](balenas3sourcebase.md#readonly-buildid)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L56)*
+*Defined in [lib/source-destination/balena-s3-source.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L56)*
 
 ___
 
@@ -159,7 +159,7 @@ ___
 
 • **configuration**? : *[Dictionary](../interfaces/dictionary.md)‹any›*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L62)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L62)*
 
 ___
 
@@ -170,7 +170,7 @@ ___
 		{ crc: number; zLen: number; buffer: Buffer }
 	>()
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L63)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L63)*
 
 ___
 
@@ -180,7 +180,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[deviceType](balenas3sourcebase.md#readonly-devicetype)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L55)*
+*Defined in [lib/source-destination/balena-s3-source.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L55)*
 
 ___
 
@@ -188,7 +188,7 @@ ___
 
 • **deviceTypeJSON**: *[DeviceTypeJSON](../interfaces/devicetypejson.md)*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L58)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L58)*
 
 ___
 
@@ -196,7 +196,7 @@ ___
 
 • **filename**: *string*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L71)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L71)*
 
 ___
 
@@ -204,7 +204,7 @@ ___
 
 • **filenamePrefix**? : *undefined | string*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L60)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L60)*
 
 ___
 
@@ -212,7 +212,7 @@ ___
 
 • **format**: *BalenaS3CompressedSourceOptions["format"]*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L59)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L59)*
 
 ___
 
@@ -222,7 +222,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[host](balenas3sourcebase.md#readonly-host)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L52)*
+*Defined in [lib/source-destination/balena-s3-source.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L52)*
 
 ___
 
@@ -230,7 +230,7 @@ ___
 
 • **imageJSON**: *[ImageJSON](../README.md#imagejson)*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L57)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L57)*
 
 ___
 
@@ -238,7 +238,7 @@ ___
 
 • **lastModified**: *Date*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L68)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L68)*
 
 ___
 
@@ -246,7 +246,7 @@ ___
 
 • **osVersion**: *string*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:69](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L69)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:69](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L69)*
 
 ___
 
@@ -256,7 +256,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[prefix](balenas3sourcebase.md#readonly-prefix)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L54)*
+*Defined in [lib/source-destination/balena-s3-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L54)*
 
 ___
 
@@ -266,7 +266,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[release](balenas3sourcebase.md#optional-readonly-release)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L57)*
+*Defined in [lib/source-destination/balena-s3-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L57)*
 
 ___
 
@@ -274,7 +274,7 @@ ___
 
 • **size**: *number*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L70)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L70)*
 
 ___
 
@@ -282,7 +282,7 @@ ___
 
 • **supervisorVersion**: *string*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L67)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L67)*
 
 ___
 
@@ -313,7 +313,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -323,7 +323,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L286)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ## Methods
 
@@ -333,7 +333,7 @@ ___
 
 *Inherited from [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/source-destination.ts:401](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L401)*
+*Defined in [lib/source-destination/source-destination.ts:401](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L401)*
 
 **Returns:** *Promise‹void›*
 
@@ -345,7 +345,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L102)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L102)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -357,7 +357,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:233](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L233)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:233](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L233)*
 
 **Returns:** *Promise‹void›*
 
@@ -399,7 +399,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:97](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L97)*
+*Defined in [lib/source-destination/balena-s3-source.ts:97](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L97)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -411,7 +411,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L314)*
+*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L314)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -423,7 +423,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -435,7 +435,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -447,7 +447,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L302)*
+*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L302)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -459,7 +459,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -471,7 +471,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -481,7 +481,7 @@ ___
 
 ▸ **configure**(): *Promise‹void›*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:187](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L187)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:187](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L187)*
 
 **Returns:** *Promise‹void›*
 
@@ -491,7 +491,7 @@ ___
 
 ▸ **createGzipStream**(`fake`: boolean): *Promise‹GzipStream‹››*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L300)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:300](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L300)*
 
 **Parameters:**
 
@@ -509,7 +509,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L311)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L311)*
 
 **Parameters:**
 
@@ -527,7 +527,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L361)*
+*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L361)*
 
 **Parameters:**
 
@@ -545,7 +545,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -563,7 +563,7 @@ ___
 
 ▸ **createStream**(`fake`: boolean): *Promise‹any›*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L305)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L305)*
 
 **Parameters:**
 
@@ -581,7 +581,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -600,7 +600,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -618,7 +618,7 @@ ___
 
 ▸ **createZipStream**(`fake`: boolean): *Promise‹any›*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L293)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L293)*
 
 **Parameters:**
 
@@ -636,7 +636,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[download](balenas3sourcebase.md#protected-download)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:109](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L109)*
+*Defined in [lib/source-destination/balena-s3-source.ts:109](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L109)*
 
 **Parameters:**
 
@@ -688,7 +688,7 @@ ___
 
 ▸ **extractDeflateToDisk**(`filename`: string): *Promise‹BufferDisk‹››*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:177](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L177)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:177](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L177)*
 
 **Parameters:**
 
@@ -704,7 +704,7 @@ ___
 
 ▸ **findImagePart**(`imageJSON`: [ImageJSON](../README.md#imagejson), `image`: string): *[ImageJSONPart](../interfaces/imagejsonpart.md)*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:158](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L158)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:158](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L158)*
 
 **Parameters:**
 
@@ -721,7 +721,7 @@ ___
 
 ▸ **findPart**(`definition`: [FileOnPartition](../interfaces/fileonpartition.md)): *[ImageJSONPart](../interfaces/imagejsonpart.md)*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L166)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L166)*
 
 **Parameters:**
 
@@ -737,7 +737,7 @@ ___
 
 ▸ **findPartitionPart**(`imageJSON`: [ImageJSON](../README.md#imagejson), `partition`: number): *[ImageJSONPart](../interfaces/imagejsonpart.md)*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:142](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L142)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:142](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L142)*
 
 **Parameters:**
 
@@ -756,7 +756,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -768,7 +768,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -778,7 +778,7 @@ ___
 
 ▸ **getDeviceTypeJSON**(): *Promise‹[DeviceTypeJSON](../interfaces/devicetypejson.md)›*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:131](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L131)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:131](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L131)*
 
 **Returns:** *Promise‹[DeviceTypeJSON](../interfaces/devicetypejson.md)›*
 
@@ -788,7 +788,7 @@ ___
 
 ▸ **getFilename**(): *string*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:89](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L89)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:89](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L89)*
 
 **Returns:** *string*
 
@@ -798,7 +798,7 @@ ___
 
 ▸ **getImageJSON**(): *Promise‹[ImageJSON](../README.md#imagejson)›*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:126](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L126)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:126](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L126)*
 
 **Returns:** *Promise‹[ImageJSON](../README.md#imagejson)›*
 
@@ -810,7 +810,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -836,7 +836,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -846,7 +846,7 @@ ___
 
 ▸ **getOsVersion**(): *Promise‹any›*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:121](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L121)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:121](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L121)*
 
 **Returns:** *Promise‹any›*
 
@@ -856,7 +856,7 @@ ___
 
 ▸ **getPartStream**(`filename`: string): *Promise‹ReadableStream›*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:135](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L135)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:135](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L135)*
 
 **Parameters:**
 
@@ -874,7 +874,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -884,7 +884,7 @@ ___
 
 ▸ **getParts**(`fake`: boolean): *Promise‹object[]›*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:270](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L270)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:270](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L270)*
 
 **Parameters:**
 
@@ -900,7 +900,7 @@ ___
 
 ▸ **getSize**(): *Promise‹number›*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:85](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L85)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:85](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L85)*
 
 **Returns:** *Promise‹number›*
 
@@ -910,7 +910,7 @@ ___
 
 ▸ **getSupervisorVersion**(): *Promise‹object›*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:114](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L114)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:114](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L114)*
 
 **Returns:** *Promise‹object›*
 
@@ -922,7 +922,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[getUrl](balenas3sourcebase.md#protected-geturl)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:113](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L113)*
+*Defined in [lib/source-destination/balena-s3-source.ts:113](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L113)*
 
 **Parameters:**
 
@@ -1064,7 +1064,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -1152,7 +1152,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L337)*
+*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L337)*
 
 **Parameters:**
 
@@ -1241,7 +1241,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -1262,7 +1262,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[isESRVersion](balenas3sourcebase.md#static-isesrversion)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L101)*
+*Defined in [lib/source-destination/balena-s3-source.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L101)*
 
 **Parameters:**
 
@@ -1301,7 +1301,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/balenas3source.md
+++ b/doc/classes/balenas3source.md
@@ -86,7 +86,7 @@
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[constructor](balenas3sourcebase.md#constructor)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L63)*
+*Defined in [lib/source-destination/balena-s3-source.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L63)*
 
 **Parameters:**
 
@@ -112,7 +112,7 @@ Name | Type |
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[axiosInstance](balenas3sourcebase.md#protected-axiosinstance)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L58)*
+*Defined in [lib/source-destination/balena-s3-source.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L58)*
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[bucket](balenas3sourcebase.md#readonly-bucket)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L53)*
+*Defined in [lib/source-destination/balena-s3-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L53)*
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[buildId](balenas3sourcebase.md#readonly-buildid)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L56)*
+*Defined in [lib/source-destination/balena-s3-source.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L56)*
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[deviceType](balenas3sourcebase.md#readonly-devicetype)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L55)*
+*Defined in [lib/source-destination/balena-s3-source.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L55)*
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[host](balenas3sourcebase.md#readonly-host)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L52)*
+*Defined in [lib/source-destination/balena-s3-source.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L52)*
 
 ___
 
@@ -160,7 +160,7 @@ ___
 
 • **name**: *[Name](../README.md#name)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:148](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L148)*
+*Defined in [lib/source-destination/balena-s3-source.ts:148](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L148)*
 
 ___
 
@@ -168,7 +168,7 @@ ___
 
 • **names**: *[Name](../README.md#name)[]* = ['balena', 'resin']
 
-*Defined in [lib/source-destination/balena-s3-source.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L147)*
+*Defined in [lib/source-destination/balena-s3-source.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L147)*
 
 ___
 
@@ -178,7 +178,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[prefix](balenas3sourcebase.md#readonly-prefix)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L54)*
+*Defined in [lib/source-destination/balena-s3-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L54)*
 
 ___
 
@@ -186,7 +186,7 @@ ___
 
 • **rawSource**: *[Http](http.md)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:145](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L145)*
+*Defined in [lib/source-destination/balena-s3-source.ts:145](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L145)*
 
 ___
 
@@ -196,7 +196,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[release](balenas3sourcebase.md#optional-readonly-release)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L57)*
+*Defined in [lib/source-destination/balena-s3-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L57)*
 
 ___
 
@@ -204,7 +204,7 @@ ___
 
 • **zipSource**: *[ZipSource](zipsource.md)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:146](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L146)*
+*Defined in [lib/source-destination/balena-s3-source.ts:146](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L146)*
 
 ___
 
@@ -235,7 +235,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -245,7 +245,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L286)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ## Methods
 
@@ -255,7 +255,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:211](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L211)*
+*Defined in [lib/source-destination/balena-s3-source.ts:211](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L211)*
 
 **Returns:** *Promise‹void›*
 
@@ -267,7 +267,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:191](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L191)*
+*Defined in [lib/source-destination/balena-s3-source.ts:191](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L191)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -279,7 +279,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:195](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L195)*
+*Defined in [lib/source-destination/balena-s3-source.ts:195](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L195)*
 
 **Returns:** *Promise‹void›*
 
@@ -321,7 +321,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:97](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L97)*
+*Defined in [lib/source-destination/balena-s3-source.ts:97](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L97)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -333,7 +333,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L314)*
+*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L314)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -345,7 +345,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -357,7 +357,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -369,7 +369,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:167](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L167)*
+*Defined in [lib/source-destination/balena-s3-source.ts:167](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L167)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -381,7 +381,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -393,7 +393,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -405,7 +405,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:185](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L185)*
+*Defined in [lib/source-destination/balena-s3-source.ts:185](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L185)*
 
 **Parameters:**
 
@@ -423,7 +423,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L361)*
+*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L361)*
 
 **Parameters:**
 
@@ -441,7 +441,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -461,7 +461,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -480,7 +480,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -500,7 +500,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[download](balenas3sourcebase.md#protected-download)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:109](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L109)*
+*Defined in [lib/source-destination/balena-s3-source.ts:109](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L109)*
 
 **Parameters:**
 
@@ -554,7 +554,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -566,7 +566,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -578,7 +578,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -604,7 +604,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -614,7 +614,7 @@ ___
 
 ▸ **getName**(): *Promise‹[Name](../README.md#name)›*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L150)*
+*Defined in [lib/source-destination/balena-s3-source.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L150)*
 
 **Returns:** *Promise‹[Name](../README.md#name)›*
 
@@ -626,7 +626,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -638,7 +638,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[getUrl](balenas3sourcebase.md#protected-geturl)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:113](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L113)*
+*Defined in [lib/source-destination/balena-s3-source.ts:113](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L113)*
 
 **Parameters:**
 
@@ -780,7 +780,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -868,7 +868,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:171](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L171)*
+*Defined in [lib/source-destination/balena-s3-source.ts:171](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L171)*
 
 **Parameters:**
 
@@ -957,7 +957,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -978,7 +978,7 @@ ___
 
 *Inherited from [BalenaS3SourceBase](balenas3sourcebase.md).[isESRVersion](balenas3sourcebase.md#static-isesrversion)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L101)*
+*Defined in [lib/source-destination/balena-s3-source.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L101)*
 
 **Parameters:**
 
@@ -1017,7 +1017,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/balenas3sourcebase.md
+++ b/doc/classes/balenas3sourcebase.md
@@ -85,7 +85,7 @@
 
 \+ **new BalenaS3SourceBase**(`__namedParameters`: object): *[BalenaS3SourceBase](balenas3sourcebase.md)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L63)*
+*Defined in [lib/source-destination/balena-s3-source.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L63)*
 
 **Parameters:**
 
@@ -109,7 +109,7 @@ Name | Type |
 
 • **axiosInstance**: *AxiosInstance*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L58)*
+*Defined in [lib/source-destination/balena-s3-source.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L58)*
 
 ___
 
@@ -117,7 +117,7 @@ ___
 
 • **bucket**: *string*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L53)*
+*Defined in [lib/source-destination/balena-s3-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L53)*
 
 ___
 
@@ -125,7 +125,7 @@ ___
 
 • **buildId**: *string*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L56)*
+*Defined in [lib/source-destination/balena-s3-source.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L56)*
 
 ___
 
@@ -133,7 +133,7 @@ ___
 
 • **deviceType**: *string*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L55)*
+*Defined in [lib/source-destination/balena-s3-source.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L55)*
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 • **host**: *string*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L52)*
+*Defined in [lib/source-destination/balena-s3-source.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L52)*
 
 ___
 
@@ -149,7 +149,7 @@ ___
 
 • **prefix**: *string*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L54)*
+*Defined in [lib/source-destination/balena-s3-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L54)*
 
 ___
 
@@ -157,7 +157,7 @@ ___
 
 • **release**? : *undefined | string*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L57)*
+*Defined in [lib/source-destination/balena-s3-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L57)*
 
 ___
 
@@ -179,7 +179,7 @@ ___
 		'device-type.json',
 	]
 
-*Defined in [lib/source-destination/balena-s3-source.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L59)*
+*Defined in [lib/source-destination/balena-s3-source.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L59)*
 
 ___
 
@@ -200,7 +200,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -210,7 +210,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L286)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ## Methods
 
@@ -220,7 +220,7 @@ ___
 
 *Inherited from [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/source-destination.ts:401](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L401)*
+*Defined in [lib/source-destination/source-destination.ts:401](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L401)*
 
 **Returns:** *Promise‹void›*
 
@@ -232,7 +232,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L333)*
+*Defined in [lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L333)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -244,7 +244,7 @@ ___
 
 *Inherited from [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
 
-*Defined in [lib/source-destination/source-destination.ts:397](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L397)*
+*Defined in [lib/source-destination/source-destination.ts:397](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L397)*
 
 **Returns:** *Promise‹void›*
 
@@ -284,7 +284,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:97](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L97)*
+*Defined in [lib/source-destination/balena-s3-source.ts:97](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L97)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -296,7 +296,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L314)*
+*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L314)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -308,7 +308,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -320,7 +320,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -332,7 +332,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L302)*
+*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L302)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -344,7 +344,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -356,7 +356,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -368,7 +368,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:355](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L355)*
+*Defined in [lib/source-destination/source-destination.ts:355](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L355)*
 
 **Parameters:**
 
@@ -386,7 +386,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L361)*
+*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L361)*
 
 **Parameters:**
 
@@ -404,7 +404,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -424,7 +424,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -443,7 +443,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -461,7 +461,7 @@ ___
 
 ▸ **download**(`path`: string, `responseType?`: undefined | "stream"): *Promise‹AxiosResponse‹any››*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:109](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L109)*
+*Defined in [lib/source-destination/balena-s3-source.ts:109](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L109)*
 
 **Parameters:**
 
@@ -515,7 +515,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -527,7 +527,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -539,7 +539,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -565,7 +565,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -577,7 +577,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -587,7 +587,7 @@ ___
 
 ▸ **getUrl**(`path`: string): *string*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:113](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L113)*
+*Defined in [lib/source-destination/balena-s3-source.ts:113](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L113)*
 
 **Parameters:**
 
@@ -603,7 +603,7 @@ ___
 
 ▸ **isESR**(): *boolean*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:105](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L105)*
+*Defined in [lib/source-destination/balena-s3-source.ts:105](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L105)*
 
 **Returns:** *boolean*
 
@@ -739,7 +739,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -827,7 +827,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L337)*
+*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L337)*
 
 **Parameters:**
 
@@ -916,7 +916,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -935,7 +935,7 @@ ___
 
 ▸ **isESRVersion**(`buildId`: string): *boolean*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L101)*
+*Defined in [lib/source-destination/balena-s3-source.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L101)*
 
 **Parameters:**
 
@@ -974,7 +974,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/blockdevice.md
+++ b/doc/classes/blockdevice.md
@@ -99,7 +99,7 @@
 
 *Overrides [File](file.md).[constructor](file.md#constructor)*
 
-*Defined in [lib/source-destination/block-device.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L50)*
+*Defined in [lib/source-destination/block-device.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L50)*
 
 **Parameters:**
 
@@ -120,7 +120,7 @@ Name | Type | Default |
 
 • **alignment**: *number*
 
-*Defined in [lib/source-destination/block-device.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L50)*
+*Defined in [lib/source-destination/block-device.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L50)*
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 • **drive**: *[DrivelistDrive](../interfaces/drivelistdrive.md)*
 
-*Defined in [lib/source-destination/block-device.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L46)*
+*Defined in [lib/source-destination/block-device.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L46)*
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[emitsProgress](../interfaces/adaptersourcedestination.md#emitsprogress)*
 
-*Defined in [lib/source-destination/block-device.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L49)*
+*Defined in [lib/source-destination/block-device.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L49)*
 
 ___
 
@@ -148,7 +148,7 @@ ___
 
 *Inherited from [File](file.md).[fileHandle](file.md#protected-filehandle)*
 
-*Defined in [lib/source-destination/file.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L48)*
+*Defined in [lib/source-destination/file.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L48)*
 
 ___
 
@@ -156,7 +156,7 @@ ___
 
 • **oDirect**: *boolean*
 
-*Defined in [lib/source-destination/block-device.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L48)*
+*Defined in [lib/source-destination/block-device.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L48)*
 
 ___
 
@@ -166,7 +166,7 @@ ___
 
 *Inherited from [File](file.md).[oWrite](file.md#owrite)*
 
-*Defined in [lib/source-destination/file.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L47)*
+*Defined in [lib/source-destination/file.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L47)*
 
 ___
 
@@ -176,7 +176,7 @@ ___
 
 *Inherited from [File](file.md).[path](file.md#readonly-path)*
 
-*Defined in [lib/source-destination/file.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L46)*
+*Defined in [lib/source-destination/file.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L46)*
 
 ___
 
@@ -184,7 +184,7 @@ ___
 
 • **unmountOnSuccess**: *boolean*
 
-*Defined in [lib/source-destination/block-device.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L47)*
+*Defined in [lib/source-destination/block-device.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L47)*
 
 ___
 
@@ -219,7 +219,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -231,7 +231,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L286)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ## Accessors
 
@@ -239,7 +239,7 @@ ___
 
 • **get description**(): *string*
 
-*Defined in [lib/source-destination/block-device.ts:115](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L115)*
+*Defined in [lib/source-destination/block-device.ts:115](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L115)*
 
 **Returns:** *string*
 
@@ -249,7 +249,7 @@ ___
 
 • **get device**(): *string*
 
-*Defined in [lib/source-destination/block-device.ts:107](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L107)*
+*Defined in [lib/source-destination/block-device.ts:107](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L107)*
 
 **Returns:** *string*
 
@@ -259,7 +259,7 @@ ___
 
 • **get devicePath**(): *string | null*
 
-*Defined in [lib/source-destination/block-device.ts:111](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L111)*
+*Defined in [lib/source-destination/block-device.ts:111](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L111)*
 
 **Returns:** *string | null*
 
@@ -269,7 +269,7 @@ ___
 
 • **get isSystem**(): *boolean*
 
-*Defined in [lib/source-destination/block-device.ts:99](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L99)*
+*Defined in [lib/source-destination/block-device.ts:99](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L99)*
 
 **Returns:** *boolean*
 
@@ -279,7 +279,7 @@ ___
 
 • **get mountpoints**(): *Mountpoint[]*
 
-*Defined in [lib/source-destination/block-device.ts:119](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L119)*
+*Defined in [lib/source-destination/block-device.ts:119](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L119)*
 
 **Returns:** *Mountpoint[]*
 
@@ -289,7 +289,7 @@ ___
 
 • **get raw**(): *string*
 
-*Defined in [lib/source-destination/block-device.ts:103](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L103)*
+*Defined in [lib/source-destination/block-device.ts:103](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L103)*
 
 **Returns:** *string*
 
@@ -299,7 +299,7 @@ ___
 
 • **get size**(): *number | null*
 
-*Defined in [lib/source-destination/block-device.ts:123](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L123)*
+*Defined in [lib/source-destination/block-device.ts:123](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L123)*
 
 **Returns:** *number | null*
 
@@ -313,7 +313,7 @@ ___
 
 *Overrides [File](file.md).[_close](file.md#protected-_close)*
 
-*Defined in [lib/source-destination/block-device.ts:188](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L188)*
+*Defined in [lib/source-destination/block-device.ts:188](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L188)*
 
 **Returns:** *Promise‹void›*
 
@@ -327,7 +327,7 @@ ___
 
 *Overrides [File](file.md).[_getMetadata](file.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/block-device.ts:127](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L127)*
+*Defined in [lib/source-destination/block-device.ts:127](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L127)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -341,7 +341,7 @@ ___
 
 *Overrides [File](file.md).[_open](file.md#protected-_open)*
 
-*Defined in [lib/source-destination/block-device.ts:170](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L170)*
+*Defined in [lib/source-destination/block-device.ts:170](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L170)*
 
 **Returns:** *Promise‹void›*
 
@@ -379,7 +379,7 @@ ___
 
 ▸ **alignOffsetAfter**(`offset`: number): *number*
 
-*Defined in [lib/source-destination/block-device.ts:209](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L209)*
+*Defined in [lib/source-destination/block-device.ts:209](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L209)*
 
 **Parameters:**
 
@@ -395,7 +395,7 @@ ___
 
 ▸ **alignOffsetBefore**(`offset`: number): *number*
 
-*Defined in [lib/source-destination/block-device.ts:205](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L205)*
+*Defined in [lib/source-destination/block-device.ts:205](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L205)*
 
 **Parameters:**
 
@@ -411,7 +411,7 @@ ___
 
 ▸ **alignedRead**(`buffer`: [Buffer](../interfaces/alignedlockablebuffer.md#buffer), `bufferOffset`: number, `length`: number, `sourceOffset`: number): *Promise‹ReadResult›*
 
-*Defined in [lib/source-destination/block-device.ts:213](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L213)*
+*Defined in [lib/source-destination/block-device.ts:213](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L213)*
 
 **Parameters:**
 
@@ -430,7 +430,7 @@ ___
 
 ▸ **alignedWrite**(`buffer`: [Buffer](../interfaces/alignedlockablebuffer.md#buffer), `bufferOffset`: number, `length`: number, `fileOffset`: number): *Promise‹WriteResult›*
 
-*Defined in [lib/source-destination/block-device.ts:246](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L246)*
+*Defined in [lib/source-destination/block-device.ts:246](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L246)*
 
 **Parameters:**
 
@@ -455,7 +455,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/file.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L71)*
+*Defined in [lib/source-destination/file.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L71)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -469,7 +469,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L314)*
+*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L314)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -483,7 +483,7 @@ ___
 
 *Overrides [File](file.md).[canCreateSparseWriteStream](file.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/block-device.ts:142](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L142)*
+*Defined in [lib/source-destination/block-device.ts:142](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L142)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -497,7 +497,7 @@ ___
 
 *Overrides [File](file.md).[canCreateWriteStream](file.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/block-device.ts:138](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L138)*
+*Defined in [lib/source-destination/block-device.ts:138](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L138)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -513,7 +513,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/file.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L63)*
+*Defined in [lib/source-destination/file.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L63)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -527,7 +527,7 @@ ___
 
 *Overrides [File](file.md).[canWrite](file.md#canwrite)*
 
-*Defined in [lib/source-destination/block-device.ts:134](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L134)*
+*Defined in [lib/source-destination/block-device.ts:134](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L134)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -541,7 +541,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -555,7 +555,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/file.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L147)*
+*Defined in [lib/source-destination/file.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L147)*
 
 **Parameters:**
 
@@ -581,7 +581,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L361)*
+*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L361)*
 
 **Parameters:**
 
@@ -599,7 +599,7 @@ ___
 
 *Overrides [File](file.md).[createSparseWriteStream](file.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/block-device.ts:158](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L158)*
+*Defined in [lib/source-destination/block-device.ts:158](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L158)*
 
 **Parameters:**
 
@@ -621,7 +621,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -640,7 +640,7 @@ ___
 
 *Overrides [File](file.md).[createWriteStream](file.md#createwritestream)*
 
-*Defined in [lib/source-destination/block-device.ts:146](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L146)*
+*Defined in [lib/source-destination/block-device.ts:146](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L146)*
 
 **Parameters:**
 
@@ -701,7 +701,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/block-device.ts:74](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L74)*
+*Defined in [lib/source-destination/block-device.ts:74](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L74)*
 
 **Returns:** *undefined | number*
 
@@ -715,7 +715,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -729,7 +729,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -759,7 +759,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -771,7 +771,7 @@ ___
 
 *Overrides [File](file.md).[getOpenFlags](file.md#protected-getopenflags)*
 
-*Defined in [lib/source-destination/block-device.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L80)*
+*Defined in [lib/source-destination/block-device.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L80)*
 
 **Returns:** *number*
 
@@ -785,7 +785,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -867,7 +867,7 @@ ___
 
 ▸ **offsetIsAligned**(`offset`: number): *boolean*
 
-*Defined in [lib/source-destination/block-device.ts:201](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L201)*
+*Defined in [lib/source-destination/block-device.ts:201](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L201)*
 
 **Parameters:**
 
@@ -943,7 +943,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -1035,7 +1035,7 @@ ___
 
 *Overrides [File](file.md).[read](file.md#read)*
 
-*Defined in [lib/source-destination/block-device.ts:233](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L233)*
+*Defined in [lib/source-destination/block-device.ts:233](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L233)*
 
 **Parameters:**
 
@@ -1130,7 +1130,7 @@ ___
 
 *Overrides [File](file.md).[write](file.md#write)*
 
-*Defined in [lib/source-destination/block-device.ts:262](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/block-device.ts#L262)*
+*Defined in [lib/source-destination/block-device.ts:262](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/block-device.ts#L262)*
 
 **Parameters:**
 
@@ -1176,7 +1176,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/blockdeviceadapter.md
+++ b/doc/classes/blockdeviceadapter.md
@@ -55,7 +55,7 @@
 
 \+ **new BlockDeviceAdapter**(`__namedParameters`: object): *[BlockDeviceAdapter](blockdeviceadapter.md)*
 
-*Defined in [lib/scanner/adapters/block-device.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L71)*
+*Defined in [lib/scanner/adapters/block-device.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L71)*
 
 **Parameters:**
 
@@ -76,7 +76,7 @@ Name | Type | Default |
 
 • **drives**: *Map‹string, [BlockDevice](blockdevice.md)›* = new Map()
 
-*Defined in [lib/scanner/adapters/block-device.ts:69](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L69)*
+*Defined in [lib/scanner/adapters/block-device.ts:69](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L69)*
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 • **includeSystemDrives**: *function*
 
-*Defined in [lib/scanner/adapters/block-device.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L65)*
+*Defined in [lib/scanner/adapters/block-device.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L65)*
 
 #### Type declaration:
 
@@ -96,7 +96,7 @@ ___
 
 • **oDirect**: *boolean*
 
-*Defined in [lib/scanner/adapters/block-device.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L68)*
+*Defined in [lib/scanner/adapters/block-device.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L68)*
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 • **oWrite**: *boolean*
 
-*Defined in [lib/scanner/adapters/block-device.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L67)*
+*Defined in [lib/scanner/adapters/block-device.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L67)*
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 • **ready**: *boolean* = false
 
-*Defined in [lib/scanner/adapters/block-device.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L71)*
+*Defined in [lib/scanner/adapters/block-device.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L71)*
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 • **running**: *boolean* = false
 
-*Defined in [lib/scanner/adapters/block-device.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L70)*
+*Defined in [lib/scanner/adapters/block-device.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L70)*
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 • **unmountOnSuccess**: *boolean*
 
-*Defined in [lib/scanner/adapters/block-device.ts:66](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L66)*
+*Defined in [lib/scanner/adapters/block-device.ts:66](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L66)*
 
 ___
 
@@ -223,7 +223,7 @@ ___
 
 ▸ **listDrives**(): *Promise‹Map‹string, [DrivelistDrive](../interfaces/drivelistdrive.md)››*
 
-*Defined in [lib/scanner/adapters/block-device.ts:137](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L137)*
+*Defined in [lib/scanner/adapters/block-device.ts:137](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L137)*
 
 **Returns:** *Promise‹Map‹string, [DrivelistDrive](../interfaces/drivelistdrive.md)››*
 
@@ -481,7 +481,7 @@ ___
 
 ▸ **scan**(): *Promise‹void›*
 
-*Defined in [lib/scanner/adapters/block-device.ts:113](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L113)*
+*Defined in [lib/scanner/adapters/block-device.ts:113](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L113)*
 
 **Returns:** *Promise‹void›*
 
@@ -491,7 +491,7 @@ ___
 
 ▸ **scanLoop**(): *Promise‹void›*
 
-*Defined in [lib/scanner/adapters/block-device.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L102)*
+*Defined in [lib/scanner/adapters/block-device.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L102)*
 
 **Returns:** *Promise‹void›*
 
@@ -523,7 +523,7 @@ ___
 
 *Overrides [Adapter](adapter.md).[start](adapter.md#abstract-start)*
 
-*Defined in [lib/scanner/adapters/block-device.ts:91](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L91)*
+*Defined in [lib/scanner/adapters/block-device.ts:91](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L91)*
 
 **Returns:** *void*
 
@@ -535,7 +535,7 @@ ___
 
 *Overrides [Adapter](adapter.md).[stop](adapter.md#abstract-stop)*
 
-*Defined in [lib/scanner/adapters/block-device.ts:96](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L96)*
+*Defined in [lib/scanner/adapters/block-device.ts:96](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L96)*
 
 **Returns:** *void*
 

--- a/doc/classes/blockreadstream.md
+++ b/doc/classes/blockreadstream.md
@@ -75,7 +75,7 @@
 
 *Overrides void*
 
-*Defined in [lib/block-read-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-read-stream.ts#L36)*
+*Defined in [lib/block-read-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-read-stream.ts#L36)*
 
 **Parameters:**
 
@@ -99,7 +99,7 @@ Name | Type | Default |
 
 • **alignedReadableState**: *[AlignedReadableState](alignedreadablestate.md)*
 
-*Defined in [lib/block-read-stream.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-read-stream.ts#L32)*
+*Defined in [lib/block-read-stream.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-read-stream.ts#L32)*
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 • **alignment**: *number | undefined*
 
-*Defined in [lib/block-read-stream.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-read-stream.ts#L31)*
+*Defined in [lib/block-read-stream.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-read-stream.ts#L31)*
 
 ___
 
@@ -115,7 +115,7 @@ ___
 
 • **bytesRead**: *number* = 0
 
-*Defined in [lib/block-read-stream.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-read-stream.ts#L33)*
+*Defined in [lib/block-read-stream.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-read-stream.ts#L33)*
 
 ___
 
@@ -123,7 +123,7 @@ ___
 
 • **chunkSize**: *number*
 
-*Defined in [lib/block-read-stream.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-read-stream.ts#L35)*
+*Defined in [lib/block-read-stream.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-read-stream.ts#L35)*
 
 ___
 
@@ -131,7 +131,7 @@ ___
 
 • **end**: *number*
 
-*Defined in [lib/block-read-stream.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-read-stream.ts#L34)*
+*Defined in [lib/block-read-stream.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-read-stream.ts#L34)*
 
 ___
 
@@ -139,7 +139,7 @@ ___
 
 • **maxRetries**: *number*
 
-*Defined in [lib/block-read-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-read-stream.ts#L36)*
+*Defined in [lib/block-read-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-read-stream.ts#L36)*
 
 ___
 
@@ -187,7 +187,7 @@ ___
 
 • **source**: *[File](file.md)*
 
-*Defined in [lib/block-read-stream.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-read-stream.ts#L30)*
+*Defined in [lib/block-read-stream.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-read-stream.ts#L30)*
 
 ___
 
@@ -245,7 +245,7 @@ ___
 
 *Overrides [SparseFilterStream](sparsefilterstream.md).[_read](sparsefilterstream.md#_read)*
 
-*Defined in [lib/block-read-stream.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-read-stream.ts#L86)*
+*Defined in [lib/block-read-stream.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-read-stream.ts#L86)*
 
 **Returns:** *Promise‹void›*
 
@@ -1418,7 +1418,7 @@ ___
 
 ▸ **tryRead**(`buffer`: [Buffer](../interfaces/alignedlockablebuffer.md#buffer)): *Promise‹ReadResult›*
 
-*Defined in [lib/block-read-stream.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-read-stream.ts#L75)*
+*Defined in [lib/block-read-stream.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-read-stream.ts#L75)*
 
 **Parameters:**
 

--- a/doc/classes/blocksverificationerror.md
+++ b/doc/classes/blocksverificationerror.md
@@ -29,7 +29,7 @@
 
 \+ **new BlocksVerificationError**(`blocks`: [BlocksWithChecksum](../interfaces/blockswithchecksum.md), `checksum`: string): *[BlocksVerificationError](blocksverificationerror.md)*
 
-*Defined in [lib/errors.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/errors.ts#L49)*
+*Defined in [lib/errors.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/errors.ts#L49)*
 
 **Parameters:**
 
@@ -46,7 +46,7 @@ Name | Type |
 
 • **blocks**: *[BlocksWithChecksum](../interfaces/blockswithchecksum.md)*
 
-*Defined in [lib/errors.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/errors.ts#L51)*
+*Defined in [lib/errors.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/errors.ts#L51)*
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 • **checksum**: *string*
 
-*Defined in [lib/errors.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/errors.ts#L52)*
+*Defined in [lib/errors.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/errors.ts#L52)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 *Inherited from [VerificationError](verificationerror.md).[code](verificationerror.md#code)*
 
-*Defined in [lib/errors.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/errors.ts#L25)*
+*Defined in [lib/errors.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/errors.ts#L25)*
 
 ___
 

--- a/doc/classes/blocktransformstream.md
+++ b/doc/classes/blocktransformstream.md
@@ -90,7 +90,7 @@
 
 *Overrides [SourceTransform](../interfaces/sourcetransform.md).[constructor](../interfaces/sourcetransform.md#constructor)*
 
-*Defined in [lib/block-transform-stream.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-transform-stream.ts#L32)*
+*Defined in [lib/block-transform-stream.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-transform-stream.ts#L32)*
 
 **Parameters:**
 
@@ -110,7 +110,7 @@ Name | Type | Default |
 
 • **alignedReadableState**: *[AlignedReadableState](alignedreadablestate.md)*
 
-*Defined in [lib/block-transform-stream.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-transform-stream.ts#L29)*
+*Defined in [lib/block-transform-stream.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-transform-stream.ts#L29)*
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 • **bytesRead**: *number* = 0
 
-*Defined in [lib/block-transform-stream.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-transform-stream.ts#L27)*
+*Defined in [lib/block-transform-stream.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-transform-stream.ts#L27)*
 
 ___
 
@@ -126,7 +126,7 @@ ___
 
 • **bytesWritten**: *number* = 0
 
-*Defined in [lib/block-transform-stream.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-transform-stream.ts#L28)*
+*Defined in [lib/block-transform-stream.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-transform-stream.ts#L28)*
 
 ___
 
@@ -134,7 +134,7 @@ ___
 
 • **currentBuffer**: *[AlignedLockableBuffer](../interfaces/alignedlockablebuffer.md)*
 
-*Defined in [lib/block-transform-stream.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-transform-stream.ts#L30)*
+*Defined in [lib/block-transform-stream.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-transform-stream.ts#L30)*
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 • **currentBufferPosition**: *number* = 0
 
-*Defined in [lib/block-transform-stream.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-transform-stream.ts#L31)*
+*Defined in [lib/block-transform-stream.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-transform-stream.ts#L31)*
 
 ___
 
@@ -190,7 +190,7 @@ ___
 
 • **unlockCurrentBuffer**: *function*
 
-*Defined in [lib/block-transform-stream.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-transform-stream.ts#L32)*
+*Defined in [lib/block-transform-stream.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-transform-stream.ts#L32)*
 
 #### Type declaration:
 
@@ -254,7 +254,7 @@ ___
 
 ▸ **__flush**(): *void*
 
-*Defined in [lib/block-transform-stream.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-transform-stream.ts#L51)*
+*Defined in [lib/block-transform-stream.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-transform-stream.ts#L51)*
 
 **Returns:** *void*
 
@@ -318,7 +318,7 @@ ___
 
 *Overrides [SparseFilterStream](sparsefilterstream.md).[_flush](sparsefilterstream.md#_flush)*
 
-*Defined in [lib/block-transform-stream.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-transform-stream.ts#L101)*
+*Defined in [lib/block-transform-stream.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-transform-stream.ts#L101)*
 
 **Parameters:**
 
@@ -360,7 +360,7 @@ ___
 
 *Overrides [SourceTransform](../interfaces/sourcetransform.md).[_transform](../interfaces/sourcetransform.md#_transform)*
 
-*Defined in [lib/block-transform-stream.ts:93](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-transform-stream.ts#L93)*
+*Defined in [lib/block-transform-stream.ts:93](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-transform-stream.ts#L93)*
 
 **Parameters:**
 
@@ -1432,7 +1432,7 @@ ___
 
 ▸ **pushChunk**(`chunk`: [Buffer](../interfaces/alignedlockablebuffer.md#buffer)): *Promise‹void›*
 
-*Defined in [lib/block-transform-stream.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-transform-stream.ts#L62)*
+*Defined in [lib/block-transform-stream.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-transform-stream.ts#L62)*
 
 **Parameters:**
 
@@ -1799,7 +1799,7 @@ ___
 
 ▸ **alignIfNeeded**(`stream`: ReadableStream, `alignment?`: undefined | number, `numBuffers?`: undefined | number): *ReadableStream‹› | [BlockTransformStream](blocktransformstream.md)‹›*
 
-*Defined in [lib/block-transform-stream.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-transform-stream.ts#L110)*
+*Defined in [lib/block-transform-stream.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-transform-stream.ts#L110)*
 
 **Parameters:**
 

--- a/doc/classes/blockwritestream.md
+++ b/doc/classes/blockwritestream.md
@@ -72,7 +72,7 @@
 
 *Overrides [CountingWritable](countingwritable.md).[constructor](countingwritable.md#constructor)*
 
-*Defined in [lib/block-write-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-write-stream.ts#L36)*
+*Defined in [lib/block-write-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-write-stream.ts#L36)*
 
 **Parameters:**
 
@@ -93,7 +93,7 @@ Name | Type | Default |
 
 • **bytesWritten**: *number* = 0
 
-*Defined in [lib/block-write-stream.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-write-stream.ts#L34)*
+*Defined in [lib/block-write-stream.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-write-stream.ts#L34)*
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 • **delayFirstBuffer**: *boolean*
 
-*Defined in [lib/block-write-stream.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-write-stream.ts#L32)*
+*Defined in [lib/block-write-stream.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-write-stream.ts#L32)*
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 • **destination**: *[BlockDevice](blockdevice.md)*
 
-*Defined in [lib/block-write-stream.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-write-stream.ts#L31)*
+*Defined in [lib/block-write-stream.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-write-stream.ts#L31)*
 
 ___
 
@@ -117,7 +117,7 @@ ___
 
 • **firstBuffer**? : *[Buffer](../interfaces/alignedlockablebuffer.md#buffer)*
 
-*Defined in [lib/block-write-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-write-stream.ts#L36)*
+*Defined in [lib/block-write-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-write-stream.ts#L36)*
 
 ___
 
@@ -125,7 +125,7 @@ ___
 
 • **maxRetries**: *number*
 
-*Defined in [lib/block-write-stream.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-write-stream.ts#L33)*
+*Defined in [lib/block-write-stream.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-write-stream.ts#L33)*
 
 ___
 
@@ -133,7 +133,7 @@ ___
 
 • **position**: *number* = 0
 
-*Defined in [lib/block-write-stream.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-write-stream.ts#L35)*
+*Defined in [lib/block-write-stream.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-write-stream.ts#L35)*
 
 ___
 
@@ -181,7 +181,7 @@ Defined in node_modules/@types/node/events.d.ts:18
 
 ▸ **__final**(): *Promise‹void›*
 
-*Defined in [lib/block-write-stream.ts:92](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-write-stream.ts#L92)*
+*Defined in [lib/block-write-stream.ts:92](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-write-stream.ts#L92)*
 
 **Returns:** *Promise‹void›*
 
@@ -191,7 +191,7 @@ ___
 
 ▸ **__write**(`buffer`: [AlignedLockableBuffer](../interfaces/alignedlockablebuffer.md)): *Promise‹void›*
 
-*Defined in [lib/block-write-stream.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-write-stream.ts#L65)*
+*Defined in [lib/block-write-stream.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-write-stream.ts#L65)*
 
 **Parameters:**
 
@@ -235,7 +235,7 @@ ___
 
 *Overrides [CountingWritable](countingwritable.md).[_final](countingwritable.md#_final)*
 
-*Defined in [lib/block-write-stream.ts:108](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-write-stream.ts#L108)*
+*Defined in [lib/block-write-stream.ts:108](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-write-stream.ts#L108)*
 
 **`summary`** Write buffered data before a stream ends, called by stream internals
 
@@ -261,7 +261,7 @@ ___
 
 *Overrides void*
 
-*Defined in [lib/block-write-stream.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-write-stream.ts#L84)*
+*Defined in [lib/block-write-stream.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-write-stream.ts#L84)*
 
 **Parameters:**
 
@@ -1673,7 +1673,7 @@ ___
 
 ▸ **writeBuffer**(`buffer`: [Buffer](../interfaces/alignedlockablebuffer.md#buffer), `position`: number): *Promise‹void›*
 
-*Defined in [lib/block-write-stream.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/block-write-stream.ts#L55)*
+*Defined in [lib/block-write-stream.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/block-write-stream.ts#L55)*
 
 **Parameters:**
 

--- a/doc/classes/bzip2source.md
+++ b/doc/classes/bzip2source.md
@@ -76,7 +76,7 @@
 
 *Inherited from [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
 
-*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L20)*
 
 **Parameters:**
 
@@ -94,7 +94,7 @@ Name | Type |
 
 *Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
 
-*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L22)*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L22)*
 
 ___
 
@@ -125,7 +125,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -135,7 +135,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/bzip2.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/bzip2.ts#L24)*
+*Defined in [lib/source-destination/bzip2.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/bzip2.ts#L24)*
 
 ___
 
@@ -145,7 +145,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
 
-*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L20)*
 
 ## Methods
 
@@ -157,7 +157,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L30)*
+*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L30)*
 
 **Returns:** *Promise‹void›*
 
@@ -171,7 +171,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/compressed-source.ts:105](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/compressed-source.ts#L105)*
+*Defined in [lib/source-destination/compressed-source.ts:105](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L105)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -185,7 +185,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
 
-*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L26)*
+*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L26)*
 
 **Returns:** *Promise‹void›*
 
@@ -227,7 +227,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/compressed-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/compressed-source.ts#L53)*
+*Defined in [lib/source-destination/compressed-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L53)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -239,7 +239,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L314)*
+*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L314)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -251,7 +251,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -263,7 +263,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -275,7 +275,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L302)*
+*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L302)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -287,7 +287,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -299,7 +299,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -313,7 +313,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/compressed-source.ts#L57)*
+*Defined in [lib/source-destination/compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L57)*
 
 **Parameters:**
 
@@ -335,7 +335,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L361)*
+*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L361)*
 
 **Parameters:**
 
@@ -353,7 +353,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -373,7 +373,7 @@ ___
 
 *Overrides [CompressedSource](compressedsource.md).[createTransform](compressedsource.md#protected-abstract-createtransform)*
 
-*Defined in [lib/source-destination/bzip2.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/bzip2.ts#L26)*
+*Defined in [lib/source-destination/bzip2.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/bzip2.ts#L26)*
 
 **Returns:** *Transform*
 
@@ -385,7 +385,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -404,7 +404,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -459,7 +459,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -471,7 +471,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -483,7 +483,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -509,7 +509,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -521,7 +521,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -533,7 +533,7 @@ ___
 
 *Overrides [CompressedSource](compressedsource.md).[getSize](compressedsource.md#protected-getsize)*
 
-*Defined in [lib/source-destination/bzip2.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/bzip2.ts#L30)*
+*Defined in [lib/source-destination/bzip2.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/bzip2.ts#L30)*
 
 **Returns:** *Promise‹object | undefined›*
 
@@ -545,7 +545,7 @@ ___
 
 *Inherited from [CompressedSource](compressedsource.md).[getSizeFromPartitionTable](compressedsource.md#protected-getsizefrompartitiontable)*
 
-*Defined in [lib/source-destination/compressed-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/compressed-source.ts#L87)*
+*Defined in [lib/source-destination/compressed-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L87)*
 
 **Returns:** *Promise‹number | undefined›*
 
@@ -681,7 +681,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -769,7 +769,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L337)*
+*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L337)*
 
 **Parameters:**
 
@@ -858,7 +858,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -900,7 +900,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/checksumverificationerror.md
+++ b/doc/classes/checksumverificationerror.md
@@ -29,7 +29,7 @@
 
 \+ **new ChecksumVerificationError**(`message`: string, `checksum`: string, `expectedChecksum`: string): *[ChecksumVerificationError](checksumverificationerror.md)*
 
-*Defined in [lib/errors.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/errors.ts#L28)*
+*Defined in [lib/errors.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/errors.ts#L28)*
 
 **Parameters:**
 
@@ -47,7 +47,7 @@ Name | Type |
 
 • **checksum**: *string*
 
-*Defined in [lib/errors.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/errors.ts#L31)*
+*Defined in [lib/errors.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/errors.ts#L31)*
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 *Inherited from [VerificationError](verificationerror.md).[code](verificationerror.md#code)*
 
-*Defined in [lib/errors.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/errors.ts#L25)*
+*Defined in [lib/errors.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/errors.ts#L25)*
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 • **expectedChecksum**: *string*
 
-*Defined in [lib/errors.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/errors.ts#L32)*
+*Defined in [lib/errors.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/errors.ts#L32)*
 
 ___
 

--- a/doc/classes/compressedsource.md
+++ b/doc/classes/compressedsource.md
@@ -82,7 +82,7 @@
 
 *Inherited from [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
 
-*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L20)*
 
 **Parameters:**
 
@@ -100,7 +100,7 @@ Name | Type |
 
 *Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
 
-*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L22)*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L22)*
 
 ___
 
@@ -131,7 +131,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L286)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ___
 
@@ -151,7 +151,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
 
-*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L20)*
 
 ## Methods
 
@@ -163,7 +163,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L30)*
+*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L30)*
 
 **Returns:** *Promise‹void›*
 
@@ -175,7 +175,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/compressed-source.ts:105](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/compressed-source.ts#L105)*
+*Defined in [lib/source-destination/compressed-source.ts:105](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L105)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -189,7 +189,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
 
-*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L26)*
+*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L26)*
 
 **Returns:** *Promise‹void›*
 
@@ -229,7 +229,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/compressed-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/compressed-source.ts#L53)*
+*Defined in [lib/source-destination/compressed-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L53)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -241,7 +241,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L314)*
+*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L314)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -253,7 +253,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -265,7 +265,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -277,7 +277,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L302)*
+*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L302)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -289,7 +289,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -301,7 +301,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -313,7 +313,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/compressed-source.ts#L57)*
+*Defined in [lib/source-destination/compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L57)*
 
 **Parameters:**
 
@@ -335,7 +335,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L361)*
+*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L361)*
 
 **Parameters:**
 
@@ -353,7 +353,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -371,7 +371,7 @@ ___
 
 ▸ **createTransform**(): *Transform*
 
-*Defined in [lib/source-destination/compressed-source.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/compressed-source.ts#L45)*
+*Defined in [lib/source-destination/compressed-source.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L45)*
 
 **Returns:** *Transform*
 
@@ -383,7 +383,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -402,7 +402,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -457,7 +457,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -469,7 +469,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -481,7 +481,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -507,7 +507,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -519,7 +519,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -529,7 +529,7 @@ ___
 
 ▸ **getSize**(): *Promise‹object | undefined›*
 
-*Defined in [lib/source-destination/compressed-source.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/compressed-source.ts#L47)*
+*Defined in [lib/source-destination/compressed-source.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L47)*
 
 **Returns:** *Promise‹object | undefined›*
 
@@ -539,7 +539,7 @@ ___
 
 ▸ **getSizeFromPartitionTable**(): *Promise‹number | undefined›*
 
-*Defined in [lib/source-destination/compressed-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/compressed-source.ts#L87)*
+*Defined in [lib/source-destination/compressed-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L87)*
 
 **Returns:** *Promise‹number | undefined›*
 
@@ -675,7 +675,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -763,7 +763,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L337)*
+*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L337)*
 
 **Parameters:**
 
@@ -852,7 +852,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -894,7 +894,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/configuredsource.md
+++ b/doc/classes/configuredsource.md
@@ -83,7 +83,7 @@
 
 *Overrides [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L101)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L101)*
 
 **Parameters:**
 
@@ -106,7 +106,7 @@ Name | Type | Default |
 
 • **checksumType**: *[ChecksumType](../README.md#checksumtype)*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:98](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L98)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:98](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L98)*
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 • **chunkSize**: *number*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:99](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L99)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:99](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L99)*
 
 ___
 
@@ -122,7 +122,7 @@ ___
 
 • **configure**? : *[ConfigureFunction](../README.md#configurefunction)*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L101)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L101)*
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 • **createStreamFromDisk**: *boolean*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:97](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L97)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:97](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L97)*
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 • **disk**: *[SourceDisk](sourcedisk.md)*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:100](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L100)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:100](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L100)*
 
 ___
 
@@ -146,7 +146,7 @@ ___
 
 • **shouldTrimPartitions**: *boolean*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:96](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L96)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:96](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L96)*
 
 ___
 
@@ -156,7 +156,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
 
-*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L22)*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L22)*
 
 ___
 
@@ -187,7 +187,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -197,7 +197,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L286)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ___
 
@@ -207,7 +207,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
 
-*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L20)*
 
 ## Methods
 
@@ -217,7 +217,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[_close](sourcesource.md#protected-_close)*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:303](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L303)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:303](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L303)*
 
 **Returns:** *Promise‹void›*
 
@@ -229,7 +229,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:248](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L248)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:248](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L248)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -241,7 +241,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[_open](sourcesource.md#protected-_open)*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L292)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L292)*
 
 **Returns:** *Promise‹void›*
 
@@ -281,7 +281,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:162](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L162)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:162](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L162)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -293,7 +293,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L166)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L166)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -305,7 +305,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -317,7 +317,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -329,7 +329,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:158](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L158)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:158](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L158)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -341,7 +341,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -353,7 +353,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -365,7 +365,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:179](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L179)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:179](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L179)*
 
 **Parameters:**
 
@@ -383,7 +383,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:226](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L226)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:226](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L226)*
 
 **Parameters:**
 
@@ -403,7 +403,7 @@ ___
 
 ▸ **createSparseReadStreamFromDisk**(`generateChecksums`: boolean, `alignment?`: undefined | number, `numBuffers`: number): *Promise‹[SparseReadStream](sparsereadstream.md)›*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:191](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L191)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:191](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L191)*
 
 **Parameters:**
 
@@ -421,7 +421,7 @@ ___
 
 ▸ **createSparseReadStreamFromStream**(`generateChecksums`: boolean, `alignment?`: undefined | number, `numBuffers`: number): *Promise‹[SparseFilterStream](sparsefilterstream.md)›*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:207](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L207)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:207](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L207)*
 
 **Parameters:**
 
@@ -441,7 +441,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -461,7 +461,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -480,7 +480,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -535,7 +535,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -547,7 +547,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:131](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L131)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:131](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L131)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -557,7 +557,7 @@ ___
 
 ▸ **getBlocksWithChecksumType**(`generateChecksums`: boolean): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:145](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L145)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:145](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L145)*
 
 **Parameters:**
 
@@ -575,7 +575,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -601,7 +601,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -613,7 +613,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -749,7 +749,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -837,7 +837,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:170](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L170)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:170](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L170)*
 
 **Parameters:**
 
@@ -924,7 +924,7 @@ ___
 
 ▸ **trimPartitions**(): *Promise‹void›*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:255](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L255)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:255](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L255)*
 
 **Returns:** *Promise‹void›*
 
@@ -936,7 +936,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -978,7 +978,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/countinghashstream.md
+++ b/doc/classes/countinghashstream.md
@@ -85,7 +85,7 @@
 
 *Overrides [SourceTransform](../interfaces/sourcetransform.md).[constructor](../interfaces/sourcetransform.md#constructor)*
 
-*Defined in [typings/xxhash/index.d.ts:12](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/typings/xxhash/index.d.ts#L12)*
+*Defined in [typings/xxhash/index.d.ts:12](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/typings/xxhash/index.d.ts#L12)*
 
 **Parameters:**
 
@@ -103,7 +103,7 @@ Name | Type |
 
 • **bytesWritten**: *number* = 0
 
-*Defined in [lib/source-destination/source-destination.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L48)*
+*Defined in [lib/source-destination/source-destination.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L48)*
 
 ___
 
@@ -203,7 +203,7 @@ ___
 
 ▸ **__transform**(`chunk`: [Buffer](../interfaces/alignedlockablebuffer.md#buffer) | [AlignedLockableBuffer](../interfaces/alignedlockablebuffer.md), `encoding`: string): *Promise‹void›*
 
-*Defined in [lib/source-destination/source-destination.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L50)*
+*Defined in [lib/source-destination/source-destination.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L50)*
 
 **Parameters:**
 
@@ -310,7 +310,7 @@ ___
 
 *Overrides [SourceTransform](../interfaces/sourcetransform.md).[_transform](../interfaces/sourcetransform.md#_transform)*
 
-*Defined in [lib/source-destination/source-destination.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L67)*
+*Defined in [lib/source-destination/source-destination.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L67)*
 
 **Parameters:**
 

--- a/doc/classes/countingwritable.md
+++ b/doc/classes/countingwritable.md
@@ -81,7 +81,7 @@ Name | Type |
 
 • **bytesWritten**: *number* = 0
 
-*Defined in [lib/source-destination/progress.ts:99](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/progress.ts#L99)*
+*Defined in [lib/source-destination/progress.ts:99](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/progress.ts#L99)*
 
 ___
 
@@ -89,7 +89,7 @@ ___
 
 • **position**: *number | undefined*
 
-*Defined in [lib/source-destination/progress.ts:100](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/progress.ts#L100)*
+*Defined in [lib/source-destination/progress.ts:100](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/progress.ts#L100)*
 
 ___
 
@@ -189,7 +189,7 @@ ___
 
 *Overrides void*
 
-*Defined in [lib/source-destination/progress.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/progress.ts#L102)*
+*Defined in [lib/source-destination/progress.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/progress.ts#L102)*
 
 **Parameters:**
 

--- a/doc/classes/dmgsource.md
+++ b/doc/classes/dmgsource.md
@@ -75,7 +75,7 @@
 
 *Overrides [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
 
-*Defined in [lib/source-destination/dmg.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/dmg.ts#L54)*
+*Defined in [lib/source-destination/dmg.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/dmg.ts#L54)*
 
 **Parameters:**
 
@@ -91,7 +91,7 @@ Name | Type |
 
 • **image**: *UDIFImage*
 
-*Defined in [lib/source-destination/dmg.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/dmg.ts#L54)*
+*Defined in [lib/source-destination/dmg.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/dmg.ts#L54)*
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
 
-*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L22)*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L22)*
 
 ___
 
@@ -132,7 +132,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -147,7 +147,7 @@ ___
 		BLOCK.LZFSE,
 	]
 
-*Defined in [lib/source-destination/dmg.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/dmg.ts#L44)*
+*Defined in [lib/source-destination/dmg.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/dmg.ts#L44)*
 
 ___
 
@@ -157,7 +157,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/dmg.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/dmg.ts#L53)*
+*Defined in [lib/source-destination/dmg.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/dmg.ts#L53)*
 
 ___
 
@@ -167,7 +167,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
 
-*Defined in [lib/source-destination/dmg.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/dmg.ts#L52)*
+*Defined in [lib/source-destination/dmg.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/dmg.ts#L52)*
 
 ## Methods
 
@@ -179,7 +179,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L30)*
+*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L30)*
 
 **Returns:** *Promise‹void›*
 
@@ -191,7 +191,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/dmg.ts:144](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/dmg.ts#L144)*
+*Defined in [lib/source-destination/dmg.ts:144](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/dmg.ts#L144)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -203,7 +203,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[_open](sourcesource.md#protected-_open)*
 
-*Defined in [lib/source-destination/dmg.ts:152](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/dmg.ts#L152)*
+*Defined in [lib/source-destination/dmg.ts:152](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/dmg.ts#L152)*
 
 **Returns:** *Promise‹void›*
 
@@ -243,7 +243,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/dmg.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/dmg.ts#L60)*
+*Defined in [lib/source-destination/dmg.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/dmg.ts#L60)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -255,7 +255,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/dmg.ts:64](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/dmg.ts#L64)*
+*Defined in [lib/source-destination/dmg.ts:64](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/dmg.ts#L64)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -267,7 +267,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -279,7 +279,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -291,7 +291,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L302)*
+*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L302)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -303,7 +303,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -315,7 +315,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -327,7 +327,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/dmg.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/dmg.ts#L68)*
+*Defined in [lib/source-destination/dmg.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/dmg.ts#L68)*
 
 **Parameters:**
 
@@ -350,7 +350,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/dmg.ts:81](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/dmg.ts#L81)*
+*Defined in [lib/source-destination/dmg.ts:81](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/dmg.ts#L81)*
 
 **Parameters:**
 
@@ -371,7 +371,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -391,7 +391,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -410,7 +410,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -465,7 +465,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -477,7 +477,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/dmg.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/dmg.ts#L104)*
+*Defined in [lib/source-destination/dmg.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/dmg.ts#L104)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -489,7 +489,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -515,7 +515,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -527,7 +527,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -663,7 +663,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -751,7 +751,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L337)*
+*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L337)*
 
 **Parameters:**
 
@@ -840,7 +840,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -882,7 +882,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/driverlessdevice.md
+++ b/doc/classes/driverlessdevice.md
@@ -83,7 +83,7 @@
 
 \+ **new DriverlessDevice**(`driverlessDevice`: WinUsbDriverlessDevice): *[DriverlessDevice](driverlessdevice.md)*
 
-*Defined in [lib/source-destination/driverless.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/driverless.ts#L34)*
+*Defined in [lib/source-destination/driverless.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/driverless.ts#L34)*
 
 **Parameters:**
 
@@ -99,7 +99,7 @@ Name | Type |
 
 • **accessible**: *boolean* = false
 
-*Defined in [lib/source-destination/driverless.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/driverless.ts#L25)*
+*Defined in [lib/source-destination/driverless.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/driverless.ts#L25)*
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[description](../interfaces/adaptersourcedestination.md#description)*
 
-*Defined in [lib/source-destination/driverless.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/driverless.ts#L34)*
+*Defined in [lib/source-destination/driverless.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/driverless.ts#L34)*
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[device](../interfaces/adaptersourcedestination.md#device)*
 
-*Defined in [lib/source-destination/driverless.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/driverless.ts#L27)*
+*Defined in [lib/source-destination/driverless.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/driverless.ts#L27)*
 
 ___
 
@@ -127,7 +127,7 @@ ___
 
 • **deviceDescriptor**: *object*
 
-*Defined in [lib/source-destination/driverless.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/driverless.ts#L33)*
+*Defined in [lib/source-destination/driverless.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/driverless.ts#L33)*
 
 #### Type declaration:
 
@@ -143,7 +143,7 @@ ___
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[devicePath](../interfaces/adaptersourcedestination.md#devicepath)*
 
-*Defined in [lib/source-destination/driverless.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/driverless.ts#L28)*
+*Defined in [lib/source-destination/driverless.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/driverless.ts#L28)*
 
 ___
 
@@ -153,7 +153,7 @@ ___
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[emitsProgress](../interfaces/adaptersourcedestination.md#emitsprogress)*
 
-*Defined in [lib/source-destination/driverless.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/driverless.ts#L32)*
+*Defined in [lib/source-destination/driverless.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/driverless.ts#L32)*
 
 ___
 
@@ -163,7 +163,7 @@ ___
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[isSystem](../interfaces/adaptersourcedestination.md#issystem)*
 
-*Defined in [lib/source-destination/driverless.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/driverless.ts#L29)*
+*Defined in [lib/source-destination/driverless.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/driverless.ts#L29)*
 
 ___
 
@@ -173,7 +173,7 @@ ___
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[mountpoints](../interfaces/adaptersourcedestination.md#mountpoints)*
 
-*Defined in [lib/source-destination/driverless.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/driverless.ts#L30)*
+*Defined in [lib/source-destination/driverless.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/driverless.ts#L30)*
 
 ___
 
@@ -183,7 +183,7 @@ ___
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[raw](../interfaces/adaptersourcedestination.md#raw)*
 
-*Defined in [lib/source-destination/driverless.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/driverless.ts#L26)*
+*Defined in [lib/source-destination/driverless.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/driverless.ts#L26)*
 
 ___
 
@@ -193,7 +193,7 @@ ___
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[size](../interfaces/adaptersourcedestination.md#size)*
 
-*Defined in [lib/source-destination/driverless.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/driverless.ts#L31)*
+*Defined in [lib/source-destination/driverless.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/driverless.ts#L31)*
 
 ___
 
@@ -228,7 +228,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -240,7 +240,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L286)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ## Methods
 
@@ -252,7 +252,7 @@ ___
 
 *Inherited from [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/source-destination.ts:401](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L401)*
+*Defined in [lib/source-destination/source-destination.ts:401](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L401)*
 
 **Returns:** *Promise‹void›*
 
@@ -266,7 +266,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L333)*
+*Defined in [lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L333)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -280,7 +280,7 @@ ___
 
 *Inherited from [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
 
-*Defined in [lib/source-destination/source-destination.ts:397](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L397)*
+*Defined in [lib/source-destination/source-destination.ts:397](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L397)*
 
 **Returns:** *Promise‹void›*
 
@@ -322,7 +322,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:310](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L310)*
+*Defined in [lib/source-destination/source-destination.ts:310](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L310)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -336,7 +336,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L314)*
+*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L314)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -350,7 +350,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -364,7 +364,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -378,7 +378,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L302)*
+*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L302)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -392,7 +392,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -406,7 +406,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -420,7 +420,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:355](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L355)*
+*Defined in [lib/source-destination/source-destination.ts:355](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L355)*
 
 **Parameters:**
 
@@ -440,7 +440,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L361)*
+*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L361)*
 
 **Parameters:**
 
@@ -458,7 +458,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -480,7 +480,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -499,7 +499,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -560,7 +560,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -574,7 +574,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -588,7 +588,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -618,7 +618,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -632,7 +632,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -774,7 +774,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -866,7 +866,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L337)*
+*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L337)*
 
 **Parameters:**
 
@@ -961,7 +961,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -1007,7 +1007,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/file.md
+++ b/doc/classes/file.md
@@ -75,7 +75,7 @@
 
 \+ **new File**(`__namedParameters`: object): *[File](file.md)*
 
-*Defined in [lib/source-destination/file.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L48)*
+*Defined in [lib/source-destination/file.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L48)*
 
 **Parameters:**
 
@@ -94,7 +94,7 @@ Name | Type | Default |
 
 • **fileHandle**: *fs.FileHandle*
 
-*Defined in [lib/source-destination/file.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L48)*
+*Defined in [lib/source-destination/file.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L48)*
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 • **oWrite**: *boolean*
 
-*Defined in [lib/source-destination/file.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L47)*
+*Defined in [lib/source-destination/file.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L47)*
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 • **path**: *string*
 
-*Defined in [lib/source-destination/file.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L46)*
+*Defined in [lib/source-destination/file.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L46)*
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -151,7 +151,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L286)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ## Methods
 
@@ -161,7 +161,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/file.ts:215](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L215)*
+*Defined in [lib/source-destination/file.ts:215](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L215)*
 
 **Returns:** *Promise‹void›*
 
@@ -173,7 +173,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/file.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L83)*
+*Defined in [lib/source-destination/file.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L83)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -185,7 +185,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
 
-*Defined in [lib/source-destination/file.ts:205](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L205)*
+*Defined in [lib/source-destination/file.ts:205](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L205)*
 
 **Returns:** *Promise‹void›*
 
@@ -225,7 +225,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/file.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L71)*
+*Defined in [lib/source-destination/file.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L71)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -237,7 +237,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L314)*
+*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L314)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -249,7 +249,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/file.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L79)*
+*Defined in [lib/source-destination/file.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L79)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -261,7 +261,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/file.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L75)*
+*Defined in [lib/source-destination/file.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L75)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -273,7 +273,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/file.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L63)*
+*Defined in [lib/source-destination/file.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L63)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -285,7 +285,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/file.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L67)*
+*Defined in [lib/source-destination/file.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L67)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -297,7 +297,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -309,7 +309,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/file.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L147)*
+*Defined in [lib/source-destination/file.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L147)*
 
 **Parameters:**
 
@@ -333,7 +333,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L361)*
+*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L361)*
 
 **Parameters:**
 
@@ -351,7 +351,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/file.ts:194](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L194)*
+*Defined in [lib/source-destination/file.ts:194](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L194)*
 
 **Parameters:**
 
@@ -371,7 +371,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -390,7 +390,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/file.ts:180](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L180)*
+*Defined in [lib/source-destination/file.ts:180](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L180)*
 
 **Parameters:**
 
@@ -445,7 +445,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -457,7 +457,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -469,7 +469,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -495,7 +495,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -505,7 +505,7 @@ ___
 
 ▸ **getOpenFlags**(): *number*
 
-*Defined in [lib/source-destination/file.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L56)*
+*Defined in [lib/source-destination/file.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L56)*
 
 **Returns:** *number*
 
@@ -517,7 +517,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -653,7 +653,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -741,7 +741,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/file.ts:90](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L90)*
+*Defined in [lib/source-destination/file.ts:90](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L90)*
 
 **Parameters:**
 
@@ -830,7 +830,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/file.ts:138](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/file.ts#L138)*
+*Defined in [lib/source-destination/file.ts:138](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/file.ts#L138)*
 
 **Parameters:**
 
@@ -872,7 +872,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/http.md
+++ b/doc/classes/http.md
@@ -79,7 +79,7 @@
 
 \+ **new Http**(`__namedParameters`: object): *[Http](http.md)*
 
-*Defined in [lib/source-destination/http.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/http.ts#L44)*
+*Defined in [lib/source-destination/http.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/http.ts#L44)*
 
 **Parameters:**
 
@@ -99,7 +99,7 @@ Name | Type | Default |
 
 • **acceptsRange**: *boolean*
 
-*Defined in [lib/source-destination/http.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/http.ts#L41)*
+*Defined in [lib/source-destination/http.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/http.ts#L41)*
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 • **avoidRandomAccess**: *boolean*
 
-*Defined in [lib/source-destination/http.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/http.ts#L39)*
+*Defined in [lib/source-destination/http.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/http.ts#L39)*
 
 ___
 
@@ -115,7 +115,7 @@ ___
 
 • **axiosInstance**: *AxiosInstance*
 
-*Defined in [lib/source-destination/http.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/http.ts#L44)*
+*Defined in [lib/source-destination/http.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/http.ts#L44)*
 
 ___
 
@@ -123,7 +123,7 @@ ___
 
 • **error**: *[Error](notcapable.md#static-error)*
 
-*Defined in [lib/source-destination/http.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/http.ts#L43)*
+*Defined in [lib/source-destination/http.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/http.ts#L43)*
 
 ___
 
@@ -131,7 +131,7 @@ ___
 
 • **ready**: *Promise‹void›*
 
-*Defined in [lib/source-destination/http.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/http.ts#L42)*
+*Defined in [lib/source-destination/http.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/http.ts#L42)*
 
 ___
 
@@ -139,7 +139,7 @@ ___
 
 • **redirectUrl**: *string*
 
-*Defined in [lib/source-destination/http.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/http.ts#L38)*
+*Defined in [lib/source-destination/http.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/http.ts#L38)*
 
 ___
 
@@ -147,7 +147,7 @@ ___
 
 • **size**: *number | undefined*
 
-*Defined in [lib/source-destination/http.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/http.ts#L40)*
+*Defined in [lib/source-destination/http.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/http.ts#L40)*
 
 ___
 
@@ -155,7 +155,7 @@ ___
 
 • **url**: *string*
 
-*Defined in [lib/source-destination/http.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/http.ts#L37)*
+*Defined in [lib/source-destination/http.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/http.ts#L37)*
 
 ___
 
@@ -186,7 +186,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -196,7 +196,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L286)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ## Methods
 
@@ -206,7 +206,7 @@ ___
 
 *Inherited from [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/source-destination.ts:401](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L401)*
+*Defined in [lib/source-destination/source-destination.ts:401](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L401)*
 
 **Returns:** *Promise‹void›*
 
@@ -218,7 +218,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/http.ts:99](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/http.ts#L99)*
+*Defined in [lib/source-destination/http.ts:99](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/http.ts#L99)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -230,7 +230,7 @@ ___
 
 *Inherited from [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
 
-*Defined in [lib/source-destination/source-destination.ts:397](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L397)*
+*Defined in [lib/source-destination/source-destination.ts:397](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L397)*
 
 **Returns:** *Promise‹void›*
 
@@ -270,7 +270,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/http.ts:95](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/http.ts#L95)*
+*Defined in [lib/source-destination/http.ts:95](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/http.ts#L95)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -282,7 +282,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L314)*
+*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L314)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -294,7 +294,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -306,7 +306,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -318,7 +318,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/http.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/http.ts#L87)*
+*Defined in [lib/source-destination/http.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/http.ts#L87)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -330,7 +330,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -342,7 +342,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -354,7 +354,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/http.ts:144](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/http.ts#L144)*
+*Defined in [lib/source-destination/http.ts:144](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/http.ts#L144)*
 
 **Parameters:**
 
@@ -376,7 +376,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L361)*
+*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L361)*
 
 **Parameters:**
 
@@ -394,7 +394,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -414,7 +414,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -433,7 +433,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -488,7 +488,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -500,7 +500,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -510,7 +510,7 @@ ___
 
 ▸ **getInfo**(): *Promise‹void›*
 
-*Defined in [lib/source-destination/http.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/http.ts#L62)*
+*Defined in [lib/source-destination/http.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/http.ts#L62)*
 
 **Returns:** *Promise‹void›*
 
@@ -522,7 +522,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -548,7 +548,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -560,7 +560,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -570,7 +570,7 @@ ___
 
 ▸ **getRange**(`start`: number, `end?`: undefined | number): *string*
 
-*Defined in [lib/source-destination/http.ts:115](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/http.ts#L115)*
+*Defined in [lib/source-destination/http.ts:115](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/http.ts#L115)*
 
 **Parameters:**
 
@@ -713,7 +713,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -801,7 +801,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/http.ts:124](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/http.ts#L124)*
+*Defined in [lib/source-destination/http.ts:124](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/http.ts#L124)*
 
 **Parameters:**
 
@@ -890,7 +890,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -932,7 +932,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/multidestination.md
+++ b/doc/classes/multidestination.md
@@ -78,7 +78,7 @@
 
 \+ **new MultiDestination**(`destinations`: [SourceDestination](sourcedestination.md)[]): *[MultiDestination](multidestination.md)*
 
-*Defined in [lib/source-destination/multi-destination.ts:107](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L107)*
+*Defined in [lib/source-destination/multi-destination.ts:107](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L107)*
 
 **Parameters:**
 
@@ -94,7 +94,7 @@ Name | Type |
 
 • **destinations**: *Set‹[SourceDestination](sourcedestination.md)›* = new Set()
 
-*Defined in [lib/source-destination/multi-destination.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L106)*
+*Defined in [lib/source-destination/multi-destination.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L106)*
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 • **erroredDestinations**: *Set‹[SourceDestination](sourcedestination.md)›* = new Set()
 
-*Defined in [lib/source-destination/multi-destination.ts:107](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L107)*
+*Defined in [lib/source-destination/multi-destination.ts:107](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L107)*
 
 ___
 
@@ -133,7 +133,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -143,7 +143,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L286)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ## Accessors
 
@@ -151,7 +151,7 @@ ___
 
 • **get activeDestinations**(): *Set‹[SourceDestination](sourcedestination.md)›*
 
-*Defined in [lib/source-destination/multi-destination.ts:151](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L151)*
+*Defined in [lib/source-destination/multi-destination.ts:151](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L151)*
 
 **Returns:** *Set‹[SourceDestination](sourcedestination.md)›*
 
@@ -163,7 +163,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/multi-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L356)*
+*Defined in [lib/source-destination/multi-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L356)*
 
 **Returns:** *Promise‹void›*
 
@@ -175,7 +175,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L333)*
+*Defined in [lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L333)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -187,7 +187,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
 
-*Defined in [lib/source-destination/multi-destination.ts:344](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L344)*
+*Defined in [lib/source-destination/multi-destination.ts:344](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L344)*
 
 **Returns:** *Promise‹void›*
 
@@ -225,7 +225,7 @@ ___
 
 ▸ **can**(`methodName`: "canRead" | "canWrite" | "canCreateReadStream" | "canCreateSparseReadStream" | "canCreateWriteStream" | "canCreateSparseWriteStream"): *Promise‹boolean›*
 
-*Defined in [lib/source-destination/multi-destination.ts:155](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L155)*
+*Defined in [lib/source-destination/multi-destination.ts:155](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L155)*
 
 **Parameters:**
 
@@ -243,7 +243,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/multi-destination.ts:181](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L181)*
+*Defined in [lib/source-destination/multi-destination.ts:181](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L181)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -255,7 +255,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/multi-destination.ts:185](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L185)*
+*Defined in [lib/source-destination/multi-destination.ts:185](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L185)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -267,7 +267,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/multi-destination.ts:193](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L193)*
+*Defined in [lib/source-destination/multi-destination.ts:193](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L193)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -279,7 +279,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/multi-destination.ts:189](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L189)*
+*Defined in [lib/source-destination/multi-destination.ts:189](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L189)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -291,7 +291,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/multi-destination.ts:173](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L173)*
+*Defined in [lib/source-destination/multi-destination.ts:173](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L173)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -303,7 +303,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/multi-destination.ts:177](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L177)*
+*Defined in [lib/source-destination/multi-destination.ts:177](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L177)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -315,7 +315,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -327,7 +327,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/multi-destination.ts:228](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L228)*
+*Defined in [lib/source-destination/multi-destination.ts:228](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L228)*
 
 **Parameters:**
 
@@ -345,7 +345,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/multi-destination.ts:235](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L235)*
+*Defined in [lib/source-destination/multi-destination.ts:235](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L235)*
 
 **Parameters:**
 
@@ -363,7 +363,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/multi-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L331)*
+*Defined in [lib/source-destination/multi-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L331)*
 
 **Parameters:**
 
@@ -379,7 +379,7 @@ ___
 
 ▸ **createStream**(`methodName`: "createWriteStream", ...`args`: Parameters‹SourceDestination["createWriteStream"]›): *Promise‹WritableStream›*
 
-*Defined in [lib/source-destination/multi-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L244)*
+*Defined in [lib/source-destination/multi-destination.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L244)*
 
 **Parameters:**
 
@@ -392,7 +392,7 @@ Name | Type |
 
 ▸ **createStream**(`methodName`: "createSparseWriteStream", ...`args`: Parameters‹SourceDestination["createSparseWriteStream"]›): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Defined in [lib/source-destination/multi-destination.ts:249](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L249)*
+*Defined in [lib/source-destination/multi-destination.ts:249](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L249)*
 
 **Parameters:**
 
@@ -411,7 +411,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/multi-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L337)*
+*Defined in [lib/source-destination/multi-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L337)*
 
 **Parameters:**
 
@@ -430,7 +430,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/multi-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L325)*
+*Defined in [lib/source-destination/multi-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L325)*
 
 **Parameters:**
 
@@ -446,7 +446,7 @@ ___
 
 ▸ **destinationError**(`destination`: [SourceDestination](sourcedestination.md), `error`: [Error](notcapable.md#static-error), `stream?`: EventEmitter): *void*
 
-*Defined in [lib/source-destination/multi-destination.ts:132](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L132)*
+*Defined in [lib/source-destination/multi-destination.ts:132](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L132)*
 
 **Parameters:**
 
@@ -501,7 +501,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/multi-destination.ts:119](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L119)*
+*Defined in [lib/source-destination/multi-destination.ts:119](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L119)*
 
 **Returns:** *number | undefined*
 
@@ -513,7 +513,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -525,7 +525,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -551,7 +551,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -563,7 +563,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -699,7 +699,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -787,7 +787,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/multi-destination.ts:197](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L197)*
+*Defined in [lib/source-destination/multi-destination.ts:197](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L197)*
 
 **Parameters:**
 
@@ -876,7 +876,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/multi-destination.ts:212](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L212)*
+*Defined in [lib/source-destination/multi-destination.ts:212](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L212)*
 
 **Parameters:**
 
@@ -918,7 +918,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/multidestinationerror.md
+++ b/doc/classes/multidestinationerror.md
@@ -29,7 +29,7 @@
 
 \+ **new MultiDestinationError**(`error`: [Error](notcapable.md#static-error), `destination`: [SourceDestination](sourcedestination.md)): *[MultiDestinationError](multidestinationerror.md)*
 
-*Defined in [lib/source-destination/multi-destination.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L39)*
+*Defined in [lib/source-destination/multi-destination.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L39)*
 
 **Parameters:**
 
@@ -46,7 +46,7 @@ Name | Type |
 
 • **destination**: *[SourceDestination](sourcedestination.md)*
 
-*Defined in [lib/source-destination/multi-destination.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L40)*
+*Defined in [lib/source-destination/multi-destination.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L40)*
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 • **error**: *[Error](notcapable.md#static-error)*
 
-*Defined in [lib/source-destination/multi-destination.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L40)*
+*Defined in [lib/source-destination/multi-destination.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L40)*
 
 ___
 

--- a/doc/classes/multidestinationverifier.md
+++ b/doc/classes/multidestinationverifier.md
@@ -53,7 +53,7 @@
 
 \+ **new MultiDestinationVerifier**(`source`: [MultiDestination](multidestination.md), `checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[MultiDestinationVerifier](multidestinationverifier.md)*
 
-*Defined in [lib/source-destination/multi-destination.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L47)*
+*Defined in [lib/source-destination/multi-destination.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L47)*
 
 **Parameters:**
 
@@ -71,7 +71,7 @@ Name | Type |
 
 • **timer**: *Timer*
 
-*Defined in [lib/source-destination/multi-destination.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L47)*
+*Defined in [lib/source-destination/multi-destination.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L47)*
 
 ___
 
@@ -79,7 +79,7 @@ ___
 
 • **verifiers**: *Set‹[Verifier](verifier.md)›* = new Set()
 
-*Defined in [lib/source-destination/multi-destination.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L46)*
+*Defined in [lib/source-destination/multi-destination.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L46)*
 
 ___
 
@@ -146,7 +146,7 @@ ___
 
 ▸ **emitProgress**(): *void*
 
-*Defined in [lib/source-destination/multi-destination.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L80)*
+*Defined in [lib/source-destination/multi-destination.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L80)*
 
 **Returns:** *void*
 
@@ -186,7 +186,7 @@ ___
 
 *Inherited from [Verifier](verifier.md).[handleEventsAndPipe](verifier.md#protected-handleeventsandpipe)*
 
-*Defined in [lib/source-destination/source-destination.ts:156](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L156)*
+*Defined in [lib/source-destination/source-destination.ts:156](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L156)*
 
 **Parameters:**
 
@@ -327,7 +327,7 @@ ___
 
 ▸ **oneVerifierFinished**(`verifier`: [Verifier](verifier.md)): *void*
 
-*Defined in [lib/source-destination/multi-destination.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L68)*
+*Defined in [lib/source-destination/multi-destination.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L68)*
 
 **Parameters:**
 
@@ -469,7 +469,7 @@ ___
 
 *Overrides [Verifier](verifier.md).[run](verifier.md#abstract-run)*
 
-*Defined in [lib/source-destination/multi-destination.ts:89](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/multi-destination.ts#L89)*
+*Defined in [lib/source-destination/multi-destination.ts:89](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/multi-destination.ts#L89)*
 
 **Returns:** *Promise‹void›*
 
@@ -522,28 +522,28 @@ Name | Type |
 
 *Inherited from [Verifier](verifier.md).[progress](verifier.md#progress)*
 
-*Defined in [lib/source-destination/source-destination.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L147)*
+*Defined in [lib/source-destination/source-destination.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L147)*
 
 ###  averageSpeed
 
 • **averageSpeed**: *number* = 0
 
-*Defined in [lib/source-destination/source-destination.ts:151](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L151)*
+*Defined in [lib/source-destination/source-destination.ts:151](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L151)*
 
 ###  bytes
 
 • **bytes**: *number* = 0
 
-*Defined in [lib/source-destination/source-destination.ts:148](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L148)*
+*Defined in [lib/source-destination/source-destination.ts:148](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L148)*
 
 ###  position
 
 • **position**: *number* = 0
 
-*Defined in [lib/source-destination/source-destination.ts:149](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L149)*
+*Defined in [lib/source-destination/source-destination.ts:149](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L149)*
 
 ###  speed
 
 • **speed**: *number* = 0
 
-*Defined in [lib/source-destination/source-destination.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L150)*
+*Defined in [lib/source-destination/source-destination.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L150)*

--- a/doc/classes/randomaccesszipsource.md
+++ b/doc/classes/randomaccesszipsource.md
@@ -85,7 +85,7 @@
 
 *Overrides [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
 
-*Defined in [lib/source-destination/zip.ts:164](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L164)*
+*Defined in [lib/source-destination/zip.ts:164](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L164)*
 
 **Parameters:**
 
@@ -109,7 +109,7 @@ Name | Type |
 
 • **entries**: *Entry[]* = []
 
-*Defined in [lib/source-destination/zip.ts:164](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L164)*
+*Defined in [lib/source-destination/zip.ts:164](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L164)*
 
 ___
 
@@ -117,7 +117,7 @@ ___
 
 • **match**: *function*
 
-*Defined in [lib/source-destination/zip.ts:168](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L168)*
+*Defined in [lib/source-destination/zip.ts:168](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L168)*
 
 #### Type declaration:
 
@@ -135,7 +135,7 @@ ___
 
 • **ready**: *Promise‹void›*
 
-*Defined in [lib/source-destination/zip.ts:163](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L163)*
+*Defined in [lib/source-destination/zip.ts:163](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L163)*
 
 ___
 
@@ -145,7 +145,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
 
-*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L22)*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L22)*
 
 ___
 
@@ -153,7 +153,7 @@ ___
 
 • **zip**: *ZipFile*
 
-*Defined in [lib/source-destination/zip.ts:162](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L162)*
+*Defined in [lib/source-destination/zip.ts:162](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L162)*
 
 ___
 
@@ -184,7 +184,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -201,7 +201,7 @@ ___
 		'version',
 	]
 
-*Defined in [lib/source-destination/zip.ts:152](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L152)*
+*Defined in [lib/source-destination/zip.ts:152](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L152)*
 
 ___
 
@@ -211,7 +211,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L286)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ___
 
@@ -221,7 +221,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
 
-*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L20)*
 
 ## Methods
 
@@ -233,7 +233,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L30)*
+*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L30)*
 
 **Returns:** *Promise‹void›*
 
@@ -245,7 +245,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/zip.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L321)*
+*Defined in [lib/source-destination/zip.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L321)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -257,7 +257,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[_open](sourcesource.md#protected-_open)*
 
-*Defined in [lib/source-destination/zip.ts:228](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L228)*
+*Defined in [lib/source-destination/zip.ts:228](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L228)*
 
 **Returns:** *Promise‹void›*
 
@@ -297,7 +297,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/zip.ts:198](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L198)*
+*Defined in [lib/source-destination/zip.ts:198](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L198)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -309,7 +309,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/zip.ts:202](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L202)*
+*Defined in [lib/source-destination/zip.ts:202](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L202)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -321,7 +321,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -333,7 +333,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -345,7 +345,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L302)*
+*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L302)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -357,7 +357,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -369,7 +369,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -381,7 +381,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/zip.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L272)*
+*Defined in [lib/source-destination/zip.ts:272](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L272)*
 
 **Parameters:**
 
@@ -404,7 +404,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/zip.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L298)*
+*Defined in [lib/source-destination/zip.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L298)*
 
 **Parameters:**
 
@@ -426,7 +426,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -446,7 +446,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -465,7 +465,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -520,7 +520,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -532,7 +532,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -542,7 +542,7 @@ ___
 
 ▸ **getEntries**(): *Promise‹Entry[]›*
 
-*Defined in [lib/source-destination/zip.ts:207](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L207)*
+*Defined in [lib/source-destination/zip.ts:207](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L207)*
 
 **Returns:** *Promise‹Entry[]›*
 
@@ -552,7 +552,7 @@ ___
 
 ▸ **getEntryByName**(`name`: string): *Promise‹Entry | undefined›*
 
-*Defined in [lib/source-destination/zip.ts:234](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L234)*
+*Defined in [lib/source-destination/zip.ts:234](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L234)*
 
 **Parameters:**
 
@@ -568,7 +568,7 @@ ___
 
 ▸ **getImageEntry**(): *Promise‹Entry›*
 
-*Defined in [lib/source-destination/zip.ts:212](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L212)*
+*Defined in [lib/source-destination/zip.ts:212](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L212)*
 
 **Returns:** *Promise‹Entry›*
 
@@ -580,7 +580,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -590,7 +590,7 @@ ___
 
 ▸ **getJson**(`name`: string): *Promise‹any›*
 
-*Defined in [lib/source-destination/zip.ts:265](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L265)*
+*Defined in [lib/source-destination/zip.ts:265](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L265)*
 
 **Parameters:**
 
@@ -622,7 +622,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -634,7 +634,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -644,7 +644,7 @@ ___
 
 ▸ **getStream**(`name`: string): *Promise‹ReadableStream | undefined›*
 
-*Defined in [lib/source-destination/zip.ts:243](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L243)*
+*Defined in [lib/source-destination/zip.ts:243](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L243)*
 
 **Parameters:**
 
@@ -660,7 +660,7 @@ ___
 
 ▸ **getString**(`name`: string): *Promise‹string | undefined›*
 
-*Defined in [lib/source-destination/zip.ts:257](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L257)*
+*Defined in [lib/source-destination/zip.ts:257](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L257)*
 
 **Parameters:**
 
@@ -676,7 +676,7 @@ ___
 
 ▸ **init**(): *Promise‹void›*
 
-*Defined in [lib/source-destination/zip.ts:174](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L174)*
+*Defined in [lib/source-destination/zip.ts:174](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L174)*
 
 **Returns:** *Promise‹void›*
 
@@ -812,7 +812,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -900,7 +900,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L337)*
+*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L337)*
 
 **Parameters:**
 
@@ -989,7 +989,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -1031,7 +1031,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/scanner.md
+++ b/doc/classes/scanner.md
@@ -50,7 +50,7 @@
 
 \+ **new Scanner**(`adapters`: [Adapter](adapter.md)[]): *[Scanner](scanner.md)*
 
-*Defined in [lib/scanner/scanner.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/scanner.ts#L25)*
+*Defined in [lib/scanner/scanner.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/scanner.ts#L25)*
 
 **Parameters:**
 
@@ -66,7 +66,7 @@ Name | Type |
 
 • **adapters**: *[Adapter](adapter.md)[]*
 
-*Defined in [lib/scanner/scanner.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/scanner.ts#L27)*
+*Defined in [lib/scanner/scanner.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/scanner.ts#L27)*
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 • **drives**: *Set‹[AdapterSourceDestination](../interfaces/adaptersourcedestination.md)›* = new Set()
 
-*Defined in [lib/scanner/scanner.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/scanner.ts#L25)*
+*Defined in [lib/scanner/scanner.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/scanner.ts#L25)*
 
 ___
 
@@ -155,7 +155,7 @@ ___
 
 ▸ **getBy**(`field`: "raw" | "device" | "devicePath", `value`: string): *[AdapterSourceDestination](../interfaces/adaptersourcedestination.md) | undefined*
 
-*Defined in [lib/scanner/scanner.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/scanner.ts#L46)*
+*Defined in [lib/scanner/scanner.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/scanner.ts#L46)*
 
 **Parameters:**
 
@@ -282,7 +282,7 @@ ___
 
 ▸ **onAttach**(`drive`: [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)): *void*
 
-*Defined in [lib/scanner/scanner.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/scanner.ts#L36)*
+*Defined in [lib/scanner/scanner.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/scanner.ts#L36)*
 
 **Parameters:**
 
@@ -298,7 +298,7 @@ ___
 
 ▸ **onDetach**(`drive`: [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)): *void*
 
-*Defined in [lib/scanner/scanner.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/scanner.ts#L41)*
+*Defined in [lib/scanner/scanner.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/scanner.ts#L41)*
 
 **Parameters:**
 
@@ -486,7 +486,7 @@ ___
 
 ▸ **start**(): *Promise‹void›*
 
-*Defined in [lib/scanner/scanner.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/scanner.ts#L57)*
+*Defined in [lib/scanner/scanner.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/scanner.ts#L57)*
 
 **Returns:** *Promise‹void›*
 
@@ -496,7 +496,7 @@ ___
 
 ▸ **stop**(): *void*
 
-*Defined in [lib/scanner/scanner.ts:74](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/scanner.ts#L74)*
+*Defined in [lib/scanner/scanner.ts:74](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/scanner.ts#L74)*
 
 **Returns:** *void*
 

--- a/doc/classes/singleusestreamsource.md
+++ b/doc/classes/singleusestreamsource.md
@@ -71,7 +71,7 @@
 
 \+ **new SingleUseStreamSource**(`stream`: ReadableStream): *[SingleUseStreamSource](singleusestreamsource.md)*
 
-*Defined in [lib/source-destination/single-use-stream-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/single-use-stream-source.ts#L26)*
+*Defined in [lib/source-destination/single-use-stream-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/single-use-stream-source.ts#L26)*
 
 **Parameters:**
 
@@ -87,7 +87,7 @@ Name | Type |
 
 • **stream**: *ReadableStream*
 
-*Defined in [lib/source-destination/single-use-stream-source.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/single-use-stream-source.ts#L28)*
+*Defined in [lib/source-destination/single-use-stream-source.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/single-use-stream-source.ts#L28)*
 
 ___
 
@@ -95,7 +95,7 @@ ___
 
 • **used**: *boolean* = false
 
-*Defined in [lib/source-destination/single-use-stream-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/single-use-stream-source.ts#L26)*
+*Defined in [lib/source-destination/single-use-stream-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/single-use-stream-source.ts#L26)*
 
 ___
 
@@ -126,7 +126,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -136,7 +136,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L286)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ## Methods
 
@@ -146,7 +146,7 @@ ___
 
 *Inherited from [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/source-destination.ts:401](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L401)*
+*Defined in [lib/source-destination/source-destination.ts:401](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L401)*
 
 **Returns:** *Promise‹void›*
 
@@ -158,7 +158,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L333)*
+*Defined in [lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L333)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -170,7 +170,7 @@ ___
 
 *Inherited from [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
 
-*Defined in [lib/source-destination/source-destination.ts:397](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L397)*
+*Defined in [lib/source-destination/source-destination.ts:397](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L397)*
 
 **Returns:** *Promise‹void›*
 
@@ -210,7 +210,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/single-use-stream-source.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/single-use-stream-source.ts#L32)*
+*Defined in [lib/source-destination/single-use-stream-source.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/single-use-stream-source.ts#L32)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -222,7 +222,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L314)*
+*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L314)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -234,7 +234,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -246,7 +246,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -258,7 +258,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L302)*
+*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L302)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -270,7 +270,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -282,7 +282,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -294,7 +294,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/single-use-stream-source.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/single-use-stream-source.ts#L36)*
+*Defined in [lib/source-destination/single-use-stream-source.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/single-use-stream-source.ts#L36)*
 
 **Parameters:**
 
@@ -315,7 +315,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L361)*
+*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L361)*
 
 **Parameters:**
 
@@ -333,7 +333,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -353,7 +353,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -372,7 +372,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -427,7 +427,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -439,7 +439,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -451,7 +451,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -477,7 +477,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -489,7 +489,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -625,7 +625,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -713,7 +713,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L337)*
+*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L337)*
 
 **Parameters:**
 
@@ -802,7 +802,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -844,7 +844,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/sourcedestination.md
+++ b/doc/classes/sourcedestination.md
@@ -16,6 +16,8 @@
 
   ↳ [MultiDestination](multidestination.md)
 
+  ↳ [UsbBBbootDrive](usbbbbootdrive.md)
+
   ↳ [UsbbootDrive](usbbootdrive.md)
 
   ↳ [DriverlessDevice](driverlessdevice.md)
@@ -89,7 +91,7 @@
 
 • **isOpen**: *boolean* = false
 
-*Defined in [lib/source-destination/source-destination.ts:290](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L290)*
+*Defined in [lib/source-destination/source-destination.ts:290](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L290)*
 
 ___
 
@@ -97,7 +99,7 @@ ___
 
 • **metadata**: *[Metadata](../interfaces/metadata.md)*
 
-*Defined in [lib/source-destination/source-destination.ts:289](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L289)*
+*Defined in [lib/source-destination/source-destination.ts:289](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L289)*
 
 ___
 
@@ -126,7 +128,7 @@ ___
 		'wic',
 	]
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -134,7 +136,7 @@ ___
 
 ▪ **mimetype**? : *undefined | string*
 
-*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L286)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ___
 
@@ -142,7 +144,7 @@ ___
 
 ▪ **mimetypes**: *Map‹string, [SourceSource](sourcesource.md)›* = new Map<string, typeof SourceSource>()
 
-*Defined in [lib/source-destination/source-destination.ts:287](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L287)*
+*Defined in [lib/source-destination/source-destination.ts:287](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L287)*
 
 ## Methods
 
@@ -150,7 +152,7 @@ ___
 
 ▸ **_close**(): *Promise‹void›*
 
-*Defined in [lib/source-destination/source-destination.ts:401](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L401)*
+*Defined in [lib/source-destination/source-destination.ts:401](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L401)*
 
 **Returns:** *Promise‹void›*
 
@@ -160,7 +162,7 @@ ___
 
 ▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Defined in [lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L333)*
+*Defined in [lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L333)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -170,7 +172,7 @@ ___
 
 ▸ **_open**(): *Promise‹void›*
 
-*Defined in [lib/source-destination/source-destination.ts:397](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L397)*
+*Defined in [lib/source-destination/source-destination.ts:397](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L397)*
 
 **Returns:** *Promise‹void›*
 
@@ -208,7 +210,7 @@ ___
 
 ▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Defined in [lib/source-destination/source-destination.ts:310](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L310)*
+*Defined in [lib/source-destination/source-destination.ts:310](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L310)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -218,7 +220,7 @@ ___
 
 ▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
 
-*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L314)*
+*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L314)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -228,7 +230,7 @@ ___
 
 ▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -238,7 +240,7 @@ ___
 
 ▸ **canCreateWriteStream**(): *Promise‹boolean›*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -248,7 +250,7 @@ ___
 
 ▸ **canRead**(): *Promise‹boolean›*
 
-*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L302)*
+*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L302)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -258,7 +260,7 @@ ___
 
 ▸ **canWrite**(): *Promise‹boolean›*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -268,7 +270,7 @@ ___
 
 ▸ **close**(): *Promise‹void›*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -278,7 +280,7 @@ ___
 
 ▸ **createReadStream**(`_options`: [CreateReadStreamOptions](../interfaces/createreadstreamoptions.md)): *Promise‹ReadableStream›*
 
-*Defined in [lib/source-destination/source-destination.ts:355](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L355)*
+*Defined in [lib/source-destination/source-destination.ts:355](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L355)*
 
 **Parameters:**
 
@@ -294,7 +296,7 @@ ___
 
 ▸ **createSparseReadStream**(`_options`: [CreateSparseReadStreamOptions](../interfaces/createsparsereadstreamoptions.md)): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
 
-*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L361)*
+*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L361)*
 
 **Parameters:**
 
@@ -310,7 +312,7 @@ ___
 
 ▸ **createSparseWriteStream**(`_options`: object): *Promise‹[SparseWritable](../interfaces/sparsewritable.md)›*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -328,7 +330,7 @@ ___
 
 ▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -345,7 +347,7 @@ ___
 
 ▸ **createWriteStream**(`_options`: object): *Promise‹WritableStream›*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -398,7 +400,7 @@ ___
 
 ▸ **getAlignment**(): *number | undefined*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -408,7 +410,7 @@ ___
 
 ▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -418,7 +420,7 @@ ___
 
 ▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -428,7 +430,7 @@ ___
 
 ▸ **getInnerSourceHelper**(`mimetype?`: undefined | string): *Promise‹[SourceDestination](sourcedestination.md)‹››*
 
-*Defined in [lib/source-destination/source-destination.ts:458](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L458)*
+*Defined in [lib/source-destination/source-destination.ts:458](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L458)*
 
 **Parameters:**
 
@@ -458,7 +460,7 @@ ___
 
 ▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -468,7 +470,7 @@ ___
 
 ▸ **getMimeTypeFromContent**(): *Promise‹string | undefined›*
 
-*Defined in [lib/source-destination/source-destination.ts:439](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L439)*
+*Defined in [lib/source-destination/source-destination.ts:439](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L439)*
 
 **Returns:** *Promise‹string | undefined›*
 
@@ -478,7 +480,7 @@ ___
 
 ▸ **getMimeTypeFromName**(): *Promise‹string | undefined›*
 
-*Defined in [lib/source-destination/source-destination.ts:428](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L428)*
+*Defined in [lib/source-destination/source-destination.ts:428](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L428)*
 
 **Returns:** *Promise‹string | undefined›*
 
@@ -488,7 +490,7 @@ ___
 
 ▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -622,7 +624,7 @@ ___
 
 ▸ **open**(): *Promise‹void›*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -708,7 +710,7 @@ ___
 
 ▸ **read**(`_buffer`: [Buffer](../interfaces/alignedlockablebuffer.md#buffer), `_bufferOffset`: number, `_length`: number, `_sourceOffset`: number): *Promise‹ReadResult›*
 
-*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L337)*
+*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L337)*
 
 **Parameters:**
 
@@ -795,7 +797,7 @@ ___
 
 ▸ **write**(`_buffer`: [Buffer](../interfaces/alignedlockablebuffer.md#buffer), `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -835,7 +837,7 @@ ___
 
 ▸ **register**(`Cls`: typeof SourceSource): *void*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/sourcedestinationfs.md
+++ b/doc/classes/sourcedestinationfs.md
@@ -29,7 +29,7 @@
 
 \+ **new SourceDestinationFs**(`source`: [SourceDestination](sourcedestination.md)): *[SourceDestinationFs](sourcedestinationfs.md)*
 
-*Defined in [lib/source-destination/source-destination.ts:91](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L91)*
+*Defined in [lib/source-destination/source-destination.ts:91](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L91)*
 
 **Parameters:**
 
@@ -45,7 +45,7 @@ Name | Type |
 
 • **source**: *[SourceDestination](sourcedestination.md)*
 
-*Defined in [lib/source-destination/source-destination.ts:93](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L93)*
+*Defined in [lib/source-destination/source-destination.ts:93](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L93)*
 
 ## Methods
 
@@ -53,7 +53,7 @@ Name | Type |
 
 ▸ **close**(`_fd`: number, `callback`: function): *void*
 
-*Defined in [lib/source-destination/source-destination.ts:103](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L103)*
+*Defined in [lib/source-destination/source-destination.ts:103](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L103)*
 
 **Parameters:**
 
@@ -77,7 +77,7 @@ ___
 
 ▸ **fstat**(`_fd`: number, `callback`: function): *void*
 
-*Defined in [lib/source-destination/source-destination.ts:107](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L107)*
+*Defined in [lib/source-destination/source-destination.ts:107](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L107)*
 
 **Parameters:**
 
@@ -102,7 +102,7 @@ ___
 
 ▸ **open**(`_path`: string, `_options`: any, `callback`: function): *void*
 
-*Defined in [lib/source-destination/source-destination.ts:95](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L95)*
+*Defined in [lib/source-destination/source-destination.ts:95](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L95)*
 
 **Parameters:**
 
@@ -129,7 +129,7 @@ ___
 
 ▸ **read**(`_fd`: number, `buffer`: [Buffer](../interfaces/alignedlockablebuffer.md#buffer), `bufferOffset`: number, `length`: number, `sourceOffset`: number, `callback`: function): *void*
 
-*Defined in [lib/source-destination/source-destination.ts:123](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L123)*
+*Defined in [lib/source-destination/source-destination.ts:123](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L123)*
 
 **Parameters:**
 

--- a/doc/classes/sourcedisk.md
+++ b/doc/classes/sourcedisk.md
@@ -48,7 +48,7 @@
 
 *Overrides void*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L47)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L47)*
 
 **Parameters:**
 
@@ -124,7 +124,7 @@ ___
 
 • **source**: *[SourceDestination](sourcedestination.md)*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L48)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L48)*
 
 ## Methods
 
@@ -134,7 +134,7 @@ ___
 
 *Overrides void*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:90](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L90)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:90](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L90)*
 
 **Returns:** *Promise‹void›*
 
@@ -146,7 +146,7 @@ ___
 
 *Overrides void*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L63)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L63)*
 
 **Returns:** *Promise‹number›*
 
@@ -158,7 +158,7 @@ ___
 
 *Overrides void*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:72](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L72)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:72](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L72)*
 
 **Parameters:**
 
@@ -179,7 +179,7 @@ ___
 
 *Overrides void*
 
-*Defined in [lib/source-destination/configured-source/configured-source.ts:81](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configured-source.ts#L81)*
+*Defined in [lib/source-destination/configured-source/configured-source.ts:81](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configured-source.ts#L81)*
 
 **Parameters:**
 

--- a/doc/classes/sourcerandomaccessreader.md
+++ b/doc/classes/sourcerandomaccessreader.md
@@ -48,7 +48,7 @@
 
 \+ **new SourceRandomAccessReader**(`source`: [SourceDestination](sourcedestination.md)): *[SourceRandomAccessReader](sourcerandomaccessreader.md)*
 
-*Defined in [lib/source-destination/zip.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L130)*
+*Defined in [lib/source-destination/zip.ts:130](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L130)*
 
 **Parameters:**
 
@@ -64,7 +64,7 @@ Name | Type |
 
 • **source**: *[SourceDestination](sourcedestination.md)*
 
-*Defined in [lib/source-destination/zip.ts:131](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L131)*
+*Defined in [lib/source-destination/zip.ts:131](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L131)*
 
 ___
 
@@ -84,7 +84,7 @@ Defined in node_modules/@types/node/events.d.ts:18
 
 *Overrides void*
 
-*Defined in [lib/source-destination/zip.ts:135](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L135)*
+*Defined in [lib/source-destination/zip.ts:135](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L135)*
 
 **Parameters:**
 

--- a/doc/classes/sourcesource.md
+++ b/doc/classes/sourcesource.md
@@ -83,7 +83,7 @@
 
 \+ **new SourceSource**(`source`: [SourceDestination](sourcedestination.md)): *[SourceSource](sourcesource.md)*
 
-*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L20)*
 
 **Parameters:**
 
@@ -99,7 +99,7 @@ Name | Type |
 
 • **source**: *[SourceDestination](sourcedestination.md)*
 
-*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L22)*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L22)*
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -140,7 +140,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L286)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ___
 
@@ -148,7 +148,7 @@ ___
 
 ▪ **requiresRandomReadableSource**: *boolean* = false
 
-*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L20)*
 
 ## Methods
 
@@ -158,7 +158,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L30)*
+*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L30)*
 
 **Returns:** *Promise‹void›*
 
@@ -170,7 +170,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L333)*
+*Defined in [lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L333)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -182,7 +182,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
 
-*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L26)*
+*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L26)*
 
 **Returns:** *Promise‹void›*
 
@@ -222,7 +222,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:310](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L310)*
+*Defined in [lib/source-destination/source-destination.ts:310](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L310)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -234,7 +234,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L314)*
+*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L314)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -246,7 +246,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -258,7 +258,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -270,7 +270,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L302)*
+*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L302)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -282,7 +282,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -294,7 +294,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -306,7 +306,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:355](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L355)*
+*Defined in [lib/source-destination/source-destination.ts:355](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L355)*
 
 **Parameters:**
 
@@ -324,7 +324,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L361)*
+*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L361)*
 
 **Parameters:**
 
@@ -342,7 +342,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -362,7 +362,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -381,7 +381,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -436,7 +436,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -448,7 +448,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -460,7 +460,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -486,7 +486,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -498,7 +498,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -634,7 +634,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -722,7 +722,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L337)*
+*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L337)*
 
 **Parameters:**
 
@@ -811,7 +811,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -853,7 +853,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/sparsefilterstream.md
+++ b/doc/classes/sparsefilterstream.md
@@ -88,7 +88,7 @@
 
 *Overrides [SourceTransform](../interfaces/sourcetransform.md).[constructor](../interfaces/sourcetransform.md#constructor)*
 
-*Defined in [lib/sparse-stream/sparse-filter-stream.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-filter-stream.ts#L30)*
+*Defined in [lib/sparse-stream/sparse-filter-stream.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-filter-stream.ts#L30)*
 
 **Parameters:**
 
@@ -110,7 +110,7 @@ Name | Type |
 
 *Implementation of [SparseReadable](../interfaces/sparsereadable.md).[blocks](../interfaces/sparsereadable.md#blocks)*
 
-*Defined in [lib/sparse-stream/sparse-filter-stream.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-filter-stream.ts#L27)*
+*Defined in [lib/sparse-stream/sparse-filter-stream.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-filter-stream.ts#L27)*
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 • **position**: *number* = 0
 
-*Defined in [lib/sparse-stream/sparse-filter-stream.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-filter-stream.ts#L30)*
+*Defined in [lib/sparse-stream/sparse-filter-stream.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-filter-stream.ts#L30)*
 
 ___
 
@@ -168,7 +168,7 @@ ___
 
 • **state**? : *[SparseReaderState](../interfaces/sparsereaderstate.md)*
 
-*Defined in [lib/sparse-stream/sparse-filter-stream.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-filter-stream.ts#L29)*
+*Defined in [lib/sparse-stream/sparse-filter-stream.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-filter-stream.ts#L29)*
 
 ___
 
@@ -176,7 +176,7 @@ ___
 
 • **stateIterator**: *Iterator‹[SparseReaderState](../interfaces/sparsereaderstate.md)›*
 
-*Defined in [lib/sparse-stream/sparse-filter-stream.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-filter-stream.ts#L28)*
+*Defined in [lib/sparse-stream/sparse-filter-stream.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-filter-stream.ts#L28)*
 
 ___
 
@@ -238,7 +238,7 @@ ___
 
 ▸ **__transform**(`buffer`: [Buffer](../interfaces/alignedlockablebuffer.md#buffer)): *void*
 
-*Defined in [lib/sparse-stream/sparse-filter-stream.ts:69](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-filter-stream.ts#L69)*
+*Defined in [lib/sparse-stream/sparse-filter-stream.ts:69](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-filter-stream.ts#L69)*
 
 **Parameters:**
 
@@ -344,7 +344,7 @@ ___
 
 *Overrides [SourceTransform](../interfaces/sourcetransform.md).[_transform](../interfaces/sourcetransform.md#_transform)*
 
-*Defined in [lib/sparse-stream/sparse-filter-stream.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-filter-stream.ts#L55)*
+*Defined in [lib/sparse-stream/sparse-filter-stream.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-filter-stream.ts#L55)*
 
 **Parameters:**
 
@@ -828,7 +828,7 @@ ___
 
 ▸ **nextBlock**(): *void*
 
-*Defined in [lib/sparse-stream/sparse-filter-stream.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-filter-stream.ts#L51)*
+*Defined in [lib/sparse-stream/sparse-filter-stream.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-filter-stream.ts#L51)*
 
 **Returns:** *void*
 

--- a/doc/classes/sparsereadstream.md
+++ b/doc/classes/sparsereadstream.md
@@ -77,7 +77,7 @@
 
 *Overrides void*
 
-*Defined in [lib/sparse-stream/sparse-read-stream.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-read-stream.ts#L39)*
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-read-stream.ts#L39)*
 
 **Parameters:**
 
@@ -101,7 +101,7 @@ Name | Type | Default |
 
 • **alignedReadableState**? : *[AlignedReadableState](alignedreadablestate.md)*
 
-*Defined in [lib/sparse-stream/sparse-read-stream.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-read-stream.ts#L39)*
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-read-stream.ts#L39)*
 
 ___
 
@@ -111,7 +111,7 @@ ___
 
 *Implementation of [SparseReadable](../interfaces/sparsereadable.md).[blocks](../interfaces/sparsereadable.md#blocks)*
 
-*Defined in [lib/sparse-stream/sparse-read-stream.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-read-stream.ts#L34)*
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-read-stream.ts#L34)*
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 • **chunkSize**: *number*
 
-*Defined in [lib/sparse-stream/sparse-read-stream.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-read-stream.ts#L35)*
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-read-stream.ts#L35)*
 
 ___
 
@@ -127,7 +127,7 @@ ___
 
 • **positionInBlock**: *number* = 0
 
-*Defined in [lib/sparse-stream/sparse-read-stream.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-read-stream.ts#L38)*
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-read-stream.ts#L38)*
 
 ___
 
@@ -177,7 +177,7 @@ ___
 
 • **source**: *[SourceDestination](sourcedestination.md)*
 
-*Defined in [lib/sparse-stream/sparse-read-stream.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-read-stream.ts#L33)*
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-read-stream.ts#L33)*
 
 ___
 
@@ -185,7 +185,7 @@ ___
 
 • **state**? : *[SparseReaderState](../interfaces/sparsereaderstate.md)*
 
-*Defined in [lib/sparse-stream/sparse-read-stream.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-read-stream.ts#L37)*
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-read-stream.ts#L37)*
 
 ___
 
@@ -193,7 +193,7 @@ ___
 
 • **stateIterator**: *Iterator‹[SparseReaderState](../interfaces/sparsereaderstate.md)›*
 
-*Defined in [lib/sparse-stream/sparse-read-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-read-stream.ts#L36)*
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-read-stream.ts#L36)*
 
 ___
 
@@ -225,7 +225,7 @@ ___
 
 ▸ **__read**(): *Promise‹[SparseStreamChunk](../interfaces/sparsestreamchunk.md) | null›*
 
-*Defined in [lib/sparse-stream/sparse-read-stream.ts:91](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-read-stream.ts#L91)*
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:91](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-read-stream.ts#L91)*
 
 **Returns:** *Promise‹[SparseStreamChunk](../interfaces/sparsestreamchunk.md) | null›*
 
@@ -263,7 +263,7 @@ ___
 
 *Overrides [SparseFilterStream](sparsefilterstream.md).[_read](sparsefilterstream.md#_read)*
 
-*Defined in [lib/sparse-stream/sparse-read-stream.ts:77](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-read-stream.ts#L77)*
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:77](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-read-stream.ts#L77)*
 
 **Returns:** *Promise‹void›*
 
@@ -616,7 +616,7 @@ ___
 
 ▸ **nextBlock**(): *void*
 
-*Defined in [lib/sparse-stream/sparse-read-stream.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-read-stream.ts#L86)*
+*Defined in [lib/sparse-stream/sparse-read-stream.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-read-stream.ts#L86)*
 
 **Returns:** *void*
 

--- a/doc/classes/sparsestreamverifier.md
+++ b/doc/classes/sparsestreamverifier.md
@@ -51,7 +51,7 @@
 
 \+ **new SparseStreamVerifier**(`source`: [SourceDestination](sourcedestination.md), `blocks`: [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]): *[SparseStreamVerifier](sparsestreamverifier.md)*
 
-*Defined in [lib/source-destination/source-destination.ts:207](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L207)*
+*Defined in [lib/source-destination/source-destination.ts:207](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L207)*
 
 **Parameters:**
 
@@ -68,7 +68,7 @@ Name | Type |
 
 • **blocks**: *[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]*
 
-*Defined in [lib/source-destination/source-destination.ts:210](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L210)*
+*Defined in [lib/source-destination/source-destination.ts:210](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L210)*
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 • **source**: *[SourceDestination](sourcedestination.md)*
 
-*Defined in [lib/source-destination/source-destination.ts:209](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L209)*
+*Defined in [lib/source-destination/source-destination.ts:209](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L209)*
 
 ___
 
@@ -173,7 +173,7 @@ ___
 
 *Inherited from [Verifier](verifier.md).[handleEventsAndPipe](verifier.md#protected-handleeventsandpipe)*
 
-*Defined in [lib/source-destination/source-destination.ts:156](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L156)*
+*Defined in [lib/source-destination/source-destination.ts:156](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L156)*
 
 **Parameters:**
 
@@ -440,7 +440,7 @@ ___
 
 *Overrides [Verifier](verifier.md).[run](verifier.md#abstract-run)*
 
-*Defined in [lib/source-destination/source-destination.ts:215](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L215)*
+*Defined in [lib/source-destination/source-destination.ts:215](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L215)*
 
 **Returns:** *Promise‹void›*
 
@@ -493,28 +493,28 @@ Name | Type |
 
 *Inherited from [Verifier](verifier.md).[progress](verifier.md#progress)*
 
-*Defined in [lib/source-destination/source-destination.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L147)*
+*Defined in [lib/source-destination/source-destination.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L147)*
 
 ###  averageSpeed
 
 • **averageSpeed**: *number* = 0
 
-*Defined in [lib/source-destination/source-destination.ts:151](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L151)*
+*Defined in [lib/source-destination/source-destination.ts:151](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L151)*
 
 ###  bytes
 
 • **bytes**: *number* = 0
 
-*Defined in [lib/source-destination/source-destination.ts:148](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L148)*
+*Defined in [lib/source-destination/source-destination.ts:148](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L148)*
 
 ###  position
 
 • **position**: *number* = 0
 
-*Defined in [lib/source-destination/source-destination.ts:149](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L149)*
+*Defined in [lib/source-destination/source-destination.ts:149](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L149)*
 
 ###  speed
 
 • **speed**: *number* = 0
 
-*Defined in [lib/source-destination/source-destination.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L150)*
+*Defined in [lib/source-destination/source-destination.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L150)*

--- a/doc/classes/sparsetransformstream.md
+++ b/doc/classes/sparsetransformstream.md
@@ -88,7 +88,7 @@
 
 *Overrides [SourceTransform](../interfaces/sourcetransform.md).[constructor](../interfaces/sourcetransform.md#constructor)*
 
-*Defined in [lib/sparse-stream/sparse-transform-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-transform-stream.ts#L36)*
+*Defined in [lib/sparse-stream/sparse-transform-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-transform-stream.ts#L36)*
 
 **Parameters:**
 
@@ -109,7 +109,7 @@ Name | Type | Default |
 
 • **alignedReadableState**: *[AlignedReadableState](alignedreadablestate.md)*
 
-*Defined in [lib/sparse-stream/sparse-transform-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-transform-stream.ts#L36)*
+*Defined in [lib/sparse-stream/sparse-transform-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-transform-stream.ts#L36)*
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 *Implementation of [SparseReadable](../interfaces/sparsereadable.md).[blocks](../interfaces/sparsereadable.md#blocks)*
 
-*Defined in [lib/sparse-stream/sparse-transform-stream.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-transform-stream.ts#L33)*
+*Defined in [lib/sparse-stream/sparse-transform-stream.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-transform-stream.ts#L33)*
 
 ___
 
@@ -127,7 +127,7 @@ ___
 
 • **bytesWritten**: *number* = 0
 
-*Defined in [lib/sparse-stream/sparse-transform-stream.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-transform-stream.ts#L35)*
+*Defined in [lib/sparse-stream/sparse-transform-stream.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-transform-stream.ts#L35)*
 
 ___
 
@@ -135,7 +135,7 @@ ___
 
 • **position**: *number* = 0
 
-*Defined in [lib/sparse-stream/sparse-transform-stream.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-transform-stream.ts#L34)*
+*Defined in [lib/sparse-stream/sparse-transform-stream.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-transform-stream.ts#L34)*
 
 ___
 
@@ -241,7 +241,7 @@ ___
 
 ▸ **__transform**(`chunk`: [SparseStreamChunk](../interfaces/sparsestreamchunk.md)): *Promise‹void›*
 
-*Defined in [lib/sparse-stream/sparse-transform-stream.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-transform-stream.ts#L58)*
+*Defined in [lib/sparse-stream/sparse-transform-stream.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-transform-stream.ts#L58)*
 
 **Parameters:**
 
@@ -347,7 +347,7 @@ ___
 
 *Overrides [SourceTransform](../interfaces/sourcetransform.md).[_transform](../interfaces/sourcetransform.md#_transform)*
 
-*Defined in [lib/sparse-stream/sparse-transform-stream.ts:76](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-transform-stream.ts#L76)*
+*Defined in [lib/sparse-stream/sparse-transform-stream.ts:76](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-transform-stream.ts#L76)*
 
 **Parameters:**
 

--- a/doc/classes/sparsewritestream.md
+++ b/doc/classes/sparsewritestream.md
@@ -74,7 +74,7 @@
 
 *Overrides [CountingWritable](countingwritable.md).[constructor](countingwritable.md#constructor)*
 
-*Defined in [lib/sparse-stream/sparse-write-stream.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-write-stream.ts#L18)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-write-stream.ts#L18)*
 
 **Parameters:**
 
@@ -95,7 +95,7 @@ Name | Type | Default |
 
 • **_firstChunks**: *[SparseStreamChunk](../interfaces/sparsestreamchunk.md)[]* = []
 
-*Defined in [lib/sparse-stream/sparse-write-stream.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-write-stream.ts#L18)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-write-stream.ts#L18)*
 
 ___
 
@@ -103,7 +103,7 @@ ___
 
 • **bytesWritten**: *number* = 0
 
-*Defined in [lib/sparse-stream/sparse-write-stream.ts:17](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-write-stream.ts#L17)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:17](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-write-stream.ts#L17)*
 
 ___
 
@@ -111,7 +111,7 @@ ___
 
 • **destination**: *[SourceDestination](sourcedestination.md)*
 
-*Defined in [lib/sparse-stream/sparse-write-stream.ts:13](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-write-stream.ts#L13)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:13](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-write-stream.ts#L13)*
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 • **firstBytesToKeep**: *number*
 
-*Defined in [lib/sparse-stream/sparse-write-stream.ts:14](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-write-stream.ts#L14)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:14](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-write-stream.ts#L14)*
 
 ___
 
@@ -127,7 +127,7 @@ ___
 
 • **maxRetries**: *number*
 
-*Defined in [lib/sparse-stream/sparse-write-stream.ts:15](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-write-stream.ts#L15)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:15](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-write-stream.ts#L15)*
 
 ___
 
@@ -135,7 +135,7 @@ ___
 
 • **position**: *number*
 
-*Defined in [lib/sparse-stream/sparse-write-stream.ts:16](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-write-stream.ts#L16)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:16](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-write-stream.ts#L16)*
 
 ___
 
@@ -185,7 +185,7 @@ Defined in node_modules/@types/node/events.d.ts:18
 
 ▸ **__final**(): *Promise‹void›*
 
-*Defined in [lib/sparse-stream/sparse-write-stream.ts:118](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-write-stream.ts#L118)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:118](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-write-stream.ts#L118)*
 
 **Returns:** *Promise‹void›*
 
@@ -195,7 +195,7 @@ ___
 
 ▸ **__write**(`chunk`: [SparseStreamChunk](../interfaces/sparsestreamchunk.md)): *Promise‹void›*
 
-*Defined in [lib/sparse-stream/sparse-write-stream.ts:73](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-write-stream.ts#L73)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:73](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-write-stream.ts#L73)*
 
 **Parameters:**
 
@@ -239,7 +239,7 @@ ___
 
 *Overrides [CountingWritable](countingwritable.md).[_final](countingwritable.md#_final)*
 
-*Defined in [lib/sparse-stream/sparse-write-stream.ts:132](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-write-stream.ts#L132)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:132](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-write-stream.ts#L132)*
 
 **`summary`** Write buffered data before a stream ends, called by stream internals
 
@@ -265,7 +265,7 @@ ___
 
 *Overrides void*
 
-*Defined in [lib/sparse-stream/sparse-write-stream.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-write-stream.ts#L110)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-write-stream.ts#L110)*
 
 **Parameters:**
 
@@ -480,7 +480,7 @@ ___
 
 ▸ **copyChunk**(`chunk`: [SparseStreamChunk](../interfaces/sparsestreamchunk.md)): *[SparseStreamChunk](../interfaces/sparsestreamchunk.md)*
 
-*Defined in [lib/sparse-stream/sparse-write-stream.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-write-stream.ts#L60)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-write-stream.ts#L60)*
 
 **Parameters:**
 
@@ -1709,7 +1709,7 @@ ___
 
 ▸ **writeChunk**(`chunk`: [SparseStreamChunk](../interfaces/sparsestreamchunk.md), `flushing`: boolean): *Promise‹void›*
 
-*Defined in [lib/sparse-stream/sparse-write-stream.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/sparse-write-stream.ts#L37)*
+*Defined in [lib/sparse-stream/sparse-write-stream.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/sparse-write-stream.ts#L37)*
 
 **Parameters:**
 

--- a/doc/classes/speedometer.md
+++ b/doc/classes/speedometer.md
@@ -31,7 +31,7 @@
 
 \+ **new Speedometer**(`windowSize`: number): *[Speedometer](speedometer.md)*
 
-*Defined in [lib/speedometer.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/speedometer.ts#L20)*
+*Defined in [lib/speedometer.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/speedometer.ts#L20)*
 
 **Parameters:**
 
@@ -47,7 +47,7 @@ Name | Type | Default |
 
 • **values**: *Array‹[]›* = []
 
-*Defined in [lib/speedometer.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/speedometer.ts#L20)*
+*Defined in [lib/speedometer.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/speedometer.ts#L20)*
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 • **windowSize**: *number*
 
-*Defined in [lib/speedometer.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/speedometer.ts#L22)*
+*Defined in [lib/speedometer.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/speedometer.ts#L22)*
 
 ## Methods
 
@@ -63,7 +63,7 @@ ___
 
 ▸ **moment**(`index`: number): *number*
 
-*Defined in [lib/speedometer.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/speedometer.ts#L36)*
+*Defined in [lib/speedometer.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/speedometer.ts#L36)*
 
 **Parameters:**
 
@@ -79,7 +79,7 @@ ___
 
 ▸ **now**(): *number*
 
-*Defined in [lib/speedometer.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/speedometer.ts#L26)*
+*Defined in [lib/speedometer.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/speedometer.ts#L26)*
 
 **Returns:** *number*
 
@@ -89,7 +89,7 @@ ___
 
 ▸ **removeOldValues**(`start`: number): *void*
 
-*Defined in [lib/speedometer.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/speedometer.ts#L30)*
+*Defined in [lib/speedometer.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/speedometer.ts#L30)*
 
 **Parameters:**
 
@@ -105,7 +105,7 @@ ___
 
 ▸ **speed**(`amount`: number): *number*
 
-*Defined in [lib/speedometer.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/speedometer.ts#L44)*
+*Defined in [lib/speedometer.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/speedometer.ts#L44)*
 
 **Parameters:**
 
@@ -121,7 +121,7 @@ ___
 
 ▸ **value**(`index`: number): *number*
 
-*Defined in [lib/speedometer.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/speedometer.ts#L40)*
+*Defined in [lib/speedometer.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/speedometer.ts#L40)*
 
 **Parameters:**
 

--- a/doc/classes/streamlimiter.md
+++ b/doc/classes/streamlimiter.md
@@ -83,7 +83,7 @@
 
 *Overrides [SourceTransform](../interfaces/sourcetransform.md).[constructor](../interfaces/sourcetransform.md#constructor)*
 
-*Defined in [lib/stream-limiter.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/stream-limiter.ts#L22)*
+*Defined in [lib/stream-limiter.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/stream-limiter.ts#L22)*
 
 **Parameters:**
 
@@ -100,7 +100,7 @@ Name | Type |
 
 • **maxBytes**: *number*
 
-*Defined in [lib/stream-limiter.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/stream-limiter.ts#L23)*
+*Defined in [lib/stream-limiter.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/stream-limiter.ts#L23)*
 
 ___
 
@@ -148,7 +148,7 @@ ___
 
 • **stream**: *ReadableStream*
 
-*Defined in [lib/stream-limiter.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/stream-limiter.ts#L23)*
+*Defined in [lib/stream-limiter.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/stream-limiter.ts#L23)*
 
 ___
 
@@ -298,7 +298,7 @@ ___
 
 *Overrides [SourceTransform](../interfaces/sourcetransform.md).[_transform](../interfaces/sourcetransform.md#_transform)*
 
-*Defined in [lib/stream-limiter.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/stream-limiter.ts#L29)*
+*Defined in [lib/stream-limiter.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/stream-limiter.ts#L29)*
 
 **Parameters:**
 

--- a/doc/classes/streamverifier.md
+++ b/doc/classes/streamverifier.md
@@ -52,7 +52,7 @@
 
 \+ **new StreamVerifier**(`source`: [SourceDestination](sourcedestination.md), `checksum`: string, `size`: number): *[StreamVerifier](streamverifier.md)*
 
-*Defined in [lib/source-destination/source-destination.ts:174](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L174)*
+*Defined in [lib/source-destination/source-destination.ts:174](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L174)*
 
 **Parameters:**
 
@@ -70,7 +70,7 @@ Name | Type |
 
 • **checksum**: *string*
 
-*Defined in [lib/source-destination/source-destination.ts:177](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L177)*
+*Defined in [lib/source-destination/source-destination.ts:177](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L177)*
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 • **size**: *number*
 
-*Defined in [lib/source-destination/source-destination.ts:178](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L178)*
+*Defined in [lib/source-destination/source-destination.ts:178](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L178)*
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 • **source**: *[SourceDestination](sourcedestination.md)*
 
-*Defined in [lib/source-destination/source-destination.ts:176](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L176)*
+*Defined in [lib/source-destination/source-destination.ts:176](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L176)*
 
 ___
 
@@ -183,7 +183,7 @@ ___
 
 *Inherited from [Verifier](verifier.md).[handleEventsAndPipe](verifier.md#protected-handleeventsandpipe)*
 
-*Defined in [lib/source-destination/source-destination.ts:156](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L156)*
+*Defined in [lib/source-destination/source-destination.ts:156](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L156)*
 
 **Parameters:**
 
@@ -450,7 +450,7 @@ ___
 
 *Overrides [Verifier](verifier.md).[run](verifier.md#abstract-run)*
 
-*Defined in [lib/source-destination/source-destination.ts:183](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L183)*
+*Defined in [lib/source-destination/source-destination.ts:183](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L183)*
 
 **Returns:** *Promise‹void›*
 
@@ -503,28 +503,28 @@ Name | Type |
 
 *Inherited from [Verifier](verifier.md).[progress](verifier.md#progress)*
 
-*Defined in [lib/source-destination/source-destination.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L147)*
+*Defined in [lib/source-destination/source-destination.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L147)*
 
 ###  averageSpeed
 
 • **averageSpeed**: *number* = 0
 
-*Defined in [lib/source-destination/source-destination.ts:151](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L151)*
+*Defined in [lib/source-destination/source-destination.ts:151](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L151)*
 
 ###  bytes
 
 • **bytes**: *number* = 0
 
-*Defined in [lib/source-destination/source-destination.ts:148](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L148)*
+*Defined in [lib/source-destination/source-destination.ts:148](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L148)*
 
 ###  position
 
 • **position**: *number* = 0
 
-*Defined in [lib/source-destination/source-destination.ts:149](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L149)*
+*Defined in [lib/source-destination/source-destination.ts:149](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L149)*
 
 ###  speed
 
 • **speed**: *number* = 0
 
-*Defined in [lib/source-destination/source-destination.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L150)*
+*Defined in [lib/source-destination/source-destination.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L150)*

--- a/doc/classes/streamzipsource.md
+++ b/doc/classes/streamzipsource.md
@@ -76,7 +76,7 @@
 
 *Overrides [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
 
-*Defined in [lib/source-destination/zip.ts:73](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L73)*
+*Defined in [lib/source-destination/zip.ts:73](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L73)*
 
 **Parameters:**
 
@@ -100,7 +100,7 @@ Name | Type |
 
 • **entry**? : *ZipStreamEntry*
 
-*Defined in [lib/source-destination/zip.ts:73](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L73)*
+*Defined in [lib/source-destination/zip.ts:73](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L73)*
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 • **match**: *function*
 
-*Defined in [lib/source-destination/zip.ts:77](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L77)*
+*Defined in [lib/source-destination/zip.ts:77](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L77)*
 
 #### Type declaration:
 
@@ -128,7 +128,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
 
-*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L22)*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L22)*
 
 ___
 
@@ -159,7 +159,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -169,7 +169,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L286)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ___
 
@@ -179,7 +179,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
 
-*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L20)*
 
 ## Methods
 
@@ -191,7 +191,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L30)*
+*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L30)*
 
 **Returns:** *Promise‹void›*
 
@@ -203,7 +203,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/zip.ts:120](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L120)*
+*Defined in [lib/source-destination/zip.ts:120](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L120)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -217,7 +217,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
 
-*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L26)*
+*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L26)*
 
 **Returns:** *Promise‹void›*
 
@@ -257,7 +257,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/zip.ts:82](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L82)*
+*Defined in [lib/source-destination/zip.ts:82](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L82)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -269,7 +269,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L314)*
+*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L314)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -281,7 +281,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -293,7 +293,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -305,7 +305,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L302)*
+*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L302)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -317,7 +317,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -329,7 +329,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -341,7 +341,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/zip.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L104)*
+*Defined in [lib/source-destination/zip.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L104)*
 
 **Parameters:**
 
@@ -362,7 +362,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L361)*
+*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L361)*
 
 **Parameters:**
 
@@ -380,7 +380,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -400,7 +400,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -419,7 +419,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -474,7 +474,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -486,7 +486,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -496,7 +496,7 @@ ___
 
 ▸ **getEntry**(): *Promise‹ZipStreamEntry›*
 
-*Defined in [lib/source-destination/zip.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L86)*
+*Defined in [lib/source-destination/zip.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L86)*
 
 **Returns:** *Promise‹ZipStreamEntry›*
 
@@ -508,7 +508,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -534,7 +534,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -546,7 +546,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -682,7 +682,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -770,7 +770,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L337)*
+*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L337)*
 
 **Parameters:**
 
@@ -859,7 +859,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -901,7 +901,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/usbbbbootdeviceadapter.md
+++ b/doc/classes/usbbbbootdeviceadapter.md
@@ -1,78 +1,73 @@
-[etcher-sdk](../README.md) › [DriverlessDeviceAdapter$](driverlessdeviceadapter_.md)
+[etcher-sdk](../README.md) › [UsbBBbootDeviceAdapter](usbbbbootdeviceadapter.md)
 
-# Class: DriverlessDeviceAdapter$
+# Class: UsbBBbootDeviceAdapter
 
 ## Hierarchy
 
   ↳ [Adapter](adapter.md)
 
-  ↳ **DriverlessDeviceAdapter$**
+  ↳ **UsbBBbootDeviceAdapter**
 
 ## Index
 
+### Constructors
+
+* [constructor](usbbbbootdeviceadapter.md#constructor)
+
 ### Properties
 
-* [drives](driverlessdeviceadapter_.md#private-drives)
-* [listDriverlessDevices](driverlessdeviceadapter_.md#private-listdriverlessdevices)
-* [ready](driverlessdeviceadapter_.md#private-ready)
-* [running](driverlessdeviceadapter_.md#private-running)
-* [defaultMaxListeners](driverlessdeviceadapter_.md#static-defaultmaxlisteners)
+* [drives](usbbbbootdeviceadapter.md#private-drives)
+* [scanner](usbbbbootdeviceadapter.md#private-scanner)
+* [defaultMaxListeners](usbbbbootdeviceadapter.md#static-defaultmaxlisteners)
 
 ### Methods
 
-* [addListener](driverlessdeviceadapter_.md#addlistener)
-* [emit](driverlessdeviceadapter_.md#emit)
-* [eventNames](driverlessdeviceadapter_.md#eventnames)
-* [getMaxListeners](driverlessdeviceadapter_.md#getmaxlisteners)
-* [listDrives](driverlessdeviceadapter_.md#private-listdrives)
-* [listenerCount](driverlessdeviceadapter_.md#listenercount)
-* [listeners](driverlessdeviceadapter_.md#listeners)
-* [off](driverlessdeviceadapter_.md#off)
-* [on](driverlessdeviceadapter_.md#on)
-* [once](driverlessdeviceadapter_.md#once)
-* [prependListener](driverlessdeviceadapter_.md#prependlistener)
-* [prependOnceListener](driverlessdeviceadapter_.md#prependoncelistener)
-* [rawListeners](driverlessdeviceadapter_.md#rawlisteners)
-* [removeAllListeners](driverlessdeviceadapter_.md#removealllisteners)
-* [removeListener](driverlessdeviceadapter_.md#removelistener)
-* [scan](driverlessdeviceadapter_.md#private-scan)
-* [scanLoop](driverlessdeviceadapter_.md#private-scanloop)
-* [setMaxListeners](driverlessdeviceadapter_.md#setmaxlisteners)
-* [start](driverlessdeviceadapter_.md#start)
-* [stop](driverlessdeviceadapter_.md#stop)
-* [listenerCount](driverlessdeviceadapter_.md#static-listenercount)
+* [addListener](usbbbbootdeviceadapter.md#addlistener)
+* [emit](usbbbbootdeviceadapter.md#emit)
+* [eventNames](usbbbbootdeviceadapter.md#eventnames)
+* [getMaxListeners](usbbbbootdeviceadapter.md#getmaxlisteners)
+* [listenerCount](usbbbbootdeviceadapter.md#listenercount)
+* [listeners](usbbbbootdeviceadapter.md#listeners)
+* [off](usbbbbootdeviceadapter.md#off)
+* [on](usbbbbootdeviceadapter.md#on)
+* [onAttach](usbbbbootdeviceadapter.md#private-onattach)
+* [onDetach](usbbbbootdeviceadapter.md#private-ondetach)
+* [once](usbbbbootdeviceadapter.md#once)
+* [prependListener](usbbbbootdeviceadapter.md#prependlistener)
+* [prependOnceListener](usbbbbootdeviceadapter.md#prependoncelistener)
+* [rawListeners](usbbbbootdeviceadapter.md#rawlisteners)
+* [removeAllListeners](usbbbbootdeviceadapter.md#removealllisteners)
+* [removeListener](usbbbbootdeviceadapter.md#removelistener)
+* [setMaxListeners](usbbbbootdeviceadapter.md#setmaxlisteners)
+* [start](usbbbbootdeviceadapter.md#start)
+* [stop](usbbbbootdeviceadapter.md#stop)
+* [listenerCount](usbbbbootdeviceadapter.md#static-listenercount)
+
+## Constructors
+
+###  constructor
+
+\+ **new UsbBBbootDeviceAdapter**(): *[UsbBBbootDeviceAdapter](usbbbbootdeviceadapter.md)*
+
+*Defined in [lib/scanner/adapters/usb-bb-boot.ts:11](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/usb-bb-boot.ts#L11)*
+
+**Returns:** *[UsbBBbootDeviceAdapter](usbbbbootdeviceadapter.md)*
 
 ## Properties
 
 ### `Private` drives
 
-• **drives**: *Map‹string, [DriverlessDevice](driverlessdevice.md)›* = new Map()
+• **drives**: *Map‹UsbBBbootDevice, [UsbBBbootDrive](usbbbbootdrive.md)›* = new Map()
 
-*Defined in [lib/scanner/adapters/driverless.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/driverless.ts#L29)*
-
-___
-
-### `Private` listDriverlessDevices
-
-• **listDriverlessDevices**: *any*
-
-*Defined in [lib/scanner/adapters/driverless.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/driverless.ts#L32)*
+*Defined in [lib/scanner/adapters/usb-bb-boot.ts:10](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/usb-bb-boot.ts#L10)*
 
 ___
 
-### `Private` ready
+### `Private` scanner
 
-• **ready**: *boolean* = false
+• **scanner**: *UsbBBbootScanner*
 
-*Defined in [lib/scanner/adapters/driverless.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/driverless.ts#L31)*
-
-___
-
-### `Private` running
-
-• **running**: *boolean* = false
-
-*Defined in [lib/scanner/adapters/driverless.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/driverless.ts#L30)*
+*Defined in [lib/scanner/adapters/usb-bb-boot.ts:11](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/usb-bb-boot.ts#L11)*
 
 ___
 
@@ -160,16 +155,6 @@ ___
 Defined in node_modules/@types/node/events.d.ts:29
 
 **Returns:** *number*
-
-___
-
-### `Private` listDrives
-
-▸ **listDrives**(): *Map‹string, WinUsbDriverlessDevice›*
-
-*Defined in [lib/scanner/adapters/driverless.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/driverless.ts#L87)*
-
-**Returns:** *Map‹string, WinUsbDriverlessDevice›*
 
 ___
 
@@ -266,6 +251,38 @@ Name | Type |
 `...args` | any[] |
 
 **Returns:** *this*
+
+___
+
+### `Private` onAttach
+
+▸ **onAttach**(`device`: UsbBBbootDevice): *void*
+
+*Defined in [lib/scanner/adapters/usb-bb-boot.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/usb-bb-boot.ts#L30)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`device` | UsbBBbootDevice |
+
+**Returns:** *void*
+
+___
+
+### `Private` onDetach
+
+▸ **onDetach**(`device`: UsbBBbootDevice): *void*
+
+*Defined in [lib/scanner/adapters/usb-bb-boot.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/usb-bb-boot.ts#L39)*
+
+**Parameters:**
+
+Name | Type |
+------ | ------ |
+`device` | UsbBBbootDevice |
+
+**Returns:** *void*
 
 ___
 
@@ -421,26 +438,6 @@ Name | Type |
 
 ___
 
-### `Private` scan
-
-▸ **scan**(): *void*
-
-*Defined in [lib/scanner/adapters/driverless.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/driverless.ts#L62)*
-
-**Returns:** *void*
-
-___
-
-### `Private` scanLoop
-
-▸ **scanLoop**(): *Promise‹void›*
-
-*Defined in [lib/scanner/adapters/driverless.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/driverless.ts#L45)*
-
-**Returns:** *Promise‹void›*
-
-___
-
 ###  setMaxListeners
 
 ▸ **setMaxListeners**(`n`: number): *this*
@@ -467,7 +464,7 @@ ___
 
 *Overrides [Adapter](adapter.md).[start](adapter.md#abstract-start)*
 
-*Defined in [lib/scanner/adapters/driverless.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/driverless.ts#L34)*
+*Defined in [lib/scanner/adapters/usb-bb-boot.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/usb-bb-boot.ts#L22)*
 
 **Returns:** *void*
 
@@ -479,7 +476,7 @@ ___
 
 *Overrides [Adapter](adapter.md).[stop](adapter.md#abstract-stop)*
 
-*Defined in [lib/scanner/adapters/driverless.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/driverless.ts#L39)*
+*Defined in [lib/scanner/adapters/usb-bb-boot.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/usb-bb-boot.ts#L26)*
 
 **Returns:** *void*
 

--- a/doc/classes/usbbbbootdrive.md
+++ b/doc/classes/usbbbbootdrive.md
@@ -1,106 +1,237 @@
-[etcher-sdk](../README.md) › [GZipSource](gzipsource.md)
+[etcher-sdk](../README.md) › [UsbBBbootDrive](usbbbbootdrive.md)
 
-# Class: GZipSource
+# Class: UsbBBbootDrive
 
 ## Hierarchy
 
-  ↳ [CompressedSource](compressedsource.md)
+  ↳ [SourceDestination](sourcedestination.md)
 
-  ↳ **GZipSource**
+  ↳ **UsbBBbootDrive**
+
+## Implements
+
+* [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)
 
 ## Index
 
 ### Constructors
 
-* [constructor](gzipsource.md#constructor)
+* [constructor](usbbbbootdrive.md#constructor)
 
 ### Properties
 
-* [source](gzipsource.md#protected-source)
-* [defaultMaxListeners](gzipsource.md#static-defaultmaxlisteners)
-* [imageExtensions](gzipsource.md#static-readonly-imageextensions)
-* [mimetype](gzipsource.md#static-readonly-mimetype)
-* [requiresRandomReadableSource](gzipsource.md#static-requiresrandomreadablesource)
+* [description](usbbbbootdrive.md#description)
+* [device](usbbbbootdrive.md#device)
+* [devicePath](usbbbbootdrive.md#devicepath)
+* [disabled](usbbbbootdrive.md#disabled)
+* [displayName](usbbbbootdrive.md#displayname)
+* [emitsProgress](usbbbbootdrive.md#emitsprogress)
+* [icon](usbbbbootdrive.md#icon)
+* [isReadOnly](usbbbbootdrive.md#isreadonly)
+* [isSystem](usbbbbootdrive.md#issystem)
+* [mountpoints](usbbbbootdrive.md#mountpoints)
+* [progress](usbbbbootdrive.md#progress)
+* [raw](usbbbbootdrive.md#raw)
+* [size](usbbbbootdrive.md#size)
+* [usbDevice](usbbbbootdrive.md#usbdevice)
+* [defaultMaxListeners](usbbbbootdrive.md#static-defaultmaxlisteners)
+* [imageExtensions](usbbbbootdrive.md#static-readonly-imageextensions)
+* [mimetype](usbbbbootdrive.md#static-optional-readonly-mimetype)
 
 ### Methods
 
-* [_close](gzipsource.md#protected-_close)
-* [_getMetadata](gzipsource.md#protected-_getmetadata)
-* [_open](gzipsource.md#protected-_open)
-* [addListener](gzipsource.md#addlistener)
-* [canCreateReadStream](gzipsource.md#cancreatereadstream)
-* [canCreateSparseReadStream](gzipsource.md#cancreatesparsereadstream)
-* [canCreateSparseWriteStream](gzipsource.md#cancreatesparsewritestream)
-* [canCreateWriteStream](gzipsource.md#cancreatewritestream)
-* [canRead](gzipsource.md#canread)
-* [canWrite](gzipsource.md#canwrite)
-* [close](gzipsource.md#close)
-* [createReadStream](gzipsource.md#createreadstream)
-* [createSparseReadStream](gzipsource.md#createsparsereadstream)
-* [createSparseWriteStream](gzipsource.md#createsparsewritestream)
-* [createTransform](gzipsource.md#protected-createtransform)
-* [createVerifier](gzipsource.md#createverifier)
-* [createWriteStream](gzipsource.md#createwritestream)
-* [emit](gzipsource.md#emit)
-* [eventNames](gzipsource.md#eventnames)
-* [getAlignment](gzipsource.md#getalignment)
-* [getBlocks](gzipsource.md#getblocks)
-* [getInnerSource](gzipsource.md#getinnersource)
-* [getMaxListeners](gzipsource.md#getmaxlisteners)
-* [getMetadata](gzipsource.md#getmetadata)
-* [getPartitionTable](gzipsource.md#getpartitiontable)
-* [getSize](gzipsource.md#protected-getsize)
-* [getSizeFromPartitionTable](gzipsource.md#protected-getsizefrompartitiontable)
-* [listenerCount](gzipsource.md#listenercount)
-* [listeners](gzipsource.md#listeners)
-* [off](gzipsource.md#off)
-* [on](gzipsource.md#on)
-* [once](gzipsource.md#once)
-* [open](gzipsource.md#open)
-* [prependListener](gzipsource.md#prependlistener)
-* [prependOnceListener](gzipsource.md#prependoncelistener)
-* [rawListeners](gzipsource.md#rawlisteners)
-* [read](gzipsource.md#read)
-* [removeAllListeners](gzipsource.md#removealllisteners)
-* [removeListener](gzipsource.md#removelistener)
-* [setMaxListeners](gzipsource.md#setmaxlisteners)
-* [write](gzipsource.md#write)
-* [listenerCount](gzipsource.md#static-listenercount)
-* [register](gzipsource.md#static-register)
+* [_close](usbbbbootdrive.md#protected-_close)
+* [_getMetadata](usbbbbootdrive.md#protected-_getmetadata)
+* [_open](usbbbbootdrive.md#protected-_open)
+* [addListener](usbbbbootdrive.md#addlistener)
+* [canCreateReadStream](usbbbbootdrive.md#cancreatereadstream)
+* [canCreateSparseReadStream](usbbbbootdrive.md#cancreatesparsereadstream)
+* [canCreateSparseWriteStream](usbbbbootdrive.md#cancreatesparsewritestream)
+* [canCreateWriteStream](usbbbbootdrive.md#cancreatewritestream)
+* [canRead](usbbbbootdrive.md#canread)
+* [canWrite](usbbbbootdrive.md#canwrite)
+* [close](usbbbbootdrive.md#close)
+* [createReadStream](usbbbbootdrive.md#createreadstream)
+* [createSparseReadStream](usbbbbootdrive.md#createsparsereadstream)
+* [createSparseWriteStream](usbbbbootdrive.md#createsparsewritestream)
+* [createVerifier](usbbbbootdrive.md#createverifier)
+* [createWriteStream](usbbbbootdrive.md#createwritestream)
+* [emit](usbbbbootdrive.md#emit)
+* [eventNames](usbbbbootdrive.md#eventnames)
+* [getAlignment](usbbbbootdrive.md#getalignment)
+* [getBlocks](usbbbbootdrive.md#getblocks)
+* [getInnerSource](usbbbbootdrive.md#getinnersource)
+* [getMaxListeners](usbbbbootdrive.md#getmaxlisteners)
+* [getMetadata](usbbbbootdrive.md#getmetadata)
+* [getPartitionTable](usbbbbootdrive.md#getpartitiontable)
+* [listenerCount](usbbbbootdrive.md#listenercount)
+* [listeners](usbbbbootdrive.md#listeners)
+* [off](usbbbbootdrive.md#off)
+* [on](usbbbbootdrive.md#on)
+* [once](usbbbbootdrive.md#once)
+* [open](usbbbbootdrive.md#open)
+* [prependListener](usbbbbootdrive.md#prependlistener)
+* [prependOnceListener](usbbbbootdrive.md#prependoncelistener)
+* [rawListeners](usbbbbootdrive.md#rawlisteners)
+* [read](usbbbbootdrive.md#read)
+* [removeAllListeners](usbbbbootdrive.md#removealllisteners)
+* [removeListener](usbbbbootdrive.md#removelistener)
+* [setMaxListeners](usbbbbootdrive.md#setmaxlisteners)
+* [write](usbbbbootdrive.md#write)
+* [listenerCount](usbbbbootdrive.md#static-listenercount)
+* [register](usbbbbootdrive.md#static-register)
 
 ## Constructors
 
 ###  constructor
 
-\+ **new GZipSource**(`source`: [SourceDestination](sourcedestination.md)): *[GZipSource](gzipsource.md)*
+\+ **new UsbBBbootDrive**(`usbDevice`: UsbBBbootDevice): *[UsbBBbootDrive](usbbbbootdrive.md)*
 
-*Inherited from [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
-
-*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/usb-bb-boot.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usb-bb-boot.ts#L21)*
 
 **Parameters:**
 
 Name | Type |
 ------ | ------ |
-`source` | [SourceDestination](sourcedestination.md) |
+`usbDevice` | UsbBBbootDevice |
 
-**Returns:** *[GZipSource](gzipsource.md)*
+**Returns:** *[UsbBBbootDrive](usbbbbootdrive.md)*
 
 ## Properties
 
-### `Protected` source
+###  description
 
-• **source**: *[SourceDestination](sourcedestination.md)*
+• **description**: *string* = "BeagleBone"
 
-*Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[description](../interfaces/adaptersourcedestination.md#description)*
 
-*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L22)*
+*Defined in [lib/source-destination/usb-bb-boot.ts:15](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usb-bb-boot.ts#L15)*
+
+___
+
+###  device
+
+• **device**: *null* = null
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[device](../interfaces/adaptersourcedestination.md#device)*
+
+*Defined in [lib/source-destination/usb-bb-boot.ts:11](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usb-bb-boot.ts#L11)*
+
+___
+
+###  devicePath
+
+• **devicePath**: *null* = null
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[devicePath](../interfaces/adaptersourcedestination.md#devicepath)*
+
+*Defined in [lib/source-destination/usb-bb-boot.ts:12](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usb-bb-boot.ts#L12)*
+
+___
+
+###  disabled
+
+• **disabled**: *boolean* = true
+
+*Defined in [lib/source-destination/usb-bb-boot.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usb-bb-boot.ts#L18)*
+
+___
+
+###  displayName
+
+• **displayName**: *string* = "Initializing device"
+
+*Defined in [lib/source-destination/usb-bb-boot.ts:10](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usb-bb-boot.ts#L10)*
+
+___
+
+###  emitsProgress
+
+• **emitsProgress**: *boolean* = true
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[emitsProgress](../interfaces/adaptersourcedestination.md#emitsprogress)*
+
+*Defined in [lib/source-destination/usb-bb-boot.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usb-bb-boot.ts#L20)*
+
+___
+
+###  icon
+
+• **icon**: *string* = "loading"
+
+*Defined in [lib/source-destination/usb-bb-boot.ts:13](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usb-bb-boot.ts#L13)*
+
+___
+
+###  isReadOnly
+
+• **isReadOnly**: *boolean* = false
+
+*Defined in [lib/source-destination/usb-bb-boot.ts:17](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usb-bb-boot.ts#L17)*
+
+___
+
+###  isSystem
+
+• **isSystem**: *boolean* = false
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[isSystem](../interfaces/adaptersourcedestination.md#issystem)*
+
+*Defined in [lib/source-destination/usb-bb-boot.ts:14](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usb-bb-boot.ts#L14)*
+
+___
+
+###  mountpoints
+
+• **mountpoints**: *never[]* = []
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[mountpoints](../interfaces/adaptersourcedestination.md#mountpoints)*
+
+*Defined in [lib/source-destination/usb-bb-boot.ts:16](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usb-bb-boot.ts#L16)*
+
+___
+
+###  progress
+
+• **progress**: *number* = 0
+
+*Defined in [lib/source-destination/usb-bb-boot.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usb-bb-boot.ts#L21)*
+
+___
+
+###  raw
+
+• **raw**: *null* = null
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[raw](../interfaces/adaptersourcedestination.md#raw)*
+
+*Defined in [lib/source-destination/usb-bb-boot.ts:9](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usb-bb-boot.ts#L9)*
+
+___
+
+###  size
+
+• **size**: *null* = null
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[size](../interfaces/adaptersourcedestination.md#size)*
+
+*Defined in [lib/source-destination/usb-bb-boot.ts:19](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usb-bb-boot.ts#L19)*
+
+___
+
+###  usbDevice
+
+• **usbDevice**: *UsbBBbootDevice*
+
+*Defined in [lib/source-destination/usb-bb-boot.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usb-bb-boot.ts#L23)*
 
 ___
 
 ### `Static` defaultMaxListeners
 
 ▪ **defaultMaxListeners**: *number*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[defaultMaxListeners](../interfaces/adaptersourcedestination.md#static-defaultmaxlisteners)*
 
 *Inherited from [CountingWritable](countingwritable.md).[defaultMaxListeners](countingwritable.md#static-defaultmaxlisteners)*
 
@@ -123,29 +254,23 @@ ___
 		'wic',
 	]
 
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[imageExtensions](../interfaces/adaptersourcedestination.md#static-readonly-imageextensions)*
+
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
 *Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
-### `Static` `Readonly` mimetype
+### `Static` `Optional` `Readonly` mimetype
 
-▪ **mimetype**: *"application/gzip"* = "application/gzip"
+▪ **mimetype**? : *undefined | string*
 
-*Overrides [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[mimetype](../interfaces/adaptersourcedestination.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/gzip.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/gzip.ts#L26)*
+*Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-___
-
-### `Static` requiresRandomReadableSource
-
-▪ **requiresRandomReadableSource**: *boolean* = false
-
-*Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
-
-*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ## Methods
 
@@ -153,11 +278,11 @@ ___
 
 ▸ **_close**(): *Promise‹void›*
 
-*Inherited from [SourceSource](sourcesource.md).[_close](sourcesource.md#protected-_close)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
+*Inherited from [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L30)*
+*Defined in [lib/source-destination/source-destination.ts:401](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L401)*
 
 **Returns:** *Promise‹void›*
 
@@ -167,11 +292,11 @@ ___
 
 ▸ **_getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
-*Inherited from [CompressedSource](compressedsource.md).[_getMetadata](compressedsource.md#protected-_getmetadata)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
+*Inherited from [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/compressed-source.ts:105](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L105)*
+*Defined in [lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L333)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -181,11 +306,11 @@ ___
 
 ▸ **_open**(): *Promise‹void›*
 
-*Inherited from [SourceSource](sourcesource.md).[_open](sourcesource.md#protected-_open)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
+*Inherited from [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
 
-*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L26)*
+*Defined in [lib/source-destination/source-destination.ts:397](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L397)*
 
 **Returns:** *Promise‹void›*
 
@@ -223,11 +348,11 @@ ___
 
 ▸ **canCreateReadStream**(): *Promise‹boolean›*
 
-*Inherited from [CompressedSource](compressedsource.md).[canCreateReadStream](compressedsource.md#cancreatereadstream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
+*Inherited from [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/compressed-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L53)*
+*Defined in [lib/source-destination/source-destination.ts:310](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L310)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -236,6 +361,8 @@ ___
 ###  canCreateSparseReadStream
 
 ▸ **canCreateSparseReadStream**(): *Promise‹boolean›*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
@@ -249,6 +376,8 @@ ___
 
 ▸ **canCreateSparseWriteStream**(): *Promise‹boolean›*
 
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
 *Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
@@ -260,6 +389,8 @@ ___
 ###  canCreateWriteStream
 
 ▸ **canCreateWriteStream**(): *Promise‹boolean›*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
@@ -273,6 +404,8 @@ ___
 
 ▸ **canRead**(): *Promise‹boolean›*
 
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
 *Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
 *Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L302)*
@@ -284,6 +417,8 @@ ___
 ###  canWrite
 
 ▸ **canWrite**(): *Promise‹boolean›*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
@@ -297,6 +432,8 @@ ___
 
 ▸ **close**(): *Promise‹void›*
 
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
 *Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
@@ -307,31 +444,29 @@ ___
 
 ###  createReadStream
 
-▸ **createReadStream**(`__namedParameters`: object): *Promise‹[SourceTransform](../interfaces/sourcetransform.md)›*
+▸ **createReadStream**(`_options`: [CreateReadStreamOptions](../interfaces/createreadstreamoptions.md)): *Promise‹ReadableStream›*
 
-*Inherited from [CompressedSource](compressedsource.md).[createReadStream](compressedsource.md#createreadstream)*
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
-*Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
+*Inherited from [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L57)*
+*Defined in [lib/source-destination/source-destination.ts:355](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L355)*
 
 **Parameters:**
 
-▪`Default value`  **__namedParameters**: *object*= {}
-
 Name | Type | Default |
 ------ | ------ | ------ |
-`emitProgress` | boolean | false |
-`end` | undefined &#124; number | - |
-`start` | number | 0 |
+`_options` | [CreateReadStreamOptions](../interfaces/createreadstreamoptions.md) | {} |
 
-**Returns:** *Promise‹[SourceTransform](../interfaces/sourcetransform.md)›*
+**Returns:** *Promise‹ReadableStream›*
 
 ___
 
 ###  createSparseReadStream
 
 ▸ **createSparseReadStream**(`_options`: [CreateSparseReadStreamOptions](../interfaces/createsparsereadstreamoptions.md)): *Promise‹[SparseReadable](../interfaces/sparsereadable.md)›*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
@@ -367,21 +502,11 @@ Name | Type |
 
 ___
 
-### `Protected` createTransform
-
-▸ **createTransform**(): *Transform*
-
-*Overrides [CompressedSource](compressedsource.md).[createTransform](compressedsource.md#protected-abstract-createtransform)*
-
-*Defined in [lib/source-destination/gzip.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/gzip.ts#L28)*
-
-**Returns:** *Transform*
-
-___
-
 ###  createVerifier
 
 ▸ **createVerifier**(`checksumOrBlocks`: string | [BlocksWithChecksum](../interfaces/blockswithchecksum.md)[], `size?`: undefined | number): *[Verifier](verifier.md)*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
@@ -422,6 +547,8 @@ ___
 
 ▸ **emit**(`event`: string | symbol, ...`args`: any[]): *boolean*
 
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
 *Inherited from [SourceSource](sourcesource.md).[emit](sourcesource.md#emit)*
 
 *Overrides [SparseReadable](../interfaces/sparsereadable.md).[emit](../interfaces/sparsereadable.md#emit)*
@@ -443,6 +570,8 @@ ___
 
 ▸ **eventNames**(): *Array‹string | symbol›*
 
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
 *Inherited from [CountingWritable](countingwritable.md).[eventNames](countingwritable.md#eventnames)*
 
 *Overrides [SparseReadable](../interfaces/sparsereadable.md).[eventNames](../interfaces/sparsereadable.md#eventnames)*
@@ -457,6 +586,8 @@ ___
 
 ▸ **getAlignment**(): *number | undefined*
 
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
 *Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
@@ -468,6 +599,8 @@ ___
 ###  getBlocks
 
 ▸ **getBlocks**(): *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
@@ -481,6 +614,8 @@ ___
 
 ▸ **getInnerSource**(): *Promise‹[SourceDestination](sourcedestination.md)›*
 
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
 *Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
@@ -492,6 +627,8 @@ ___
 ###  getMaxListeners
 
 ▸ **getMaxListeners**(): *number*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Inherited from [CountingWritable](countingwritable.md).[getMaxListeners](countingwritable.md#getmaxlisteners)*
 
@@ -507,6 +644,8 @@ ___
 
 ▸ **getMetadata**(): *Promise‹[Metadata](../interfaces/metadata.md)›*
 
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
 *Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
@@ -519,6 +658,8 @@ ___
 
 ▸ **getPartitionTable**(): *Promise‹GetPartitionsResult | undefined›*
 
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
 *Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
@@ -527,33 +668,11 @@ ___
 
 ___
 
-### `Protected` getSize
-
-▸ **getSize**(): *Promise‹object | undefined›*
-
-*Overrides [CompressedSource](compressedsource.md).[getSize](compressedsource.md#protected-getsize)*
-
-*Defined in [lib/source-destination/gzip.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/gzip.ts#L32)*
-
-**Returns:** *Promise‹object | undefined›*
-
-___
-
-### `Protected` getSizeFromPartitionTable
-
-▸ **getSizeFromPartitionTable**(): *Promise‹number | undefined›*
-
-*Inherited from [CompressedSource](compressedsource.md).[getSizeFromPartitionTable](compressedsource.md#protected-getsizefrompartitiontable)*
-
-*Defined in [lib/source-destination/compressed-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L87)*
-
-**Returns:** *Promise‹number | undefined›*
-
-___
-
 ###  listenerCount
 
 ▸ **listenerCount**(`type`: string | symbol): *number*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
@@ -574,6 +693,8 @@ ___
 ###  listeners
 
 ▸ **listeners**(`event`: string | symbol): *Function[]*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Inherited from [CountingWritable](countingwritable.md).[listeners](countingwritable.md#listeners)*
 
@@ -679,6 +800,8 @@ ___
 
 ▸ **open**(): *Promise‹void›*
 
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
 *Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
@@ -747,6 +870,8 @@ ___
 
 ▸ **rawListeners**(`event`: string | symbol): *Function[]*
 
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
 *Inherited from [CountingWritable](countingwritable.md).[rawListeners](countingwritable.md#rawlisteners)*
 
 *Overrides [SparseReadable](../interfaces/sparsereadable.md).[rawListeners](../interfaces/sparsereadable.md#rawlisteners)*
@@ -766,6 +891,8 @@ ___
 ###  read
 
 ▸ **read**(`_buffer`: [Buffer](../interfaces/alignedlockablebuffer.md#buffer), `_bufferOffset`: number, `_length`: number, `_sourceOffset`: number): *Promise‹ReadResult›*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
@@ -787,6 +914,8 @@ ___
 ###  removeAllListeners
 
 ▸ **removeAllListeners**(`event?`: string | symbol): *this*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Inherited from [CountingWritable](countingwritable.md).[removeAllListeners](countingwritable.md#removealllisteners)*
 
@@ -836,6 +965,8 @@ ___
 
 ▸ **setMaxListeners**(`n`: number): *this*
 
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
 *Inherited from [CountingWritable](countingwritable.md).[setMaxListeners](countingwritable.md#setmaxlisteners)*
 
 *Overrides [SparseReadable](../interfaces/sparsereadable.md).[setMaxListeners](../interfaces/sparsereadable.md#setmaxlisteners)*
@@ -855,6 +986,8 @@ ___
 ###  write
 
 ▸ **write**(`_buffer`: [Buffer](../interfaces/alignedlockablebuffer.md#buffer), `_bufferOffset`: number, `_length`: number, `_fileOffset`: number): *Promise‹WriteResult›*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
@@ -877,6 +1010,8 @@ ___
 
 ▸ **listenerCount**(`emitter`: EventEmitter, `event`: string | symbol): *number*
 
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
+
 *Inherited from [CountingWritable](countingwritable.md).[listenerCount](countingwritable.md#static-listenercount)*
 
 Defined in node_modules/@types/node/events.d.ts:17
@@ -897,6 +1032,8 @@ ___
 ### `Static` register
 
 ▸ **register**(`Cls`: typeof SourceSource): *void*
+
+*Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md)*
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 

--- a/doc/classes/usbbootdeviceadapter.md
+++ b/doc/classes/usbbootdeviceadapter.md
@@ -49,7 +49,7 @@
 
 \+ **new UsbbootDeviceAdapter**(): *[UsbbootDeviceAdapter](usbbootdeviceadapter.md)*
 
-*Defined in [lib/scanner/adapters/usbboot.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/usbboot.ts#L28)*
+*Defined in [lib/scanner/adapters/usbboot.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/usbboot.ts#L28)*
 
 **Returns:** *[UsbbootDeviceAdapter](usbbootdeviceadapter.md)*
 
@@ -59,7 +59,7 @@
 
 • **drives**: *Map‹UsbbootDevice, [UsbbootDrive](usbbootdrive.md)›* = new Map()
 
-*Defined in [lib/scanner/adapters/usbboot.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/usbboot.ts#L27)*
+*Defined in [lib/scanner/adapters/usbboot.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/usbboot.ts#L27)*
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 • **scanner**? : *UsbbootScannerType*
 
-*Defined in [lib/scanner/adapters/usbboot.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/usbboot.ts#L28)*
+*Defined in [lib/scanner/adapters/usbboot.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/usbboot.ts#L28)*
 
 ___
 
@@ -258,7 +258,7 @@ ___
 
 ▸ **onAttach**(`device`: UsbbootDevice): *void*
 
-*Defined in [lib/scanner/adapters/usbboot.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/usbboot.ts#L53)*
+*Defined in [lib/scanner/adapters/usbboot.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/usbboot.ts#L53)*
 
 **Parameters:**
 
@@ -274,7 +274,7 @@ ___
 
 ▸ **onDetach**(`device`: UsbbootDevice): *void*
 
-*Defined in [lib/scanner/adapters/usbboot.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/usbboot.ts#L62)*
+*Defined in [lib/scanner/adapters/usbboot.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/usbboot.ts#L62)*
 
 **Parameters:**
 
@@ -464,7 +464,7 @@ ___
 
 *Overrides [Adapter](adapter.md).[start](adapter.md#abstract-start)*
 
-*Defined in [lib/scanner/adapters/usbboot.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/usbboot.ts#L45)*
+*Defined in [lib/scanner/adapters/usbboot.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/usbboot.ts#L45)*
 
 **Returns:** *void*
 
@@ -476,7 +476,7 @@ ___
 
 *Overrides [Adapter](adapter.md).[stop](adapter.md#abstract-stop)*
 
-*Defined in [lib/scanner/adapters/usbboot.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/usbboot.ts#L49)*
+*Defined in [lib/scanner/adapters/usbboot.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/usbboot.ts#L49)*
 
 **Returns:** *void*
 

--- a/doc/classes/usbbootdrive.md
+++ b/doc/classes/usbbootdrive.md
@@ -87,7 +87,7 @@
 
 \+ **new UsbbootDrive**(`usbDevice`: UsbbootDevice): *[UsbbootDrive](usbbootdrive.md)*
 
-*Defined in [lib/source-destination/usbboot.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/usbboot.ts#L37)*
+*Defined in [lib/source-destination/usbboot.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usbboot.ts#L37)*
 
 **Parameters:**
 
@@ -105,7 +105,7 @@ Name | Type |
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[description](../interfaces/adaptersourcedestination.md#description)*
 
-*Defined in [lib/source-destination/usbboot.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/usbboot.ts#L31)*
+*Defined in [lib/source-destination/usbboot.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usbboot.ts#L31)*
 
 ___
 
@@ -115,7 +115,7 @@ ___
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[device](../interfaces/adaptersourcedestination.md#device)*
 
-*Defined in [lib/source-destination/usbboot.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/usbboot.ts#L27)*
+*Defined in [lib/source-destination/usbboot.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usbboot.ts#L27)*
 
 ___
 
@@ -125,7 +125,7 @@ ___
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[devicePath](../interfaces/adaptersourcedestination.md#devicepath)*
 
-*Defined in [lib/source-destination/usbboot.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/usbboot.ts#L28)*
+*Defined in [lib/source-destination/usbboot.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usbboot.ts#L28)*
 
 ___
 
@@ -133,7 +133,7 @@ ___
 
 • **disabled**: *boolean* = true
 
-*Defined in [lib/source-destination/usbboot.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/usbboot.ts#L34)*
+*Defined in [lib/source-destination/usbboot.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usbboot.ts#L34)*
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 • **displayName**: *string* = "Initializing device"
 
-*Defined in [lib/source-destination/usbboot.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/usbboot.ts#L26)*
+*Defined in [lib/source-destination/usbboot.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usbboot.ts#L26)*
 
 ___
 
@@ -151,7 +151,7 @@ ___
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[emitsProgress](../interfaces/adaptersourcedestination.md#emitsprogress)*
 
-*Defined in [lib/source-destination/usbboot.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/usbboot.ts#L36)*
+*Defined in [lib/source-destination/usbboot.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usbboot.ts#L36)*
 
 ___
 
@@ -159,7 +159,7 @@ ___
 
 • **icon**: *string* = "loading"
 
-*Defined in [lib/source-destination/usbboot.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/usbboot.ts#L29)*
+*Defined in [lib/source-destination/usbboot.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usbboot.ts#L29)*
 
 ___
 
@@ -167,7 +167,7 @@ ___
 
 • **isReadOnly**: *boolean* = false
 
-*Defined in [lib/source-destination/usbboot.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/usbboot.ts#L33)*
+*Defined in [lib/source-destination/usbboot.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usbboot.ts#L33)*
 
 ___
 
@@ -177,7 +177,7 @@ ___
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[isSystem](../interfaces/adaptersourcedestination.md#issystem)*
 
-*Defined in [lib/source-destination/usbboot.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/usbboot.ts#L30)*
+*Defined in [lib/source-destination/usbboot.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usbboot.ts#L30)*
 
 ___
 
@@ -187,7 +187,7 @@ ___
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[mountpoints](../interfaces/adaptersourcedestination.md#mountpoints)*
 
-*Defined in [lib/source-destination/usbboot.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/usbboot.ts#L32)*
+*Defined in [lib/source-destination/usbboot.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usbboot.ts#L32)*
 
 ___
 
@@ -195,7 +195,7 @@ ___
 
 • **progress**: *number* = 0
 
-*Defined in [lib/source-destination/usbboot.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/usbboot.ts#L37)*
+*Defined in [lib/source-destination/usbboot.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usbboot.ts#L37)*
 
 ___
 
@@ -205,7 +205,7 @@ ___
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[raw](../interfaces/adaptersourcedestination.md#raw)*
 
-*Defined in [lib/source-destination/usbboot.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/usbboot.ts#L25)*
+*Defined in [lib/source-destination/usbboot.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usbboot.ts#L25)*
 
 ___
 
@@ -215,7 +215,7 @@ ___
 
 *Implementation of [AdapterSourceDestination](../interfaces/adaptersourcedestination.md).[size](../interfaces/adaptersourcedestination.md#size)*
 
-*Defined in [lib/source-destination/usbboot.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/usbboot.ts#L35)*
+*Defined in [lib/source-destination/usbboot.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usbboot.ts#L35)*
 
 ___
 
@@ -223,7 +223,7 @@ ___
 
 • **usbDevice**: *UsbbootDevice*
 
-*Defined in [lib/source-destination/usbboot.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/usbboot.ts#L39)*
+*Defined in [lib/source-destination/usbboot.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/usbboot.ts#L39)*
 
 ___
 
@@ -258,7 +258,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -270,7 +270,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L286)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ## Methods
 
@@ -282,7 +282,7 @@ ___
 
 *Inherited from [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/source-destination.ts:401](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L401)*
+*Defined in [lib/source-destination/source-destination.ts:401](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L401)*
 
 **Returns:** *Promise‹void›*
 
@@ -296,7 +296,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L333)*
+*Defined in [lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L333)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -310,7 +310,7 @@ ___
 
 *Inherited from [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
 
-*Defined in [lib/source-destination/source-destination.ts:397](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L397)*
+*Defined in [lib/source-destination/source-destination.ts:397](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L397)*
 
 **Returns:** *Promise‹void›*
 
@@ -352,7 +352,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:310](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L310)*
+*Defined in [lib/source-destination/source-destination.ts:310](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L310)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -366,7 +366,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L314)*
+*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L314)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -380,7 +380,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -394,7 +394,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -408,7 +408,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L302)*
+*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L302)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -422,7 +422,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -436,7 +436,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -450,7 +450,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:355](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L355)*
+*Defined in [lib/source-destination/source-destination.ts:355](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L355)*
 
 **Parameters:**
 
@@ -470,7 +470,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L361)*
+*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L361)*
 
 **Parameters:**
 
@@ -488,7 +488,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -510,7 +510,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -529,7 +529,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -590,7 +590,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -604,7 +604,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -618,7 +618,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -648,7 +648,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -662,7 +662,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -804,7 +804,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -896,7 +896,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L337)*
+*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L337)*
 
 **Parameters:**
 
@@ -991,7 +991,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -1037,7 +1037,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/verificationerror.md
+++ b/doc/classes/verificationerror.md
@@ -28,7 +28,7 @@
 
 • **code**: *string* = "EVALIDATION"
 
-*Defined in [lib/errors.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/errors.ts#L25)*
+*Defined in [lib/errors.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/errors.ts#L25)*
 
 ___
 

--- a/doc/classes/verifier.md
+++ b/doc/classes/verifier.md
@@ -138,7 +138,7 @@ ___
 
 ▸ **handleEventsAndPipe**(`stream`: ReadableStream, `meter`: WritableStream): *void*
 
-*Defined in [lib/source-destination/source-destination.ts:156](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L156)*
+*Defined in [lib/source-destination/source-destination.ts:156](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L156)*
 
 **Parameters:**
 
@@ -403,7 +403,7 @@ ___
 
 ▸ **run**(): *Promise‹void›*
 
-*Defined in [lib/source-destination/source-destination.ts:154](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L154)*
+*Defined in [lib/source-destination/source-destination.ts:154](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L154)*
 
 **Returns:** *Promise‹void›*
 
@@ -454,28 +454,28 @@ Name | Type |
 
 ### ▪ **progress**: *object*
 
-*Defined in [lib/source-destination/source-destination.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L147)*
+*Defined in [lib/source-destination/source-destination.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L147)*
 
 ###  averageSpeed
 
 • **averageSpeed**: *number* = 0
 
-*Defined in [lib/source-destination/source-destination.ts:151](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L151)*
+*Defined in [lib/source-destination/source-destination.ts:151](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L151)*
 
 ###  bytes
 
 • **bytes**: *number* = 0
 
-*Defined in [lib/source-destination/source-destination.ts:148](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L148)*
+*Defined in [lib/source-destination/source-destination.ts:148](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L148)*
 
 ###  position
 
 • **position**: *number* = 0
 
-*Defined in [lib/source-destination/source-destination.ts:149](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L149)*
+*Defined in [lib/source-destination/source-destination.ts:149](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L149)*
 
 ###  speed
 
 • **speed**: *number* = 0
 
-*Defined in [lib/source-destination/source-destination.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L150)*
+*Defined in [lib/source-destination/source-destination.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L150)*

--- a/doc/classes/xzsource.md
+++ b/doc/classes/xzsource.md
@@ -76,7 +76,7 @@
 
 *Inherited from [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
 
-*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L20)*
 
 **Parameters:**
 
@@ -94,7 +94,7 @@ Name | Type |
 
 *Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
 
-*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L22)*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L22)*
 
 ___
 
@@ -125,7 +125,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -135,7 +135,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/xz.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/xz.ts#L28)*
+*Defined in [lib/source-destination/xz.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/xz.ts#L28)*
 
 ___
 
@@ -145,7 +145,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
 
-*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L20)*
 
 ## Methods
 
@@ -157,7 +157,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L30)*
+*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L30)*
 
 **Returns:** *Promise‹void›*
 
@@ -171,7 +171,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/compressed-source.ts:105](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/compressed-source.ts#L105)*
+*Defined in [lib/source-destination/compressed-source.ts:105](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L105)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -185,7 +185,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
 
-*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L26)*
+*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L26)*
 
 **Returns:** *Promise‹void›*
 
@@ -227,7 +227,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/compressed-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/compressed-source.ts#L53)*
+*Defined in [lib/source-destination/compressed-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L53)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -239,7 +239,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L314)*
+*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L314)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -251,7 +251,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -263,7 +263,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -275,7 +275,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L302)*
+*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L302)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -287,7 +287,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -299,7 +299,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -313,7 +313,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/compressed-source.ts#L57)*
+*Defined in [lib/source-destination/compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L57)*
 
 **Parameters:**
 
@@ -335,7 +335,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L361)*
+*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L361)*
 
 **Parameters:**
 
@@ -353,7 +353,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -373,7 +373,7 @@ ___
 
 *Overrides [CompressedSource](compressedsource.md).[createTransform](compressedsource.md#protected-abstract-createtransform)*
 
-*Defined in [lib/source-destination/xz.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/xz.ts#L30)*
+*Defined in [lib/source-destination/xz.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/xz.ts#L30)*
 
 **Returns:** *Transform*
 
@@ -385,7 +385,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -404,7 +404,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -459,7 +459,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -471,7 +471,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -483,7 +483,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -509,7 +509,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -521,7 +521,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -533,7 +533,7 @@ ___
 
 *Overrides [CompressedSource](compressedsource.md).[getSize](compressedsource.md#protected-getsize)*
 
-*Defined in [lib/source-destination/xz.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/xz.ts#L34)*
+*Defined in [lib/source-destination/xz.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/xz.ts#L34)*
 
 **Returns:** *Promise‹object | undefined›*
 
@@ -545,7 +545,7 @@ ___
 
 *Inherited from [CompressedSource](compressedsource.md).[getSizeFromPartitionTable](compressedsource.md#protected-getsizefrompartitiontable)*
 
-*Defined in [lib/source-destination/compressed-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/compressed-source.ts#L87)*
+*Defined in [lib/source-destination/compressed-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L87)*
 
 **Returns:** *Promise‹number | undefined›*
 
@@ -681,7 +681,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -769,7 +769,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L337)*
+*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L337)*
 
 **Parameters:**
 
@@ -858,7 +858,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -900,7 +900,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/classes/zipsource.md
+++ b/doc/classes/zipsource.md
@@ -78,7 +78,7 @@
 
 *Overrides [SourceSource](sourcesource.md).[constructor](sourcesource.md#constructor)*
 
-*Defined in [lib/source-destination/zip.ts:362](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L362)*
+*Defined in [lib/source-destination/zip.ts:362](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L362)*
 
 **Parameters:**
 
@@ -104,7 +104,7 @@ Name | Type |
 
 • **implementation**: *[RandomAccessZipSource](randomaccesszipsource.md) | [StreamZipSource](streamzipsource.md)*
 
-*Defined in [lib/source-destination/zip.ts:362](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L362)*
+*Defined in [lib/source-destination/zip.ts:362](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L362)*
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 • **match**: *function*
 
-*Defined in [lib/source-destination/zip.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L367)*
+*Defined in [lib/source-destination/zip.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L367)*
 
 #### Type declaration:
 
@@ -130,7 +130,7 @@ ___
 
 • **preferStreamSource**: *boolean*
 
-*Defined in [lib/source-destination/zip.ts:366](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L366)*
+*Defined in [lib/source-destination/zip.ts:366](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L366)*
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 • **ready**: *Promise‹void›*
 
-*Defined in [lib/source-destination/zip.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L361)*
+*Defined in [lib/source-destination/zip.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L361)*
 
 ___
 
@@ -148,7 +148,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[source](sourcesource.md#protected-source)*
 
-*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L22)*
+*Defined in [lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L22)*
 
 ___
 
@@ -179,7 +179,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[imageExtensions](sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -189,7 +189,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[mimetype](sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/zip.ts:360](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L360)*
+*Defined in [lib/source-destination/zip.ts:360](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L360)*
 
 ___
 
@@ -199,7 +199,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[requiresRandomReadableSource](sourcesource.md#static-requiresrandomreadablesource)*
 
-*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L20)*
+*Defined in [lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L20)*
 
 ## Methods
 
@@ -211,7 +211,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_close](sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L30)*
+*Defined in [lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L30)*
 
 **Returns:** *Promise‹void›*
 
@@ -223,7 +223,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[_getMetadata](sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/zip.ts:425](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L425)*
+*Defined in [lib/source-destination/zip.ts:425](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L425)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -237,7 +237,7 @@ ___
 
 *Overrides [SourceDestination](sourcedestination.md).[_open](sourcedestination.md#protected-_open)*
 
-*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-source.ts#L26)*
+*Defined in [lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-source.ts#L26)*
 
 **Returns:** *Promise‹void›*
 
@@ -277,7 +277,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateReadStream](sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/zip.ts:381](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L381)*
+*Defined in [lib/source-destination/zip.ts:381](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L381)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -289,7 +289,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[canCreateSparseReadStream](sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/zip.ts:391](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L391)*
+*Defined in [lib/source-destination/zip.ts:391](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L391)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -301,7 +301,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateSparseWriteStream](sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -313,7 +313,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canCreateWriteStream](sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -325,7 +325,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canRead](sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L302)*
+*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L302)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -337,7 +337,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[canWrite](sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -349,7 +349,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[close](sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -361,7 +361,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createReadStream](sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/zip.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L396)*
+*Defined in [lib/source-destination/zip.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L396)*
 
 **Parameters:**
 
@@ -385,7 +385,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[createSparseReadStream](sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/zip.ts:412](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L412)*
+*Defined in [lib/source-destination/zip.ts:412](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L412)*
 
 **Parameters:**
 
@@ -407,7 +407,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createSparseWriteStream](sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -427,7 +427,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createVerifier](sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -446,7 +446,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[createWriteStream](sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -501,7 +501,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getAlignment](sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -513,7 +513,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getBlocks](sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](../interfaces/blockswithchecksum.md)[]›*
 
@@ -525,7 +525,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getInnerSource](sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](sourcedestination.md)›*
 
@@ -551,7 +551,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getMetadata](sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](../interfaces/metadata.md)›*
 
@@ -563,7 +563,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[getPartitionTable](sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -699,7 +699,7 @@ ___
 
 *Overrides [SourceSource](sourcesource.md).[open](sourcesource.md#open)*
 
-*Defined in [lib/source-destination/zip.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L386)*
+*Defined in [lib/source-destination/zip.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L386)*
 
 **Returns:** *Promise‹void›*
 
@@ -709,7 +709,7 @@ ___
 
 ▸ **prepare**(): *Promise‹void›*
 
-*Defined in [lib/source-destination/zip.ts:373](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/zip.ts#L373)*
+*Defined in [lib/source-destination/zip.ts:373](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/zip.ts#L373)*
 
 **Returns:** *Promise‹void›*
 
@@ -797,7 +797,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[read](sourcesource.md#read)*
 
-*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L337)*
+*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L337)*
 
 **Parameters:**
 
@@ -886,7 +886,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[write](sourcesource.md#write)*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -928,7 +928,7 @@ ___
 
 *Inherited from [SourceSource](sourcesource.md).[register](sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/interfaces/adaptersourcedestination.md
+++ b/doc/interfaces/adaptersourcedestination.md
@@ -12,6 +12,7 @@
 
 * [BlockDevice](../classes/blockdevice.md)
 * [DriverlessDevice](../classes/driverlessdevice.md)
+* [UsbBBbootDrive](../classes/usbbbbootdrive.md)
 * [UsbbootDrive](../classes/usbbootdrive.md)
 
 ## Index
@@ -79,7 +80,7 @@
 
 • **description**: *string*
 
-*Defined in [lib/scanner/adapters/adapter.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/adapter.ts#L27)*
+*Defined in [lib/scanner/adapters/adapter.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/adapter.ts#L27)*
 
 ___
 
@@ -87,7 +88,7 @@ ___
 
 • **device**: *string | null*
 
-*Defined in [lib/scanner/adapters/adapter.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/adapter.ts#L24)*
+*Defined in [lib/scanner/adapters/adapter.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/adapter.ts#L24)*
 
 ___
 
@@ -95,7 +96,7 @@ ___
 
 • **devicePath**: *string | null*
 
-*Defined in [lib/scanner/adapters/adapter.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/adapter.ts#L25)*
+*Defined in [lib/scanner/adapters/adapter.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/adapter.ts#L25)*
 
 ___
 
@@ -103,7 +104,7 @@ ___
 
 • **emitsProgress**: *boolean*
 
-*Defined in [lib/scanner/adapters/adapter.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/adapter.ts#L30)*
+*Defined in [lib/scanner/adapters/adapter.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/adapter.ts#L30)*
 
 ___
 
@@ -111,7 +112,7 @@ ___
 
 • **isSystem**: *boolean*
 
-*Defined in [lib/scanner/adapters/adapter.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/adapter.ts#L26)*
+*Defined in [lib/scanner/adapters/adapter.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/adapter.ts#L26)*
 
 ___
 
@@ -119,7 +120,7 @@ ___
 
 • **mountpoints**: *Array‹object›*
 
-*Defined in [lib/scanner/adapters/adapter.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/adapter.ts#L28)*
+*Defined in [lib/scanner/adapters/adapter.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/adapter.ts#L28)*
 
 ___
 
@@ -127,7 +128,7 @@ ___
 
 • **raw**: *string | null*
 
-*Defined in [lib/scanner/adapters/adapter.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/adapter.ts#L23)*
+*Defined in [lib/scanner/adapters/adapter.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/adapter.ts#L23)*
 
 ___
 
@@ -135,7 +136,7 @@ ___
 
 • **size**: *number | null*
 
-*Defined in [lib/scanner/adapters/adapter.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/adapter.ts#L29)*
+*Defined in [lib/scanner/adapters/adapter.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/adapter.ts#L29)*
 
 ___
 
@@ -166,7 +167,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[imageExtensions](../classes/sourcesource.md#static-readonly-imageextensions)*
 
-*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L274)*
+*Defined in [lib/source-destination/source-destination.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L274)*
 
 ___
 
@@ -176,7 +177,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[mimetype](../classes/sourcesource.md#static-optional-readonly-mimetype)*
 
-*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L286)*
+*Defined in [lib/source-destination/source-destination.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L286)*
 
 ## Methods
 
@@ -186,7 +187,7 @@ ___
 
 *Inherited from [SourceDestination](../classes/sourcedestination.md).[_close](../classes/sourcedestination.md#protected-_close)*
 
-*Defined in [lib/source-destination/source-destination.ts:401](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L401)*
+*Defined in [lib/source-destination/source-destination.ts:401](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L401)*
 
 **Returns:** *Promise‹void›*
 
@@ -198,7 +199,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[_getMetadata](../classes/sourcesource.md#protected-_getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L333)*
+*Defined in [lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L333)*
 
 **Returns:** *Promise‹[Metadata](metadata.md)›*
 
@@ -210,7 +211,7 @@ ___
 
 *Inherited from [SourceDestination](../classes/sourcedestination.md).[_open](../classes/sourcedestination.md#protected-_open)*
 
-*Defined in [lib/source-destination/source-destination.ts:397](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L397)*
+*Defined in [lib/source-destination/source-destination.ts:397](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L397)*
 
 **Returns:** *Promise‹void›*
 
@@ -250,7 +251,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[canCreateReadStream](../classes/sourcesource.md#cancreatereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:310](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L310)*
+*Defined in [lib/source-destination/source-destination.ts:310](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L310)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -262,7 +263,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[canCreateSparseReadStream](../classes/sourcesource.md#cancreatesparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L314)*
+*Defined in [lib/source-destination/source-destination.ts:314](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L314)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -274,7 +275,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[canCreateSparseWriteStream](../classes/sourcesource.md#cancreatesparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L322)*
+*Defined in [lib/source-destination/source-destination.ts:322](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L322)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -286,7 +287,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[canCreateWriteStream](../classes/sourcesource.md#cancreatewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L318)*
+*Defined in [lib/source-destination/source-destination.ts:318](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L318)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -298,7 +299,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[canRead](../classes/sourcesource.md#canread)*
 
-*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L302)*
+*Defined in [lib/source-destination/source-destination.ts:302](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L302)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -310,7 +311,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[canWrite](../classes/sourcesource.md#canwrite)*
 
-*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L306)*
+*Defined in [lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L306)*
 
 **Returns:** *Promise‹boolean›*
 
@@ -322,7 +323,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[close](../classes/sourcesource.md#close)*
 
-*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L390)*
+*Defined in [lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L390)*
 
 **Returns:** *Promise‹void›*
 
@@ -334,7 +335,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[createReadStream](../classes/sourcesource.md#createreadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:355](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L355)*
+*Defined in [lib/source-destination/source-destination.ts:355](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L355)*
 
 **Parameters:**
 
@@ -352,7 +353,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[createSparseReadStream](../classes/sourcesource.md#createsparsereadstream)*
 
-*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L361)*
+*Defined in [lib/source-destination/source-destination.ts:361](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L361)*
 
 **Parameters:**
 
@@ -370,7 +371,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[createSparseWriteStream](../classes/sourcesource.md#createsparsewritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L377)*
+*Defined in [lib/source-destination/source-destination.ts:377](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L377)*
 
 **Parameters:**
 
@@ -390,7 +391,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[createVerifier](../classes/sourcesource.md#createverifier)*
 
-*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L405)*
+*Defined in [lib/source-destination/source-destination.ts:405](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L405)*
 
 **Parameters:**
 
@@ -409,7 +410,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[createWriteStream](../classes/sourcesource.md#createwritestream)*
 
-*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L371)*
+*Defined in [lib/source-destination/source-destination.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L371)*
 
 **Parameters:**
 
@@ -464,7 +465,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[getAlignment](../classes/sourcesource.md#getalignment)*
 
-*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L298)*
+*Defined in [lib/source-destination/source-destination.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L298)*
 
 **Returns:** *number | undefined*
 
@@ -476,7 +477,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[getBlocks](../classes/sourcesource.md#getblocks)*
 
-*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L367)*
+*Defined in [lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L367)*
 
 **Returns:** *Promise‹[BlocksWithChecksum](blockswithchecksum.md)[]›*
 
@@ -488,7 +489,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[getInnerSource](../classes/sourcesource.md#getinnersource)*
 
-*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L475)*
+*Defined in [lib/source-destination/source-destination.ts:475](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L475)*
 
 **Returns:** *Promise‹[SourceDestination](../classes/sourcedestination.md)›*
 
@@ -514,7 +515,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[getMetadata](../classes/sourcesource.md#getmetadata)*
 
-*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L326)*
+*Defined in [lib/source-destination/source-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L326)*
 
 **Returns:** *Promise‹[Metadata](metadata.md)›*
 
@@ -526,7 +527,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[getPartitionTable](../classes/sourcesource.md#getpartitiontable)*
 
-*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L496)*
+*Defined in [lib/source-destination/source-destination.ts:496](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L496)*
 
 **Returns:** *Promise‹GetPartitionsResult | undefined›*
 
@@ -662,7 +663,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[open](../classes/sourcesource.md#open)*
 
-*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L383)*
+*Defined in [lib/source-destination/source-destination.ts:383](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L383)*
 
 **Returns:** *Promise‹void›*
 
@@ -750,7 +751,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[read](../classes/sourcesource.md#read)*
 
-*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L337)*
+*Defined in [lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L337)*
 
 **Parameters:**
 
@@ -839,7 +840,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[write](../classes/sourcesource.md#write)*
 
-*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L346)*
+*Defined in [lib/source-destination/source-destination.ts:346](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L346)*
 
 **Parameters:**
 
@@ -881,7 +882,7 @@ ___
 
 *Inherited from [SourceSource](../classes/sourcesource.md).[register](../classes/sourcesource.md#static-register)*
 
-*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L292)*
+*Defined in [lib/source-destination/source-destination.ts:292](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L292)*
 
 **Parameters:**
 

--- a/doc/interfaces/alignedlockablebuffer.md
+++ b/doc/interfaces/alignedlockablebuffer.md
@@ -176,7 +176,7 @@ ___
 
 • **alignment**: *number*
 
-*Defined in [lib/aligned-lockable-buffer.ts:5](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/aligned-lockable-buffer.ts#L5)*
+*Defined in [lib/aligned-lockable-buffer.ts:5](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/aligned-lockable-buffer.ts#L5)*
 
 ___
 
@@ -242,7 +242,7 @@ ___
 
 • **lock**: *function*
 
-*Defined in [lib/aligned-lockable-buffer.ts:6](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/aligned-lockable-buffer.ts#L6)*
+*Defined in [lib/aligned-lockable-buffer.ts:6](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/aligned-lockable-buffer.ts#L6)*
 
 #### Type declaration:
 
@@ -254,7 +254,7 @@ ___
 
 • **rlock**: *function*
 
-*Defined in [lib/aligned-lockable-buffer.ts:7](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/aligned-lockable-buffer.ts#L7)*
+*Defined in [lib/aligned-lockable-buffer.ts:7](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/aligned-lockable-buffer.ts#L7)*
 
 #### Type declaration:
 
@@ -268,7 +268,7 @@ ___
 
 *Overrides void*
 
-*Defined in [lib/aligned-lockable-buffer.ts:8](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/aligned-lockable-buffer.ts#L8)*
+*Defined in [lib/aligned-lockable-buffer.ts:8](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/aligned-lockable-buffer.ts#L8)*
 
 #### Type declaration:
 

--- a/doc/interfaces/awscredentials.md
+++ b/doc/interfaces/awscredentials.md
@@ -20,7 +20,7 @@
 
 • **accessKeyId**: *string*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L36)*
+*Defined in [lib/source-destination/balena-s3-source.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L36)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **secretAccessKey**: *string*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L37)*
+*Defined in [lib/source-destination/balena-s3-source.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L37)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **sessionToken**? : *undefined | string*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L38)*
+*Defined in [lib/source-destination/balena-s3-source.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L38)*

--- a/doc/interfaces/balenas3compressedsourceoptions.md
+++ b/doc/interfaces/balenas3compressedsourceoptions.md
@@ -31,7 +31,7 @@
 
 *Inherited from [BalenaS3SourceOptions](balenas3sourceoptions.md).[awsCredentials](balenas3sourceoptions.md#optional-awscredentials)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L48)*
+*Defined in [lib/source-destination/balena-s3-source.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L48)*
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 *Inherited from [BalenaS3SourceOptions](balenas3sourceoptions.md).[bucket](balenas3sourceoptions.md#bucket)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L43)*
+*Defined in [lib/source-destination/balena-s3-source.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L43)*
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 *Inherited from [BalenaS3SourceOptions](balenas3sourceoptions.md).[buildId](balenas3sourceoptions.md#buildid)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L46)*
+*Defined in [lib/source-destination/balena-s3-source.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L46)*
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 • **configuration**? : *[Dictionary](dictionary.md)‹any›*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L41)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L41)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 *Inherited from [BalenaS3SourceOptions](balenas3sourceoptions.md).[deviceType](balenas3sourceoptions.md#devicetype)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L45)*
+*Defined in [lib/source-destination/balena-s3-source.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L45)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 • **filenamePrefix**? : *undefined | string*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L40)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L40)*
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 • **format**: *"zip" | "gzip"*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L39)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L39)*
 
 ___
 
@@ -95,7 +95,7 @@ ___
 
 *Inherited from [BalenaS3SourceOptions](balenas3sourceoptions.md).[host](balenas3sourceoptions.md#host)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L42)*
+*Defined in [lib/source-destination/balena-s3-source.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L42)*
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 *Inherited from [BalenaS3SourceOptions](balenas3sourceoptions.md).[prefix](balenas3sourceoptions.md#optional-prefix)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L44)*
+*Defined in [lib/source-destination/balena-s3-source.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L44)*
 
 ___
 
@@ -115,4 +115,4 @@ ___
 
 *Inherited from [BalenaS3SourceOptions](balenas3sourceoptions.md).[release](balenas3sourceoptions.md#optional-release)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L47)*
+*Defined in [lib/source-destination/balena-s3-source.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L47)*

--- a/doc/interfaces/balenas3sourceoptions.md
+++ b/doc/interfaces/balenas3sourceoptions.md
@@ -26,7 +26,7 @@
 
 • **awsCredentials**? : *[AwsCredentials](awscredentials.md)*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L48)*
+*Defined in [lib/source-destination/balena-s3-source.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L48)*
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 • **bucket**: *string*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L43)*
+*Defined in [lib/source-destination/balena-s3-source.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L43)*
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 • **buildId**: *string*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L46)*
+*Defined in [lib/source-destination/balena-s3-source.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L46)*
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 • **deviceType**: *string*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L45)*
+*Defined in [lib/source-destination/balena-s3-source.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L45)*
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 • **host**: *string*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L42)*
+*Defined in [lib/source-destination/balena-s3-source.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L42)*
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 • **prefix**? : *undefined | string*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L44)*
+*Defined in [lib/source-destination/balena-s3-source.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L44)*
 
 ___
 
@@ -74,4 +74,4 @@ ___
 
 • **release**? : *undefined | string*
 
-*Defined in [lib/source-destination/balena-s3-source.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-source.ts#L47)*
+*Defined in [lib/source-destination/balena-s3-source.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-source.ts#L47)*

--- a/doc/interfaces/block.md
+++ b/doc/interfaces/block.md
@@ -19,7 +19,7 @@
 
 • **length**: *number*
 
-*Defined in [lib/sparse-stream/shared.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L34)*
+*Defined in [lib/sparse-stream/shared.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L34)*
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 • **offset**: *number*
 
-*Defined in [lib/sparse-stream/shared.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L33)*
+*Defined in [lib/sparse-stream/shared.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L33)*

--- a/doc/interfaces/blockswithchecksum.md
+++ b/doc/interfaces/blockswithchecksum.md
@@ -20,7 +20,7 @@
 
 • **blocks**: *[Block](block.md)[]*
 
-*Defined in [lib/sparse-stream/shared.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L40)*
+*Defined in [lib/sparse-stream/shared.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L40)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **checksum**? : *undefined | string*
 
-*Defined in [lib/sparse-stream/shared.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L39)*
+*Defined in [lib/sparse-stream/shared.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L39)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **checksumType**? : *[ChecksumType](../README.md#checksumtype)*
 
-*Defined in [lib/sparse-stream/shared.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L38)*
+*Defined in [lib/sparse-stream/shared.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L38)*

--- a/doc/interfaces/copyoperation.md
+++ b/doc/interfaces/copyoperation.md
@@ -21,7 +21,7 @@
 
 • **command**: *"copy"*
 
-*Defined in [lib/source-destination/configured-source/configure.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configure.ts#L36)*
+*Defined in [lib/source-destination/configured-source/configure.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configure.ts#L36)*
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 • **from**: *[FileOnPartition](fileonpartition.md)*
 
-*Defined in [lib/source-destination/configured-source/configure.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configure.ts#L37)*
+*Defined in [lib/source-destination/configured-source/configure.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configure.ts#L37)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **to**: *[FileOnPartition](fileonpartition.md)*
 
-*Defined in [lib/source-destination/configured-source/configure.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configure.ts#L38)*
+*Defined in [lib/source-destination/configured-source/configure.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configure.ts#L38)*
 
 ___
 
@@ -45,4 +45,4 @@ ___
 
 • **when**: *[Dictionary](dictionary.md)‹string›*
 
-*Defined in [lib/source-destination/configured-source/configure.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configure.ts#L39)*
+*Defined in [lib/source-destination/configured-source/configure.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configure.ts#L39)*

--- a/doc/interfaces/createreadstreamoptions.md
+++ b/doc/interfaces/createreadstreamoptions.md
@@ -22,7 +22,7 @@
 
 • **alignment**? : *undefined | number*
 
-*Defined in [lib/source-destination/source-destination.ts:263](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L263)*
+*Defined in [lib/source-destination/source-destination.ts:263](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L263)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • **emitProgress**? : *undefined | false | true*
 
-*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L260)*
+*Defined in [lib/source-destination/source-destination.ts:260](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L260)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • **end**? : *undefined | number*
 
-*Defined in [lib/source-destination/source-destination.ts:262](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L262)*
+*Defined in [lib/source-destination/source-destination.ts:262](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L262)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • **numBuffers**? : *undefined | number*
 
-*Defined in [lib/source-destination/source-destination.ts:264](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L264)*
+*Defined in [lib/source-destination/source-destination.ts:264](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L264)*
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 • **start**? : *undefined | number*
 
-*Defined in [lib/source-destination/source-destination.ts:261](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L261)*
+*Defined in [lib/source-destination/source-destination.ts:261](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L261)*

--- a/doc/interfaces/createsparsereadstreamoptions.md
+++ b/doc/interfaces/createsparsereadstreamoptions.md
@@ -20,7 +20,7 @@
 
 • **alignment**? : *undefined | number*
 
-*Defined in [lib/source-destination/source-destination.ts:269](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L269)*
+*Defined in [lib/source-destination/source-destination.ts:269](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L269)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **generateChecksums**? : *undefined | false | true*
 
-*Defined in [lib/source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L268)*
+*Defined in [lib/source-destination/source-destination.ts:268](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L268)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **numBuffers**? : *undefined | number*
 
-*Defined in [lib/source-destination/source-destination.ts:270](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/source-destination.ts#L270)*
+*Defined in [lib/source-destination/source-destination.ts:270](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/source-destination.ts#L270)*

--- a/doc/interfaces/devicetypejson.md
+++ b/doc/interfaces/devicetypejson.md
@@ -19,7 +19,7 @@
 
 • **configuration**: *object*
 
-*Defined in [lib/source-destination/configured-source/configure.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configure.ts#L43)*
+*Defined in [lib/source-destination/configured-source/configure.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configure.ts#L43)*
 
 #### Type declaration:
 
@@ -33,7 +33,7 @@ ___
 
 • **yocto**: *object*
 
-*Defined in [lib/source-destination/configured-source/configure.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configure.ts#L47)*
+*Defined in [lib/source-destination/configured-source/configure.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configure.ts#L47)*
 
 #### Type declaration:
 

--- a/doc/interfaces/drivelistdrive.md
+++ b/doc/interfaces/drivelistdrive.md
@@ -102,7 +102,7 @@ ___
 
 • **displayName**: *string*
 
-*Defined in [lib/scanner/adapters/block-device.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L59)*
+*Defined in [lib/scanner/adapters/block-device.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L59)*
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 • **icon**? : *undefined | string*
 
-*Defined in [lib/scanner/adapters/block-device.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/scanner/adapters/block-device.ts#L60)*
+*Defined in [lib/scanner/adapters/block-device.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/scanner/adapters/block-device.ts#L60)*
 
 ___
 

--- a/doc/interfaces/execresult.md
+++ b/doc/interfaces/execresult.md
@@ -19,7 +19,7 @@
 
 • **stderr**: *string*
 
-*Defined in [lib/diskpart.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/diskpart.ts#L34)*
+*Defined in [lib/diskpart.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/diskpart.ts#L34)*
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 • **stdout**: *string*
 
-*Defined in [lib/diskpart.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/diskpart.ts#L33)*
+*Defined in [lib/diskpart.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/diskpart.ts#L33)*

--- a/doc/interfaces/fileonpartition.md
+++ b/doc/interfaces/fileonpartition.md
@@ -20,7 +20,7 @@
 
 • **image**? : *undefined | string*
 
-*Defined in [lib/source-destination/configured-source/configure.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configure.ts#L31)*
+*Defined in [lib/source-destination/configured-source/configure.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configure.ts#L31)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **partition**? : *[Partition](../README.md#partition)*
 
-*Defined in [lib/source-destination/configured-source/configure.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configure.ts#L30)*
+*Defined in [lib/source-destination/configured-source/configure.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configure.ts#L30)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **path**: *string*
 
-*Defined in [lib/source-destination/configured-source/configure.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/configure.ts#L32)*
+*Defined in [lib/source-destination/configured-source/configure.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/configure.ts#L32)*

--- a/doc/interfaces/imagejsonpart.md
+++ b/doc/interfaces/imagejsonpart.md
@@ -22,7 +22,7 @@
 
 • **crc**: *number*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L30)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L30)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • **filename**: *string*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L29)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L29)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • **len**: *number*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L31)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L31)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • **partitionIndex**? : *undefined | string*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L33)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L33)*
 
 ___
 
@@ -54,4 +54,4 @@ ___
 
 • **zLen**: *number*
 
-*Defined in [lib/source-destination/balena-s3-compressed-source.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/balena-s3-compressed-source.ts#L32)*
+*Defined in [lib/source-destination/balena-s3-compressed-source.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/balena-s3-compressed-source.ts#L32)*

--- a/doc/interfaces/metadata.md
+++ b/doc/interfaces/metadata.md
@@ -40,7 +40,7 @@
 
 • **blockMap**? : *BlockMap*
 
-*Defined in [lib/source-destination/metadata.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L28)*
+*Defined in [lib/source-destination/metadata.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L28)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **blockmappedSize**? : *undefined | number*
 
-*Defined in [lib/source-destination/metadata.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L26)*
+*Defined in [lib/source-destination/metadata.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L26)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • **blocks**? : *[BlocksWithChecksum](blockswithchecksum.md)[]*
 
-*Defined in [lib/source-destination/metadata.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L29)*
+*Defined in [lib/source-destination/metadata.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L29)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • **bytesToZeroOutFromTheBeginning**? : *undefined | number*
 
-*Defined in [lib/source-destination/metadata.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L32)*
+*Defined in [lib/source-destination/metadata.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L32)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 • **checksum**? : *undefined | string*
 
-*Defined in [lib/source-destination/metadata.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L33)*
+*Defined in [lib/source-destination/metadata.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L33)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 • **checksumType**? : *undefined | string*
 
-*Defined in [lib/source-destination/metadata.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L34)*
+*Defined in [lib/source-destination/metadata.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L34)*
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 • **compressedSize**? : *undefined | number*
 
-*Defined in [lib/source-destination/metadata.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L25)*
+*Defined in [lib/source-destination/metadata.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L25)*
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 • **format**? : *"zip" | "gzip"*
 
-*Defined in [lib/source-destination/metadata.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L44)*
+*Defined in [lib/source-destination/metadata.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L44)*
 
 ___
 
@@ -104,7 +104,7 @@ ___
 
 • **instructions**? : *undefined | string*
 
-*Defined in [lib/source-destination/metadata.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L30)*
+*Defined in [lib/source-destination/metadata.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L30)*
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 • **isCompressed**? : *undefined | false | true*
 
-*Defined in [lib/source-destination/metadata.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L24)*
+*Defined in [lib/source-destination/metadata.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L24)*
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 • **isEtch**? : *undefined | false | true*
 
-*Defined in [lib/source-destination/metadata.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L40)*
+*Defined in [lib/source-destination/metadata.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L40)*
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 • **isSizeEstimated**? : *undefined | false | true*
 
-*Defined in [lib/source-destination/metadata.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L23)*
+*Defined in [lib/source-destination/metadata.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L23)*
 
 ___
 
@@ -136,7 +136,7 @@ ___
 
 • **lastModified**? : *Date*
 
-*Defined in [lib/source-destination/metadata.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L43)*
+*Defined in [lib/source-destination/metadata.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L43)*
 
 ___
 
@@ -144,7 +144,7 @@ ___
 
 • **logo**? : *undefined | string*
 
-*Defined in [lib/source-destination/metadata.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L31)*
+*Defined in [lib/source-destination/metadata.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L31)*
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 • **name**? : *undefined | string*
 
-*Defined in [lib/source-destination/metadata.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L27)*
+*Defined in [lib/source-destination/metadata.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L27)*
 
 ___
 
@@ -160,7 +160,7 @@ ___
 
 • **osVersion**? : *undefined | string*
 
-*Defined in [lib/source-destination/metadata.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L42)*
+*Defined in [lib/source-destination/metadata.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L42)*
 
 ___
 
@@ -168,7 +168,7 @@ ___
 
 • **recommendedDriveSize**? : *undefined | number*
 
-*Defined in [lib/source-destination/metadata.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L35)*
+*Defined in [lib/source-destination/metadata.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L35)*
 
 ___
 
@@ -176,7 +176,7 @@ ___
 
 • **releaseNotesUrl**? : *undefined | string*
 
-*Defined in [lib/source-destination/metadata.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L36)*
+*Defined in [lib/source-destination/metadata.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L36)*
 
 ___
 
@@ -184,7 +184,7 @@ ___
 
 • **size**? : *undefined | number*
 
-*Defined in [lib/source-destination/metadata.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L22)*
+*Defined in [lib/source-destination/metadata.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L22)*
 
 ___
 
@@ -192,7 +192,7 @@ ___
 
 • **supervisorVersion**? : *undefined | string*
 
-*Defined in [lib/source-destination/metadata.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L41)*
+*Defined in [lib/source-destination/metadata.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L41)*
 
 ___
 
@@ -200,7 +200,7 @@ ___
 
 • **supportUrl**? : *undefined | string*
 
-*Defined in [lib/source-destination/metadata.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L37)*
+*Defined in [lib/source-destination/metadata.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L37)*
 
 ___
 
@@ -208,7 +208,7 @@ ___
 
 • **url**? : *undefined | string*
 
-*Defined in [lib/source-destination/metadata.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L38)*
+*Defined in [lib/source-destination/metadata.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L38)*
 
 ___
 
@@ -216,4 +216,4 @@ ___
 
 • **version**? : *undefined | string*
 
-*Defined in [lib/source-destination/metadata.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/metadata.ts#L39)*
+*Defined in [lib/source-destination/metadata.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/metadata.ts#L39)*

--- a/doc/interfaces/multidestinationprogress.md
+++ b/doc/interfaces/multidestinationprogress.md
@@ -38,7 +38,7 @@
 
 *Inherited from [MultiDestinationState](multidestinationstate.md).[active](multidestinationstate.md#active)*
 
-*Defined in [lib/multi-write.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L48)*
+*Defined in [lib/multi-write.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L48)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • **averageSpeed**: *number*
 
-*Defined in [lib/multi-write.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L65)*
+*Defined in [lib/multi-write.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L65)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [MultiDestinationState](multidestinationstate.md).[blockmappedSize](multidestinationstate.md#optional-blockmappedsize)*
 
-*Defined in [lib/multi-write.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L53)*
+*Defined in [lib/multi-write.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L53)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • **bytes**: *number*
 
-*Defined in [lib/multi-write.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L62)*
+*Defined in [lib/multi-write.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L62)*
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 *Inherited from [MultiDestinationState](multidestinationstate.md).[bytesWritten](multidestinationstate.md#optional-byteswritten)*
 
-*Defined in [lib/multi-write.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L58)*
+*Defined in [lib/multi-write.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L58)*
 
 ___
 
@@ -84,7 +84,7 @@ ___
 
 *Inherited from [MultiDestinationState](multidestinationstate.md).[compressedSize](multidestinationstate.md#optional-compressedsize)*
 
-*Defined in [lib/multi-write.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L52)*
+*Defined in [lib/multi-write.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L52)*
 
 ___
 
@@ -92,7 +92,7 @@ ___
 
 • **eta**? : *undefined | number*
 
-*Defined in [lib/multi-write.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L67)*
+*Defined in [lib/multi-write.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L67)*
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 *Inherited from [MultiDestinationState](multidestinationstate.md).[failed](multidestinationstate.md#failed)*
 
-*Defined in [lib/multi-write.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L49)*
+*Defined in [lib/multi-write.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L49)*
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 • **percentage**? : *undefined | number*
 
-*Defined in [lib/multi-write.ts:66](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L66)*
+*Defined in [lib/multi-write.ts:66](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L66)*
 
 ___
 
@@ -118,7 +118,7 @@ ___
 
 • **position**: *number*
 
-*Defined in [lib/multi-write.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L63)*
+*Defined in [lib/multi-write.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L63)*
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 *Inherited from [MultiDestinationState](multidestinationstate.md).[rootStreamAverageSpeed](multidestinationstate.md#optional-rootstreamaveragespeed)*
 
-*Defined in [lib/multi-write.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L57)*
+*Defined in [lib/multi-write.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L57)*
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 *Inherited from [MultiDestinationState](multidestinationstate.md).[rootStreamPosition](multidestinationstate.md#optional-rootstreamposition)*
 
-*Defined in [lib/multi-write.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L55)*
+*Defined in [lib/multi-write.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L55)*
 
 ___
 
@@ -148,7 +148,7 @@ ___
 
 *Inherited from [MultiDestinationState](multidestinationstate.md).[rootStreamSpeed](multidestinationstate.md#optional-rootstreamspeed)*
 
-*Defined in [lib/multi-write.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L56)*
+*Defined in [lib/multi-write.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L56)*
 
 ___
 
@@ -158,7 +158,7 @@ ___
 
 *Inherited from [MultiDestinationState](multidestinationstate.md).[size](multidestinationstate.md#optional-size)*
 
-*Defined in [lib/multi-write.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L51)*
+*Defined in [lib/multi-write.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L51)*
 
 ___
 
@@ -168,7 +168,7 @@ ___
 
 *Inherited from [MultiDestinationState](multidestinationstate.md).[sparse](multidestinationstate.md#optional-sparse)*
 
-*Defined in [lib/multi-write.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L54)*
+*Defined in [lib/multi-write.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L54)*
 
 ___
 
@@ -176,7 +176,7 @@ ___
 
 • **speed**: *number*
 
-*Defined in [lib/multi-write.ts:64](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L64)*
+*Defined in [lib/multi-write.ts:64](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L64)*
 
 ___
 
@@ -186,4 +186,4 @@ ___
 
 *Inherited from [MultiDestinationState](multidestinationstate.md).[type](multidestinationstate.md#type)*
 
-*Defined in [lib/multi-write.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L50)*
+*Defined in [lib/multi-write.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L50)*

--- a/doc/interfaces/multidestinationstate.md
+++ b/doc/interfaces/multidestinationstate.md
@@ -30,7 +30,7 @@
 
 • **active**: *number*
 
-*Defined in [lib/multi-write.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L48)*
+*Defined in [lib/multi-write.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L48)*
 
 ___
 
@@ -38,7 +38,7 @@ ___
 
 • **blockmappedSize**? : *undefined | number*
 
-*Defined in [lib/multi-write.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L53)*
+*Defined in [lib/multi-write.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L53)*
 
 ___
 
@@ -46,7 +46,7 @@ ___
 
 • **bytesWritten**? : *undefined | number*
 
-*Defined in [lib/multi-write.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L58)*
+*Defined in [lib/multi-write.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L58)*
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 • **compressedSize**? : *undefined | number*
 
-*Defined in [lib/multi-write.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L52)*
+*Defined in [lib/multi-write.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L52)*
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 • **failed**: *number*
 
-*Defined in [lib/multi-write.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L49)*
+*Defined in [lib/multi-write.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L49)*
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 • **rootStreamAverageSpeed**? : *undefined | number*
 
-*Defined in [lib/multi-write.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L57)*
+*Defined in [lib/multi-write.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L57)*
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 • **rootStreamPosition**? : *undefined | number*
 
-*Defined in [lib/multi-write.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L55)*
+*Defined in [lib/multi-write.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L55)*
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 • **rootStreamSpeed**? : *undefined | number*
 
-*Defined in [lib/multi-write.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L56)*
+*Defined in [lib/multi-write.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L56)*
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 • **size**? : *undefined | number*
 
-*Defined in [lib/multi-write.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L51)*
+*Defined in [lib/multi-write.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L51)*
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 • **sparse**? : *undefined | false | true*
 
-*Defined in [lib/multi-write.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L54)*
+*Defined in [lib/multi-write.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L54)*
 
 ___
 
@@ -110,4 +110,4 @@ ___
 
 • **type**: *[WriteStep](../README.md#writestep)*
 
-*Defined in [lib/multi-write.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L50)*
+*Defined in [lib/multi-write.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L50)*

--- a/doc/interfaces/pipesourcetodestinationsresult.md
+++ b/doc/interfaces/pipesourcetodestinationsresult.md
@@ -20,7 +20,7 @@
 
 • **bytesWritten**: *number*
 
-*Defined in [lib/multi-write.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L79)*
+*Defined in [lib/multi-write.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L79)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **failures**: *Map‹[SourceDestination](../classes/sourcedestination.md), [Error](../classes/notcapable.md#static-error)›*
 
-*Defined in [lib/multi-write.ts:78](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L78)*
+*Defined in [lib/multi-write.ts:78](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L78)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **sourceMetadata**: *[Metadata](metadata.md)*
 
-*Defined in [lib/multi-write.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/multi-write.ts#L80)*
+*Defined in [lib/multi-write.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/multi-write.ts#L80)*

--- a/doc/interfaces/progressevent.md
+++ b/doc/interfaces/progressevent.md
@@ -21,7 +21,7 @@
 
 • **averageSpeed**: *number*
 
-*Defined in [lib/source-destination/progress.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/progress.ts#L30)*
+*Defined in [lib/source-destination/progress.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/progress.ts#L30)*
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 • **bytes**: *number*
 
-*Defined in [lib/source-destination/progress.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/progress.ts#L28)*
+*Defined in [lib/source-destination/progress.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/progress.ts#L28)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **position**: *number*
 
-*Defined in [lib/source-destination/progress.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/progress.ts#L27)*
+*Defined in [lib/source-destination/progress.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/progress.ts#L27)*
 
 ___
 
@@ -45,4 +45,4 @@ ___
 
 • **speed**: *number*
 
-*Defined in [lib/source-destination/progress.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/progress.ts#L29)*
+*Defined in [lib/source-destination/progress.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/progress.ts#L29)*

--- a/doc/interfaces/sourcetransform.md
+++ b/doc/interfaces/sourcetransform.md
@@ -140,7 +140,7 @@ ___
 
 • **sourceStream**: *ReadableStream*
 
-*Defined in [lib/source-destination/compressed-source.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/compressed-source.ts#L28)*
+*Defined in [lib/source-destination/compressed-source.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/compressed-source.ts#L28)*
 
 ___
 

--- a/doc/interfaces/sparsereadable.md
+++ b/doc/interfaces/sparsereadable.md
@@ -56,7 +56,7 @@
 
 • **blocks**: *[BlocksWithChecksum](blockswithchecksum.md)[]*
 
-*Defined in [lib/sparse-stream/shared.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L49)*
+*Defined in [lib/sparse-stream/shared.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L49)*
 
 ___
 
@@ -368,7 +368,7 @@ ___
 
 ▸ **push**(`chunk`: [SparseStreamChunk](sparsestreamchunk.md)): *boolean*
 
-*Defined in [lib/sparse-stream/shared.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L50)*
+*Defined in [lib/sparse-stream/shared.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L50)*
 
 **Parameters:**
 

--- a/doc/interfaces/sparsereaderstate.md
+++ b/doc/interfaces/sparsereaderstate.md
@@ -20,7 +20,7 @@
 
 • **block**: *[BlocksWithChecksum](blockswithchecksum.md)*
 
-*Defined in [lib/sparse-stream/shared.ts:78](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L78)*
+*Defined in [lib/sparse-stream/shared.ts:78](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L78)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **hasher**? : *[AnyHasher](../README.md#anyhasher)*
 
-*Defined in [lib/sparse-stream/shared.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L80)*
+*Defined in [lib/sparse-stream/shared.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L80)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **subBlock**: *[Block](block.md)*
 
-*Defined in [lib/sparse-stream/shared.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L79)*
+*Defined in [lib/sparse-stream/shared.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L79)*

--- a/doc/interfaces/sparsestreamchunk.md
+++ b/doc/interfaces/sparsestreamchunk.md
@@ -19,7 +19,7 @@
 
 • **buffer**: *[Buffer](alignedlockablebuffer.md#buffer) | [AlignedLockableBuffer](alignedlockablebuffer.md)*
 
-*Defined in [lib/sparse-stream/shared.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L44)*
+*Defined in [lib/sparse-stream/shared.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L44)*
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 • **position**: *number*
 
-*Defined in [lib/sparse-stream/shared.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L45)*
+*Defined in [lib/sparse-stream/shared.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L45)*

--- a/doc/interfaces/sparsewritable.md
+++ b/doc/interfaces/sparsewritable.md
@@ -56,7 +56,7 @@ Defined in node_modules/@types/node/globals.d.ts:588
 
 ▸ **_write**(`chunk`: [SparseStreamChunk](sparsestreamchunk.md), `encoding`: string, `callback`: function): *void*
 
-*Defined in [lib/sparse-stream/shared.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/sparse-stream/shared.ts#L54)*
+*Defined in [lib/sparse-stream/shared.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/sparse-stream/shared.ts#L54)*
 
 **Parameters:**
 

--- a/doc/interfaces/tmpfileoptions.md
+++ b/doc/interfaces/tmpfileoptions.md
@@ -20,7 +20,7 @@
 
 • **keepOpen**? : *undefined | false | true*
 
-*Defined in [lib/tmp.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/tmp.ts#L79)*
+*Defined in [lib/tmp.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/tmp.ts#L79)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **postfix**? : *undefined | string*
 
-*Defined in [lib/tmp.ts:81](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/tmp.ts#L81)*
+*Defined in [lib/tmp.ts:81](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/tmp.ts#L81)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **prefix**? : *undefined | string*
 
-*Defined in [lib/tmp.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/tmp.ts#L80)*
+*Defined in [lib/tmp.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/tmp.ts#L80)*

--- a/doc/interfaces/tmpfileresult.md
+++ b/doc/interfaces/tmpfileresult.md
@@ -19,7 +19,7 @@
 
 • **fileHandle**? : *fs.FileHandle*
 
-*Defined in [lib/tmp.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/tmp.ts#L36)*
+*Defined in [lib/tmp.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/tmp.ts#L36)*
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 • **path**: *string*
 
-*Defined in [lib/tmp.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/tmp.ts#L35)*
+*Defined in [lib/tmp.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/tmp.ts#L35)*

--- a/doc/interfaces/wificonfig.md
+++ b/doc/interfaces/wificonfig.md
@@ -23,7 +23,7 @@
 
 • **gateway**? : *undefined | string*
 
-*Defined in [lib/source-destination/configured-source/operations/configure.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/operations/configure.ts#L30)*
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/operations/configure.ts#L30)*
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 • **ip**? : *undefined | string*
 
-*Defined in [lib/source-destination/configured-source/operations/configure.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/operations/configure.ts#L28)*
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/operations/configure.ts#L28)*
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 • **netmask**? : *undefined | string*
 
-*Defined in [lib/source-destination/configured-source/operations/configure.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/operations/configure.ts#L29)*
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/operations/configure.ts#L29)*
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 • **routeMetric**? : *number | string*
 
-*Defined in [lib/source-destination/configured-source/operations/configure.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/operations/configure.ts#L27)*
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/operations/configure.ts#L27)*
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 • **wifiKey**? : *undefined | string*
 
-*Defined in [lib/source-destination/configured-source/operations/configure.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/operations/configure.ts#L26)*
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/operations/configure.ts#L26)*
 
 ___
 
@@ -63,4 +63,4 @@ ___
 
 • **wifiSsid**: *string*
 
-*Defined in [lib/source-destination/configured-source/operations/configure.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/58b0ba2/lib/source-destination/configured-source/operations/configure.ts#L25)*
+*Defined in [lib/source-destination/configured-source/operations/configure.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/d8a6f65/lib/source-destination/configured-source/operations/configure.ts#L25)*

--- a/examples/usb-bb-boot.ts
+++ b/examples/usb-bb-boot.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 balena.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import ProgressBar = require('progress');
+
+import { scanner, sourceDestination } from '../lib/';
+
+async function main() {
+	const adapters: scanner.adapters.Adapter[] = [
+		new scanner.adapters.UsbBBbootDeviceAdapter(),
+	];
+	const deviceScanner = new scanner.Scanner(adapters);
+	console.log('Waiting for one BeagleBone');
+	const beagleBone: sourceDestination.UsbBBbootDrive = await new Promise(
+		(resolve, reject) => {
+			function onAttach(drive: scanner.adapters.AdapterSourceDestination) {
+				if (drive instanceof sourceDestination.UsbBBbootDrive) {
+					deviceScanner.removeListener('attach', onAttach);
+					resolve(drive);
+				}
+			}
+			deviceScanner.on('attach', onAttach);
+			deviceScanner.on('error', reject);
+			deviceScanner.start();
+		},
+	);
+	console.log('BeagleBone attached');
+	const progressBar = new ProgressBar('converting to block device [:bar]', {
+		total: 100,
+		width: 40,
+	});
+	function onProgress(progress: number) {
+		const delta = Math.floor(progress) - progressBar.curr;
+		progressBar.tick(delta, {});
+	}
+	beagleBone.on('progress', onProgress);
+	// Wait until it is converted to a block device
+	await new Promise<void>((resolve, reject) => {
+		function onDetach(drive: scanner.adapters.AdapterSourceDestination) {
+			if (drive === beagleBone) {
+				deviceScanner.removeListener('detach', onDetach);
+				resolve();
+			}
+		}
+		deviceScanner.on('detach', onDetach);
+		deviceScanner.on('error', reject);
+	});
+	console.log('BeagleBone detached');
+	progressBar.terminate();
+	beagleBone.removeListener('progress', onProgress);
+	deviceScanner.stop();
+}
+
+main();

--- a/lib/scanner/adapters/index.ts
+++ b/lib/scanner/adapters/index.ts
@@ -16,5 +16,6 @@
 
 export * from './adapter';
 export * from './block-device';
+export * from './usb-bb-boot';
 export * from './usbboot';
 export * from './driverless';

--- a/lib/scanner/adapters/usb-bb-boot.ts
+++ b/lib/scanner/adapters/usb-bb-boot.ts
@@ -1,0 +1,44 @@
+import {
+	UsbBBbootDevice,
+	UsbBBbootScanner,
+} from '@balena/node-beaglebone-usbboot';
+
+import { UsbBBbootDrive } from '../../source-destination/usb-bb-boot';
+import { Adapter } from './adapter';
+
+export class UsbBBbootDeviceAdapter extends Adapter {
+	private drives: Map<UsbBBbootDevice, UsbBBbootDrive> = new Map();
+	private scanner: UsbBBbootScanner;
+
+	constructor() {
+		super();
+		this.scanner = new UsbBBbootScanner();
+		this.scanner.on('attach', this.onAttach.bind(this));
+		this.scanner.on('detach', this.onDetach.bind(this));
+		this.scanner.on('ready', this.emit.bind(this, 'ready'));
+		this.scanner.on('error', this.emit.bind(this, 'error'));
+	}
+
+	public start(): void {
+		this.scanner.start();
+	}
+
+	public stop(): void {
+		this.scanner.stop();
+	}
+
+	private onAttach(device: UsbBBbootDevice): void {
+		let drive = this.drives.get(device);
+		if (drive === undefined) {
+			drive = new UsbBBbootDrive(device);
+			this.drives.set(device, drive);
+		}
+		this.emit('attach', drive);
+	}
+
+	private onDetach(device: UsbBBbootDevice): void {
+		const drive = this.drives.get(device);
+		this.drives.delete(device);
+		this.emit('detach', drive);
+	}
+}

--- a/lib/source-destination/index.ts
+++ b/lib/source-destination/index.ts
@@ -31,6 +31,7 @@ export * from './balena-s3-compressed-source';
 export * from './source-destination';
 export * from './source-source';
 export * from './single-use-stream-source';
+export * from './usb-bb-boot';
 export * from './usbboot';
 export * from './xz';
 export * from './zip';

--- a/lib/source-destination/usb-bb-boot.ts
+++ b/lib/source-destination/usb-bb-boot.ts
@@ -1,0 +1,30 @@
+import { UsbBBbootDevice } from '@balena/node-beaglebone-usbboot';
+
+import { AdapterSourceDestination } from '../scanner/adapters/adapter';
+import { SourceDestination } from './source-destination';
+
+export class UsbBBbootDrive
+	extends SourceDestination
+	implements AdapterSourceDestination {
+	public raw = null;
+	public displayName = 'Initializing device';
+	public device = null;
+	public devicePath = null;
+	public icon = 'loading';
+	public isSystem = false;
+	public description = 'BeagleBone';
+	public mountpoints = [];
+	public isReadOnly = false;
+	public disabled = true;
+	public size = null;
+	public emitsProgress = true;
+	public progress: number = 0;
+
+	constructor(public usbDevice: UsbBBbootDevice) {
+		super();
+		usbDevice.on('progress', (value) => {
+			this.progress = value;
+			this.emit('progress', value);
+		});
+	}
+}

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "winusb-driver-generator": "^1.2.3"
   },
   "dependencies": {
+    "@balena/node-beaglebone-usbboot": "^1.0.3",
     "@balena/udif": "^1.1.1",
     "@ronomon/direct-io": "^3.0.1",
     "aws4-axios": "^2.0.1",


### PR DESCRIPTION
This branch is based on #127...it just modifies his code to use the Balena-owned npm module, `@balena/node-beaglebone-usbboot`, and makes a few minor changes including a rebase and deletion of the package-lock.json file.

Note: this probably shouldn't be merged until `@balena/node-beaglebone-usbboot` is made public.