### PR TITLE
Delete node 10 npm build targets

### DIFF
--- a/.resinci.yml
+++ b/.resinci.yml
@@ -7,20 +7,20 @@ npm:
         - libudev-dev
       architecture: x86_64
       node_versions:
-        - "10"
         - "12"
         - "14"
         - "16"
+        - "18"
     - name: linux
       os: ubuntu
       packages:
         - libudev-dev
       architecture: x86
       node_versions:
-        - "10"
         - "12"
         - "14"
         - "16"
+        - "18"
     # - name: darwin
     #   os: macos
     #   packages:


### PR DESCRIPTION
Node 10 is EOL version since 2021-04-30

Closes: #235 

Change-type: minor
Signed-off-by: fisehara <harald@balena.io>