### PR TITLE
compressed-source: add imageType property

### DIFF
--- a/lib/source-destination/balena-s3-compressed-source.ts
+++ b/lib/source-destination/balena-s3-compressed-source.ts
@@ -124,7 +124,7 @@ export class BalenaS3CompressedSource extends BalenaS3SourceBase {
 	}
 
 	private async getImageJSON(): Promise<ImageJSON> {
-		const imageJSON = (await this.download('image.json')).data;
+		const imageJSON = (await this.download(`image${this.imageSuffix}.json`)).data;
 		return imageJSON;
 	}
 
@@ -135,7 +135,7 @@ export class BalenaS3CompressedSource extends BalenaS3SourceBase {
 	private async getPartStream(
 		filename: string,
 	): Promise<NodeJS.ReadableStream> {
-		const response = await this.download(`compressed/${filename}`, 'stream');
+		const response = await this.download(`compressed${this.imageSuffix}/${filename}`, 'stream');
 		return response.data;
 	}
 

--- a/lib/source-destination/balena-s3-source.ts
+++ b/lib/source-destination/balena-s3-source.ts
@@ -45,6 +45,7 @@ export interface BalenaS3SourceOptions {
 	deviceType: string; // raspberry-pi
 	buildId: string; // 2.9.6+rev1.prod
 	release?: string; // 1344795
+	imageType?: string; // raw | flasher
 	awsCredentials?: AwsCredentials;
 }
 
@@ -55,6 +56,7 @@ export abstract class BalenaS3SourceBase extends SourceDestination {
 	public readonly deviceType: string;
 	public readonly buildId: string;
 	public readonly release?: string; // Only used for preloaded images
+	public readonly imageType?: string;
 	protected axiosInstance: AxiosInstance;
 	private static filesMissingFromPreloadedImages = [
 		'VERSION',
@@ -69,6 +71,7 @@ export abstract class BalenaS3SourceBase extends SourceDestination {
 		deviceType,
 		buildId,
 		release,
+		imageType,
 		awsCredentials,
 	}: BalenaS3SourceOptions) {
 		super();
@@ -86,12 +89,17 @@ export abstract class BalenaS3SourceBase extends SourceDestination {
 		this.deviceType = deviceType;
 		this.buildId = buildId;
 		this.release = release;
+		this.imageType = imageType;
 		this.axiosInstance = axios.create();
 		if (awsCredentials !== undefined) {
 			this.axiosInstance.interceptors.request.use(
 				aws4Interceptor({ service: 's3' }, awsCredentials),
 			);
 		}
+	}
+
+	protected get imageSuffix(): string {
+		return this.imageType ? `-${this.imageType}`: ''
 	}
 
 	public async canCreateReadStream(): Promise<boolean> {
@@ -152,7 +160,7 @@ export class BalenaS3Source extends BalenaS3SourceBase {
 			try {
 				await this.axiosInstance({
 					method: 'head',
-					url: this.getUrl(`image/${name}.img`),
+					url: this.getUrl(`image/${name}${this.imageSuffix}.img`),
 				});
 				return name;
 			} catch (error) {


### PR DESCRIPTION
This ties in with modifications to balena-yocto-scripts and balena-img
that allows for multiple explicitly labeled image types, such as raw and
flasher, to be uploaded with a suffix.

This change adds the imageType property to BalenaS3CompressedSource,
which is used by a getter to generate the suffix to retrieve the
relevant files.

Change-type: patch
See: https://jel.ly.fish/improvement-offer-raw-images-device-types-ce76d0f
Signed-off-by: Joseph Kogut <joseph@balena.io>