### PR TITLE
Improvements to migration steps

### DIFF
--- a/lib/migrator/helpers.ts
+++ b/lib/migrator/helpers.ts
@@ -49,6 +49,27 @@ export const getPartitionBoundaries = async (
 };
 
 /**
+ * Calculate the size required for a partition to contain the contents of
+ * the provided source partition, rounded up to nearest MB.
+ * @param {SourceDestination} source - Device containing requested partition
+ * @param {number} partitionIndex - 1-based index of requested partition
+ * @returns calculated size in MB, rounded up
+ */
+export const calcRequiredPartitionSize = async (
+	source: SourceDestination,
+	partitionIndex = 1
+) => {
+	const sourceBoundaries = await getPartitionBoundaries(source, partitionIndex);
+	const sourcePartitionSize = sourceBoundaries.end! - sourceBoundaries.start!;
+	const alignmentBuffer = 4096;
+
+	if (isNaN(sourcePartitionSize)) {
+		throw Error("Not able to find source partition size.");
+	}
+	return Math.ceil((sourcePartitionSize + alignmentBuffer) / 1024 / 1024);
+}
+
+/**
  * Copy a partition, referenced by index, from an image file to a block device,
  * @param {File} source - source image for partition
  * @param {number} sourcePartitionIndex

--- a/lib/migrator/index.ts
+++ b/lib/migrator/index.ts
@@ -15,6 +15,7 @@ import { promisify } from 'util';
 import { exec as childExec } from 'child_process';
 const execAsync = promisify(childExec);
 import { constants as osConstants } from 'os';
+import { existsSync } from 'fs'
 
 /** Determine if running as administrator. */
 async function isElevated(): Promise<boolean> {
@@ -63,6 +64,9 @@ export const migrate = async (
 		}
 		if (!(await isElevated())) {
 			throw Error("User is not administrator");
+		}
+		if (!existsSync(imagePath)) {
+			throw Error(`Image ${imagePath} not found`);
 		}
 
 		const unallocSpace = await diskpart.getUnallocatedSize(deviceName)

--- a/lib/migrator/index.ts
+++ b/lib/migrator/index.ts
@@ -5,6 +5,7 @@ import * as diskpart from '../diskpart';
 import { File } from '../source-destination';
 import {
 	copyPartitionFromImageToDevice,
+	calcRequiredPartitionSize,
 	getTargetBlockDevice,
 	findNewPartitions
 } from './helpers';
@@ -51,9 +52,8 @@ export const migrate = async (
 ) => {
 	console.log(`Migrate ${deviceName} with image ${imagePath}`);
 	try {
-		const FREE_SPACE_NEEDED_MB = 5120
-		const BOOT_PARTITION_SIZE_MB = 47
-		const ROOTA_PARTITION_SIZE_MB = 3850
+		const BOOT_PARTITION_INDEX = 1;
+		const ROOTA_PARTITION_INDEX = 2;
 		const BOOT_FILES_SOURCE_PATH = '/EFI/BOOT';
 		const BOOT_FILES_TARGET_PATH = '/EFI/Boot';
 		const REBOOT_DELAY_SEC = 10
@@ -69,30 +69,37 @@ export const migrate = async (
 			throw Error(`Image ${imagePath} not found`);
 		}
 
-		const unallocSpace = await diskpart.getUnallocatedSize(deviceName)
-		console.log(`Found ${unallocSpace} KB not allocated on disk ${deviceName}`)
+		// determine required partition sizes and free space
+		const source = new File({ path: imagePath });
+		const requiredBootSize = await calcRequiredPartitionSize(source, BOOT_PARTITION_INDEX);
+		console.log(`Require ${requiredBootSize} MB for boot partition`);
+		const requiredRootASize = await calcRequiredPartitionSize(source, ROOTA_PARTITION_INDEX);
+		console.log(`Require ${requiredRootASize} MB for rootA partition`);
+		const requiredFreeSize = requiredBootSize + requiredRootASize;
+
+		const unallocSpace = (await diskpart.getUnallocatedSize(deviceName)) / 1024;
+		console.log(`Found ${unallocSpace} MB not allocated on disk ${deviceName}`)
 
 		// Shrink partition as needed to provide required unallocated space.
 		// Shrink amount must be for *all* of required space to ensure it is contiguous.
         // IOW, don't assume the shrink will merge with any existing unallocated space.
-		if (unallocSpace / 1024 < FREE_SPACE_NEEDED_MB) {
+		if (unallocSpace < requiredFreeSize) {
 			// must force upper case
 			const freeSpace = await checkDiskSpace(`${windowsPartition.toUpperCase()}:\\`)
-			if ((freeSpace.free / 1024 / 1024) < FREE_SPACE_NEEDED_MB) {
-				throw Error(`Need at least ${FREE_SPACE_NEEDED_MB} MB free on partition ${windowsPartition}`)
+			if ((freeSpace.free / 1024 / 1024) < requiredFreeSize) {
+				throw Error(`Need at least ${requiredFreeSize} MB free on partition ${windowsPartition}`)
 			}
-			console.log(`Shrink partition ${windowsPartition} by ${FREE_SPACE_NEEDED_MB} MB`);
-			await diskpart.shrinkPartition(windowsPartition, FREE_SPACE_NEEDED_MB);
+			console.log(`Shrink partition ${windowsPartition} by ${requiredFreeSize} MB`);
+			await diskpart.shrinkPartition(windowsPartition, requiredFreeSize);
 		}
 
 		// create partitions
 		// device from file, containing source partitions
-		const source = new File({ path: imagePath });
 		const targetDevice = await getTargetBlockDevice(windowsPartition)
 		const originalPartitions = await targetDevice.getPartitionTable()
 
 		console.log("Create flasherBootPartition");
-		await diskpart.createPartition(deviceName, BOOT_PARTITION_SIZE_MB);
+		await diskpart.createPartition(deviceName, requiredBootSize);
 		const afterFirstPartitions = await targetDevice.getPartitionTable()
 		const firstNewPartition = findNewPartitions(originalPartitions, afterFirstPartitions);
 		if (firstNewPartition.length !== 1) {
@@ -102,7 +109,7 @@ export const migrate = async (
 		console.log(`Created new partition for boot at offset ${targetBootPartition.offset} with size ${targetBootPartition.size}`);
 
 		console.log("Create flasherRootAPartition");
-		await diskpart.createPartition(deviceName, ROOTA_PARTITION_SIZE_MB);
+		await diskpart.createPartition(deviceName, requiredRootASize);
 		const afterSecondPartitions = await targetDevice.getPartitionTable()
 		const secondNewPartition = findNewPartitions(afterFirstPartitions, afterSecondPartitions)
 		if (secondNewPartition.length !== 1) {

--- a/lib/migrator/index.ts
+++ b/lib/migrator/index.ts
@@ -34,6 +34,10 @@ async function isElevated(): Promise<boolean> {
     return true;
 }
 
+function formatMB(bytes: number): string {
+	return (bytes / (1024 * 1024)).toFixed(2)
+}
+
 /**
  * @summary Sets up a UEFI based computer running Windows to switch to balenaOS, and then reboots to execute the switch.
  * !!! WARNING !!! Running this function will OVERWRITE AND DESTROY the operating system running on this computer.
@@ -69,16 +73,18 @@ export const migrate = async (
 			throw Error(`Image ${imagePath} not found`);
 		}
 
-		// determine required partition sizes and free space
+		// Determine required partition sizes and free space. Calculations are in
+        // units of bytes. However, on Windows, required sizes are rounded up to
+        // the nearest MB due to tool limitations.
 		const source = new File({ path: imagePath });
 		const requiredBootSize = await calcRequiredPartitionSize(source, BOOT_PARTITION_INDEX);
-		console.log(`Require ${requiredBootSize} MB for boot partition`);
+		console.log(`Require ${requiredBootSize} (${formatMB(requiredBootSize)} MB) for boot partition`);
 		const requiredRootASize = await calcRequiredPartitionSize(source, ROOTA_PARTITION_INDEX);
-		console.log(`Require ${requiredRootASize} MB for rootA partition`);
+		console.log(`Require ${requiredRootASize} (${formatMB(requiredRootASize)} MB) for rootA partition`);
 		const requiredFreeSize = requiredBootSize + requiredRootASize;
 
-		const unallocSpace = (await diskpart.getUnallocatedSize(deviceName)) / 1024;
-		console.log(`Found ${unallocSpace} MB not allocated on disk ${deviceName}`)
+		const unallocSpace = (await diskpart.getUnallocatedSize(deviceName)) * 1024;
+		console.log(`Found ${unallocSpace} (${formatMB(unallocSpace)} MB) not allocated on disk ${deviceName}`)
 
 		// Shrink partition as needed to provide required unallocated space.
 		// Shrink amount must be for *all* of required space to ensure it is contiguous.
@@ -86,11 +92,11 @@ export const migrate = async (
 		if (unallocSpace < requiredFreeSize) {
 			// must force upper case
 			const freeSpace = await checkDiskSpace(`${windowsPartition.toUpperCase()}:\\`)
-			if ((freeSpace.free / 1024 / 1024) < requiredFreeSize) {
-				throw Error(`Need at least ${requiredFreeSize} MB free on partition ${windowsPartition}`)
+			if (freeSpace.free < requiredFreeSize) {
+				throw Error(`Need at least ${requiredFreeSize} (${formatMB(requiredFreeSize)} MB) free on partition ${windowsPartition}`)
 			}
-			console.log(`Shrink partition ${windowsPartition} by ${requiredFreeSize} MB`);
-			await diskpart.shrinkPartition(windowsPartition, requiredFreeSize);
+			console.log(`Shrink partition ${windowsPartition} by ${requiredFreeSize} (${formatMB(requiredFreeSize)} MB)`);
+			await diskpart.shrinkPartition(windowsPartition, requiredFreeSize / (1024 * 1024));
 		}
 
 		// create partitions
@@ -99,7 +105,7 @@ export const migrate = async (
 		const originalPartitions = await targetDevice.getPartitionTable()
 
 		console.log("Create flasherBootPartition");
-		await diskpart.createPartition(deviceName, requiredBootSize);
+		await diskpart.createPartition(deviceName, requiredBootSize / (1024 * 1024));
 		const afterFirstPartitions = await targetDevice.getPartitionTable()
 		const firstNewPartition = findNewPartitions(originalPartitions, afterFirstPartitions);
 		if (firstNewPartition.length !== 1) {
@@ -109,7 +115,7 @@ export const migrate = async (
 		console.log(`Created new partition for boot at offset ${targetBootPartition.offset} with size ${targetBootPartition.size}`);
 
 		console.log("Create flasherRootAPartition");
-		await diskpart.createPartition(deviceName, requiredRootASize);
+		await diskpart.createPartition(deviceName, requiredRootASize / (1024 * 1024));
 		const afterSecondPartitions = await targetDevice.getPartitionTable()
 		const secondNewPartition = findNewPartitions(afterFirstPartitions, afterSecondPartitions)
 		if (secondNewPartition.length !== 1) {


### PR DESCRIPTION
User visible improvements:
* Determine required partition sizes by reading from the image file, rather than a hard coded size. Windows requires special consideration because the `lib/diskpart` interface (and the diskpart tool) require requests use an integral (whole) megabyte value.
* Ensure image file exists before starting

Internally the migrator steps now perform partition math in units of _bytes_, not MB. This approach is less error prone because values are always integers, and byte units is the default choice for most tools. This change exposes how we must convert bytes to/from other units to work with `lib/diskpart`. We intend to add functions that will allow us to use bytes from the migrator script, but then can adapt to tool/OS unit requirements.
