### PR TITLE
Support detecting unified and semver normalized ESR version schemes

### DIFF
--- a/lib/source-destination/balena-s3-source.ts
+++ b/lib/source-destination/balena-s3-source.ts
@@ -99,7 +99,7 @@ export abstract class BalenaS3SourceBase extends SourceDestination {
 	}
 
 	public static isESRVersion(buildId: string) {
-		return /^\d{4}\.\d{2}\.\d+\.(dev|prod)$/.test(buildId);
+		return /^\d{4}\.\d{1,2}\.\d+([.+](dev|prod))?$/.test(buildId);
 	}
 
 	private isESR() {

--- a/tests/utils.spec.ts
+++ b/tests/utils.spec.ts
@@ -20,6 +20,7 @@ import 'mocha';
 import { Readable } from 'stream';
 
 import { streamToBuffer } from '../lib/utils';
+import { BalenaS3SourceBase } from '../lib/source-destination/balena-s3-source';
 
 describe('utils', function () {
 	describe('streamToBuffer', function () {
@@ -58,6 +59,52 @@ describe('utils', function () {
 					return;
 				}
 				expect(false).to.equal(true);
+			});
+		});
+	});
+
+	describe('BalenaS3SourceBase', function () {
+		describe('isESRVersion', function () {
+			it('should return false for non-ESR versions following the original scheme', function () {
+				[
+					'2.7.8.dev',
+					'2.7.8.prod',
+					'2.80.3.0.dev',
+					'2.80.3.0.prod',
+				].forEach((v) => {
+					expect(BalenaS3SourceBase.isESRVersion(v)).to.be.false;
+				});
+			});
+
+			it('should return false for unified non-ESR versions', function () {
+				['2.88.4'].forEach((v) => {
+					expect(BalenaS3SourceBase.isESRVersion(v)).to.be.false;
+				});
+			});
+
+			it('should return true for ESR versions following the original scheme', function () {
+				['2020.04.0.prod', '2021.10.1.dev', '2021.10.1.prod'].forEach(
+					(v) => {
+						expect(BalenaS3SourceBase.isESRVersion(v)).to.be.true;
+					},
+				);
+			});
+
+			it('should return true for unified ESR versions', function () {
+				['2021.10.2', '2022.01.0'].forEach((v) => {
+					expect(BalenaS3SourceBase.isESRVersion(v)).to.be.true;
+				});
+			});
+
+			it('should return true for semver normalized ESR versions', function () {
+				[
+					'2020.4.0+prod',
+					'2020.10.1+dev',
+					'2020.10.1+prod',
+					'2022.1.0',
+				].forEach((v) => {
+					expect(BalenaS3SourceBase.isESRVersion(v)).to.be.true;
+				});
 			});
 		});
 	});


### PR DESCRIPTION
Change-type: minor
See: https://jel.ly.fish/improvement-combine-os-variants-0d96399a-660b-4d38-adca-f661378cb86e
See: https://www.flowdock.com/app/rulemotion/resin-devices/threads/391mdzJxZ_GI9c7HO7IriZAM0R-
Signed-off-by: Thodoris Greasidis <thodoris@balena.io>