### PR TITLE
patch: use wasm-bz2 for bzip decompresison

### DIFF
--- a/lib/source-destination/compressed-source.ts
+++ b/lib/source-destination/compressed-source.ts
@@ -42,7 +42,7 @@ export function getRootStream(
 }
 
 export abstract class CompressedSource extends SourceSource {
-	protected abstract createTransform(): Transform;
+	protected abstract createTransform(): Transform | Promise<Transform>;
 
 	protected async getSize(): Promise<
 		{ size: number; isEstimated: boolean } | undefined
@@ -64,7 +64,7 @@ export abstract class CompressedSource extends SourceSource {
 		}
 		const stream = await this.source.createReadStream({ emitProgress });
 		// as any because we need to add the sourceStream property
-		const transform = this.createTransform() as any;
+		const transform = await this.createTransform() as any;
 		stream.pipe(transform);
 		transform.sourceStream = stream;
 		if (end !== undefined) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@balena/node-beaglebone-usbboot": "^3.0.0",
         "@balena/udif": "^1.1.2",
+        "@foxglove/wasm-bz2": "^0.1.1",
         "@ronomon/direct-io": "^3.0.1",
         "aws4-axios": "^2.4.9",
         "axios": "^0.27.0",
@@ -30,7 +31,6 @@
         "partitioninfo": "^6.0.2",
         "rwmutex": "^1.0.0",
         "tslib": "^2.0.0",
-        "unbzip2-stream": "github:balena-io-modules/unbzip2-stream#4a54f56a25b58950f9e4277c56db2912d62242e7",
         "unzip-stream": "^0.3.0",
         "xxhash-addon": "^1.4.0",
         "yauzl": "^2.9.2",
@@ -1177,6 +1177,14 @@
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
+      }
+    },
+    "node_modules/@foxglove/wasm-bz2": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@foxglove/wasm-bz2/-/wasm-bz2-0.1.1.tgz",
+      "integrity": "sha512-huMVZ//J9S1TAh689pj7U5tstbmtGhH1g9/HCj9jE3UPaLF83dTeJIOLE0+pe16ha1iH4QRvYgv35aykikHkvA==",
+      "dependencies": {
+        "tslib": "^2"
       }
     },
     "node_modules/@ronomon/direct-io": {
@@ -5111,12 +5119,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/unbzip2-stream": {
-      "version": "1.4.2",
-      "resolved": "git+ssh://git@github.com/balena-io-modules/unbzip2-stream.git#4a54f56a25b58950f9e4277c56db2912d62242e7",
-      "integrity": "sha512-brk1qgoQuqWAWifAFEyC7At0CZxuHL90kd3S2Sdmd1GrOcUGl2bey0Bu6MVc25xAXMz7WITNKD8hxyBpNmeOdg==",
-      "license": "MIT"
-    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -6431,6 +6433,14 @@
             "through": "^2.3.8"
           }
         }
+      }
+    },
+    "@foxglove/wasm-bz2": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@foxglove/wasm-bz2/-/wasm-bz2-0.1.1.tgz",
+      "integrity": "sha512-huMVZ//J9S1TAh689pj7U5tstbmtGhH1g9/HCj9jE3UPaLF83dTeJIOLE0+pe16ha1iH4QRvYgv35aykikHkvA==",
+      "requires": {
+        "tslib": "^2"
       }
     },
     "@ronomon/direct-io": {
@@ -9463,11 +9473,6 @@
       "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
       "dev": true,
       "optional": true
-    },
-    "unbzip2-stream": {
-      "version": "git+ssh://git@github.com/balena-io-modules/unbzip2-stream.git#4a54f56a25b58950f9e4277c56db2912d62242e7",
-      "integrity": "sha512-brk1qgoQuqWAWifAFEyC7At0CZxuHL90kd3S2Sdmd1GrOcUGl2bey0Bu6MVc25xAXMz7WITNKD8hxyBpNmeOdg==",
-      "from": "unbzip2-stream@github:balena-io-modules/unbzip2-stream#4a54f56a25b58950f9e4277c56db2912d62242e7"
     },
     "universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@balena/node-beaglebone-usbboot": "^3.0.0",
     "@balena/udif": "^1.1.2",
+    "@foxglove/wasm-bz2": "^0.1.1",
     "@ronomon/direct-io": "^3.0.1",
     "aws4-axios": "^2.4.9",
     "axios": "^0.27.0",
@@ -65,7 +66,6 @@
     "partitioninfo": "^6.0.2",
     "rwmutex": "^1.0.0",
     "tslib": "^2.0.0",
-    "unbzip2-stream": "github:balena-io-modules/unbzip2-stream#4a54f56a25b58950f9e4277c56db2912d62242e7",
     "unzip-stream": "^0.3.0",
     "xxhash-addon": "^1.4.0",
     "yauzl": "^2.9.2",


### PR DESCRIPTION
Use a wasm-based bzip2 decompression lib to replace our fork of a js lib.

This passes the bz2 tests faster than the old implementation but hasn't been tested on real/big files yet.

Note that having this working in etcher-sdk doesn't mean it will work in etcher :D
So far I couldn't build etcher with this.