### PR TITLE
prevent warning from linux partitions on windows

### DIFF
--- a/lib/source-destination/multi-destination.ts
+++ b/lib/source-destination/multi-destination.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { promisify } from 'util';
 import { spawn } from 'child_process';
 import { EventEmitter } from 'events';
 import { ReadResult, WriteResult } from 'file-disk';
@@ -33,6 +34,8 @@ import {
 	SourceDestination,
 	Verifier,
 } from './source-destination';
+
+const START_SHELLHWDETECTION_DELAY = 2000;
 
 function isntNull<T>(x: T | null): x is Exclude<T, null> {
 	return x !== null;
@@ -381,10 +384,8 @@ export class MultiDestination extends SourceDestination {
 		);
 
 		if (restartSHWD) {
-			await new Promise((res) => {
-				const cp = spawn('sc', ['start', 'ShellHWDetection']);
-				cp.on('exit', res);
-			})
+			promisify(setTimeout)(START_SHELLHWDETECTION_DELAY)
+				.then(() => spawn('sc', ['start', 'ShellHWDetection']));
 		}
 	}
 }


### PR DESCRIPTION
This pull request prevents the warnings as mentioned in https://github.com/balena-io/etcher/issues/2210

This has the downside of preventing the File Explorer from recognizing the partition labels of the drives, and it takes a little longer for the drives to be mounted.

This can be tested by inserting a flash drive into your USB port, finding the physical drive path, e.g.

```
ts-node ./examples/scanner.ts
```

Then flashing with a balena source image, e.g.

```
ts-node .\examples\multi-destination.ts C:\\path\to\src\img \\.\PhysicalDrive1
```

Change-type: minor