### PR TITLE
patch: add EXLOCK flag for windows

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -69,7 +69,11 @@ function isTransientError(error: NodeJS.ErrnoException): boolean {
 	} else if (platform === 'linux') {
 		return error.code === 'EIO' || error.code === 'EBUSY';
 	} else if (platform === 'win32') {
-		return error.code === 'ENOENT' || error.code === 'UNKNOWN';
+		return (
+			error.code === 'ENOENT' ||
+			error.code === 'UNKNOWN' ||
+			error.code === 'EBUSY'
+		);
 	}
 	return false;
 }

--- a/lib/source-destination/block-device.ts
+++ b/lib/source-destination/block-device.ts
@@ -93,8 +93,9 @@ export class BlockDevice extends File implements AdapterSourceDestination {
 				flags |= constants.O_EXCL;
 			} else if (plat === 'darwin') {
 				flags |= O_EXLOCK;
+			} else if (plat === 'win32') {
+				flags |= O_EXLOCK;
 			}
-			// TODO: use O_EXCLOCK on windows too (getting EBUSY errors with it)
 		}
 		// tslint:enable:no-bitwise
 		return flags;

--- a/lib/source-destination/file.ts
+++ b/lib/source-destination/file.ts
@@ -207,7 +207,7 @@ export class File extends SourceDestination {
 			async () => {
 				this.fileHandle = await fs.open(this.path, this.getOpenFlags());
 			},
-			5,
+			150,
 			RETRY_BASE_TIMEOUT,
 		);
 	}


### PR DESCRIPTION
As discussed in several forums in public (see example: https://forums.balena.io/t/checksums-do-not-match/36537/82), windows is interfering the partitions that is readable by windows in this case FAT32. And this interference is causing balena-etcher validation to fail checksum mismatch as below:

```
index.js:2 fail event
index.js:2 {size: 63831015424, isVirtual: false, enumerator: 'USBSTOR', logicalBlockSize: 512, raw: '\\\\.\\PhysicalDrive3',Â â€¦}
index.js:2 {name: 'Error', message: 'Source and destination checksums do not match: 5d53d5bfdb7b8c48 !== b906ca881a24e045', stack: 'Error: Source and destination checksums do not matâ€¦jections (node:internal/process/task_queues:95:5)', code: 'EVALIDATION'}
index.js:2 Flash results {}
index.js:2 {}
index.js:2 Starting...
index.js:2 Error: The writer process ended unexpectedly
    at i (index.js:353:5238)
    at t.createUserError (index.js:353:6464)
    at m (index.js:140:45502)
    at index.js:140:46208
    at L.<anonymous> (index.js:140:42787)
    at L.emit (node:events:518:28)
    at e.exports.H (index.js:2:2313625)
    at e.exports.emit (node:events:518:28)
    at index.js:2:2289445
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```
In issue [#3197](https://github.com/balena-io/etcher/issues/3197) , there were several solutions suggested see 2 of them below:
1- https://superuser.com/questions/1199823/how-to-prevent-creation-of-system-volume-information-folder-in-windows-10-for/1199824#1199824
2- https://github.com/balena-io/etcher/issues/2210#issuecomment-1371840471

It seems like indeed we need exclusive lock to prevent windows to change fat partition while we are reading. To do that I implemented the TODO section in block-device.ts which required additional changes as well. 

Windows doesnt opening the file with EXLOCK permission, we need to try more than 5 times, so I took the inspiration from Rufus (another image flashing tool in windows) in there they are trying up to 150 times to get the lock. (see this code block for details: https://github.com/pbatard/rufus/blob/248a37e3084f519a02141a72a11289c1d22e7f31/src/drive.c#L152)

Thats why I changed the retry count and transient error handling for windows. I built the balena-etcher with EXLOCK which can be accessed here: https://github.com/talhaHavadar/etcher/releases/tag/test0

And I was able to write without validation error. 

To reproduce the error, you can reverse apply the solutions provided below, this will force windows to index the device and then you will get the validation error in balena etcher, some users may not able to simply disable these configurations because they might be managed by the companies.
1- https://superuser.com/questions/1199823/how-to-prevent-creation-of-system-volume-information-folder-in-windows-10-for/1199824#1199824
2- https://github.com/balena-io/etcher/issues/2210#issuecomment-1371840471
