### PR TITLE
package: Update node-raspberrypi-usbboot module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2918,9 +2918,9 @@
       "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
     },
     "node-raspberrypi-usbboot": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/node-raspberrypi-usbboot/-/node-raspberrypi-usbboot-1.0.1.tgz",
-      "integrity": "sha512-/LePaswSLKsqtu8DIuvc3sx2DDWcjMa/zFwSTfmIoPJrZItbgKrjicSd1U/jhTtjFjIzBF7TzwypmE7YEhm/lA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/node-raspberrypi-usbboot/-/node-raspberrypi-usbboot-1.0.2.tgz",
+      "integrity": "sha512-ThIEZcpdIUEY17fZ+upXrTDK9gBQI2A9Oj1KQxXDqTiRxC1AvEg1z+v2s39ZqZHxQGVu69GzsIvOxLi7GdWI4A==",
       "requires": {
         "debug": "^4.1.1",
         "usb": "^1.7.2"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "gzip-stream": "^1.1.2",
     "lzma-native": "git+https://github.com/thundron/lzma-native.git",
     "mountutils": "^1.3.20",
-    "node-raspberrypi-usbboot": "^1.0.1",
+    "node-raspberrypi-usbboot": "^1.0.2",
     "outdent": "^0.7.0",
     "partitioninfo": "^6.0.2",
     "rwmutex": "^1.0.0",


### PR DESCRIPTION
node-raspberrypi-usbboot v1.02 switches to using
the latest revision of start.elf, from upstream
raspberrypi usbboot revision 14ea684, which fixes
custom RaspberryPis switcing to MSD mode.

Change-type: patch
Signed-off-by: Alexandru Costache alexandru@balena.io

Connects-to: https://github.com/balena-io-modules/node-raspberrypi-usbboot/pull/41