### PR TITLE
Migrator: allow re-run migration

### DIFF
--- a/lib/migrator/helpers.ts
+++ b/lib/migrator/helpers.ts
@@ -3,6 +3,8 @@ import * as drivelist from 'drivelist'
 import { GetPartitionsResult, GPTPartition, MBRPartition } from 'partitioninfo';
 import { BlockDevice, SourceDestination, File } from '../source-destination';
 
+export const MS_DATA_PARTITION_ID = 'EBD0A0A2-B9E5-4433-87C0-68B6B72699C7'
+
 /**
  * Finds partitions in newTable with a partition offset not found in oldTable.
  * Expects paritioninfo partition objects.
@@ -19,6 +21,53 @@ export const findNewPartitions = (
 	return (newTable.partitions as Array<GPTPartition | MBRPartition>).filter((n) => {
 		return !oldTable.partitions.some((o) => o.offset === n.offset)
 	})
+}
+
+/**
+ * Scans the filesystem on the partitions for the provided device for the filesystem
+ * label text, assuming the filesystem is the provided type.
+ *
+ * Partition type must be GPT.
+ * 
+ * @returns partition containing the label, or null if not found
+ */
+export const findFilesystemLabel = async (
+	table: GetPartitionsResult,
+	device: BlockDevice,
+	label: string,
+	fs: 'fat16' | 'ext4'
+): Promise<GPTPartition | MBRPartition | null> => {
+
+	if (table.type == 'mbr') {
+		throw Error("Can't read MBR table")
+	}
+	// Only check non-system partitions on Windows
+	let partitions = table.partitions
+	if (process.platform == 'win32') {
+		partitions = table.partitions.filter(p => p.type.toUpperCase() == MS_DATA_PARTITION_ID)
+	}
+	// Determine label offset
+	let offset = 0
+	if (fs == 'fat16') {
+		// https://en.wikipedia.org/wiki/Desian_of_the_FAT_file_system#Extended_BIOS_Parameter_Block
+		offset = 0x2B
+	} else if (fs == 'ext4') {
+		// https://www.kernel.org/doc/html/latest/filesystems/ext4/index.html
+		offset = 0x400 + 0x78
+	}
+
+	let buf = Buffer.alloc(label.length)
+	for (const p of partitions) {
+		// Satisfy TypeScript that p is not an MBRPartition even though we tested above on the table
+		if (! ('guid' in p)) {
+			continue
+		}
+		await device.read(buf, 0, buf.length, p.offset + offset)
+		if (buf.toString() == label) {
+			return p;
+		}
+	}
+	return null
 }
 
 /**


### PR DESCRIPTION
For the migrator, we wish to allow a user to re-run the migration in case it fails on the first run. We have implemented two features to allow this use case.

Segment the migration into these tasks:
1. analyze -- implicit task to determine what needs to be done; always performed
1. shrink -- shrink existing Windows partition as needed to accommodate the new partitions
1. copy -- create/copy partitions from image
1. bootloader -- copy/setup bootloader for new boot partition
1. reboot -- actually execute the reboot

This segmentation allows the migrator or the user to omit certain tasks. For example, we can create a `--analyze-only` command line option.

Scan for the required balenaOS flasher boot and root A partition already on the target device. Of course don't attempt to create if they already exist.