### PR TITLE
patch: use http2 to fix issues with url source

### DIFF
--- a/lib/source-destination/http.ts
+++ b/lib/source-destination/http.ts
@@ -23,7 +23,7 @@ import { ReadResult } from 'file-disk';
 import { basename } from 'path';
 import { unescape } from 'querystring';
 import { parse } from 'url';
-
+import { createHTTP2Adapter } from 'axios-http2-adapter';
 import { StreamLimiter } from '../stream-limiter';
 import { Metadata } from './metadata';
 import {
@@ -60,6 +60,7 @@ export class Http extends SourceDestination {
 		if (auth) {
 			this.axiosInstance.defaults.auth = auth;
 		}
+		this.axiosInstance.defaults.adapter = createHTTP2Adapter();
 		this.ready = this.getInfo();
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@ronomon/direct-io": "^3.0.1",
         "aws4-axios": "^3.3.0",
         "axios": "^1.6.0",
+        "axios-http2-adapter": "^1.0.1",
         "balena-image-fs": "^7.2.0",
         "blockmap": "^4.0.3",
         "check-disk-space": "^3.4.0",
@@ -2624,13 +2625,25 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.8.tgz",
+      "integrity": "sha512-v/ZHtJDU39mDpyBoFVkETcd/uNdxrWRrg3bKpOKzXFA6Bvqopts6ALSMU3y6ijYxbw2B+wPrIv46egTzJXCLGQ==",
       "dependencies": {
-        "follow-redirects": "^1.15.0",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios-http2-adapter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/axios-http2-adapter/-/axios-http2-adapter-1.0.1.tgz",
+      "integrity": "sha512-qxP3Hj3JAv8CbJm3U9v0ilscc4sBDn01iIhUmGRkg6SWJfAf16WfSs+WNRCxJX/A3MuQj8sOjEqZVeqnQdASaw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.5",
+        "http2-wrapper": "~2.2.1"
+      },
+      "peerDependencies": {
+        "axios": "~1.6.1"
       }
     },
     "node_modules/balanced-match": {
@@ -4418,9 +4431,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -4959,6 +4972,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
       }
     },
     "node_modules/ieee754": {
@@ -7044,6 +7069,17 @@
         }
       ]
     },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -7197,6 +7233,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
     },
     "node_modules/resolve-dir": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@ronomon/direct-io": "^3.0.1",
     "aws4-axios": "^3.3.0",
     "axios": "^1.6.0",
+    "axios-http2-adapter": "^1.0.1",
     "balena-image-fs": "^7.2.0",
     "blockmap": "^4.0.3",
     "check-disk-space": "^3.4.0",


### PR DESCRIPTION
Using an URL as source failed for some servers (including api.balena-cloud.com) when using http/2.

This PR should fix it.