### PR TITLE
add support for basic auth

### DIFF
--- a/lib/source-destination/http.ts
+++ b/lib/source-destination/http.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import axios, { AxiosInstance, AxiosResponse } from 'axios';
+import axios, { AxiosBasicCredentials, AxiosInstance, AxiosResponse } from 'axios';
 // Always use the node adapter (even in a browser)
 // @ts-ignore
 import * as axiosNodeAdapter from 'axios/lib/adapters/http';
@@ -47,15 +47,20 @@ export class Http extends SourceDestination {
 		url,
 		avoidRandomAccess = false,
 		axiosInstance = axios.create(),
+		auth,
 	}: {
 		url: string;
 		avoidRandomAccess?: boolean;
 		axiosInstance?: AxiosInstance;
+		auth?: AxiosBasicCredentials;
 	}) {
 		super();
 		this.url = url;
 		this.avoidRandomAccess = avoidRandomAccess;
 		this.axiosInstance = axiosInstance;
+		if (auth) {
+			this.axiosInstance.defaults.auth = auth;
+		}
 		this.ready = this.getInfo();
 	}
 


### PR DESCRIPTION
This adds support for basic auth required by https://github.com/balena-io/etcher/pull/3581.
The doc has not yet been created since it would change all the URLs to the wrong repository. How could this be resolved?

The reason for this change instead of using the `axiosInstance` property is that I did not want to introduce axios as another direct dependency to etcher. 