### PR TITLE
add arch in metadata

### DIFF
--- a/lib/source-destination/balena-s3-compressed-source.ts
+++ b/lib/source-destination/balena-s3-compressed-source.ts
@@ -108,6 +108,7 @@ export class BalenaS3CompressedSource extends BalenaS3SourceBase {
 			version: this.buildId,
 			name: this.filename,
 			format: this.format,
+			arch: this.deviceTypeJSON?.arch,
 		};
 	}
 

--- a/lib/source-destination/configured-source/configure.ts
+++ b/lib/source-destination/configured-source/configure.ts
@@ -47,6 +47,7 @@ export interface DeviceTypeJSON {
 	yocto: {
 		archive?: boolean;
 	};
+	arch: string
 }
 
 const MBR_LAST_PRIMARY_PARTITION = 4;

--- a/lib/source-destination/metadata.ts
+++ b/lib/source-destination/metadata.ts
@@ -42,4 +42,5 @@ export interface Metadata {
 	osVersion?: string;
 	lastModified?: Date;
 	format?: 'zip' | 'gzip';
+	arch?: string;
 }


### PR DESCRIPTION
This is the one !

This add `arch` to the metadata returned for a image source

change-type: patch