### PR TITLE
patch: add ENV to allow listing virtual drive on Mac

### DIFF
--- a/lib/scanner/adapters/block-device.ts
+++ b/lib/scanner/adapters/block-device.ts
@@ -63,6 +63,7 @@ export interface DrivelistDrive extends $Drive {
 export class BlockDeviceAdapter extends Adapter {
 	// Emits 'attach', 'detach', 'ready' and 'error' events
 	public includeSystemDrives: () => boolean;
+	public includeVitualDrives: () => boolean;
 	private unmountOnSuccess: boolean;
 	private oWrite: boolean;
 	private oDirect: boolean;
@@ -72,17 +73,20 @@ export class BlockDeviceAdapter extends Adapter {
 
 	constructor({
 		includeSystemDrives = () => false,
+		includeVirtualDrives = () => false,
 		unmountOnSuccess = false,
 		write = false,
 		direct = true,
 	}: {
 		includeSystemDrives?: () => boolean;
+		includeVirtualDrives?: () => boolean;
 		unmountOnSuccess?: boolean;
 		write?: boolean;
 		direct?: boolean;
 	}) {
 		super();
 		this.includeSystemDrives = includeSystemDrives;
+		this.includeVitualDrives = includeVirtualDrives;
 		this.unmountOnSuccess = unmountOnSuccess;
 		this.oWrite = write;
 		this.oDirect = direct;
@@ -158,7 +162,7 @@ export class BlockDeviceAdapter extends Adapter {
 						// Exclude drives with no size
 						typeof drive.size === 'number' &&
 						// Exclude virtual drives (DMG, TimeMachine, ... on macOS)
-						!drive.isVirtual
+						(this.includeVitualDrives() || !drive.isVirtual)
 					)
 				)
 			) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "types": "build/index.d.ts",
   "scripts": {
-    "flowzone-preinstall": "sudo apt-get update && sudo apt-get install -y libudev-dev",
+    "flowzone-preinstall": "wget -qO- https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add - && sudo apt-get update && sudo apt-get install -y libudev-dev",
     "test": "npm run lint && mocha -r ts-node/register tests/**/*.spec.ts",
     "prettier": "balena-lint --fix lib typings examples tests",
     "lint": "balena-lint lib typings examples",


### PR DESCRIPTION
This adds a hidden feature (behind the `ETCHER_ALLLOW_VIRTUAL_DRIVE` ENV feature flag), to allow flashing virtual drives on mac.

Create and attach a virtual drive with:
```
hdiutil create -size 4096m -layout NONE -o virtual_disk.dmg
hdiutil attach -nomount virtual_disk.dmg
```

Then you can use it for development, testing, and future E2E automated tests.