### PR TITLE
stop diskpart.clean() from breaking CLI  flash cmd

### DIFF
--- a/lib/diskpart.ts
+++ b/lib/diskpart.ts
@@ -109,9 +109,6 @@ const runDiskpart = async (commands: string[]): Promise<string> => {
  * @param {String} device
  */
 const prepareDeviceId = (device: string) => {
-	if (platform() !== 'win32') {
-		throw new Error(`Diskpart is not available on ${platform()}`);
-	}
 	const match = device.match(PATTERN);
 	if (match === null) {
 		throw new Error(`Invalid device: "${device}"`);
@@ -130,6 +127,10 @@ const prepareDeviceId = (device: string) => {
  */
 export const clean = async (device: string): Promise<void> => {
 	debug('clean', device);
+	if (platform() !== 'win32') {
+		return
+	}
+	
 	let deviceId;
 
 	try {


### PR DESCRIPTION
An attempt to prevent `balena local flash` from failing with `invalid device`. 

When the platform is not windows, the `prepareDeviceId()` function call inside `diskpart.clean()` throws an error, which is then caught by the try/catch in `clean()` - which then throws the `invalid device` error. `diskpart.clean()` is called every time a `blockDevice` instance is created - meaning that when on linux systems, the `invalid device` error appears. 

^ This is a theory btw and if its true then the PR may fix it , calling on @kb2ma to check this out as I may be wrong as I'm pretty unfamiliar with this codebase

Change-type: patch