### PR TITLE
Embed config.json with a fixed timestamp to enable consistent checksums

### DIFF
--- a/doc/classes/errors.BlocksVerificationError.md
+++ b/doc/classes/errors.BlocksVerificationError.md
@@ -35,7 +35,7 @@
 
 ### constructor
 
-• **new BlocksVerificationError**(`blocks`, `checksum`)
+• **new BlocksVerificationError**(`blocks`, `checksum`): [`BlocksVerificationError`](errors.BlocksVerificationError.md)
 
 #### Parameters
 
@@ -44,13 +44,17 @@
 | `blocks` | [`BlocksWithChecksum`](../interfaces/sparseStream.BlocksWithChecksum.md) |
 | `checksum` | `string` |
 
+#### Returns
+
+[`BlocksVerificationError`](errors.BlocksVerificationError.md)
+
 #### Overrides
 
 [VerificationError](errors.VerificationError.md).[constructor](errors.VerificationError.md#constructor)
 
 #### Defined in
 
-[lib/errors.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/errors.ts#L50)
+[lib/errors.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/errors.ts#L50)
 
 ## Properties
 
@@ -60,7 +64,7 @@
 
 #### Defined in
 
-[lib/errors.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/errors.ts#L51)
+[lib/errors.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/errors.ts#L51)
 
 ___
 
@@ -70,7 +74,7 @@ ___
 
 #### Defined in
 
-[lib/errors.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/errors.ts#L52)
+[lib/errors.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/errors.ts#L52)
 
 ___
 
@@ -84,7 +88,7 @@ ___
 
 #### Defined in
 
-[lib/errors.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/errors.ts#L25)
+[lib/errors.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/errors.ts#L25)
 
 ___
 
@@ -161,7 +165,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:11
+node_modules/@types/node/globals.d.ts:28
 
 ___
 
@@ -175,13 +179,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:13
+node_modules/@types/node/globals.d.ts:30
 
 ## Methods
 
 ### captureStackTrace
 
-▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
 
 Create .stack property on a target object
 
@@ -202,4 +206,4 @@ Create .stack property on a target object
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:4
+node_modules/@types/node/globals.d.ts:21

--- a/doc/classes/errors.ChecksumVerificationError.md
+++ b/doc/classes/errors.ChecksumVerificationError.md
@@ -35,7 +35,7 @@
 
 ### constructor
 
-• **new ChecksumVerificationError**(`message`, `checksum`, `expectedChecksum`)
+• **new ChecksumVerificationError**(`message`, `checksum`, `expectedChecksum`): [`ChecksumVerificationError`](errors.ChecksumVerificationError.md)
 
 #### Parameters
 
@@ -45,13 +45,17 @@
 | `checksum` | `string` |
 | `expectedChecksum` | `string` |
 
+#### Returns
+
+[`ChecksumVerificationError`](errors.ChecksumVerificationError.md)
+
 #### Overrides
 
 [VerificationError](errors.VerificationError.md).[constructor](errors.VerificationError.md#constructor)
 
 #### Defined in
 
-[lib/errors.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/errors.ts#L29)
+[lib/errors.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/errors.ts#L29)
 
 ## Properties
 
@@ -61,7 +65,7 @@
 
 #### Defined in
 
-[lib/errors.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/errors.ts#L31)
+[lib/errors.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/errors.ts#L31)
 
 ___
 
@@ -75,7 +79,7 @@ ___
 
 #### Defined in
 
-[lib/errors.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/errors.ts#L25)
+[lib/errors.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/errors.ts#L25)
 
 ___
 
@@ -85,7 +89,7 @@ ___
 
 #### Defined in
 
-[lib/errors.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/errors.ts#L32)
+[lib/errors.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/errors.ts#L32)
 
 ___
 
@@ -162,7 +166,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:11
+node_modules/@types/node/globals.d.ts:28
 
 ___
 
@@ -176,13 +180,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:13
+node_modules/@types/node/globals.d.ts:30
 
 ## Methods
 
 ### captureStackTrace
 
-▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
 
 Create .stack property on a target object
 
@@ -203,4 +207,4 @@ Create .stack property on a target object
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:4
+node_modules/@types/node/globals.d.ts:21

--- a/doc/classes/errors.NotCapable.md
+++ b/doc/classes/errors.NotCapable.md
@@ -32,13 +32,17 @@
 
 ### constructor
 
-• **new NotCapable**(`message?`)
+• **new NotCapable**(`message?`): [`NotCapable`](errors.NotCapable.md)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `message?` | `string` |
+
+#### Returns
+
+[`NotCapable`](errors.NotCapable.md)
 
 #### Inherited from
 
@@ -123,7 +127,7 @@ Error.prepareStackTrace
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:11
+node_modules/@types/node/globals.d.ts:28
 
 ___
 
@@ -137,13 +141,13 @@ Error.stackTraceLimit
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:13
+node_modules/@types/node/globals.d.ts:30
 
 ## Methods
 
 ### captureStackTrace
 
-▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
 
 Create .stack property on a target object
 
@@ -164,4 +168,4 @@ Error.captureStackTrace
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:4
+node_modules/@types/node/globals.d.ts:21

--- a/doc/classes/errors.VerificationError.md
+++ b/doc/classes/errors.VerificationError.md
@@ -37,13 +37,17 @@
 
 ### constructor
 
-• **new VerificationError**(`message?`)
+• **new VerificationError**(`message?`): [`VerificationError`](errors.VerificationError.md)
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `message?` | `string` |
+
+#### Returns
+
+[`VerificationError`](errors.VerificationError.md)
 
 #### Inherited from
 
@@ -61,7 +65,7 @@ node_modules/typescript/lib/lib.es5.d.ts:1073
 
 #### Defined in
 
-[lib/errors.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/errors.ts#L25)
+[lib/errors.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/errors.ts#L25)
 
 ___
 
@@ -138,7 +142,7 @@ Error.prepareStackTrace
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:11
+node_modules/@types/node/globals.d.ts:28
 
 ___
 
@@ -152,13 +156,13 @@ Error.stackTraceLimit
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:13
+node_modules/@types/node/globals.d.ts:30
 
 ## Methods
 
 ### captureStackTrace
 
-▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
 
 Create .stack property on a target object
 
@@ -179,4 +183,4 @@ Error.captureStackTrace
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:4
+node_modules/@types/node/globals.d.ts:21

--- a/doc/classes/scanner.Scanner.md
+++ b/doc/classes/scanner.Scanner.md
@@ -60,7 +60,7 @@
 
 ### constructor
 
-• **new Scanner**(`adapters`)
+• **new Scanner**(`adapters`): [`Scanner`](scanner.Scanner.md)
 
 #### Parameters
 
@@ -68,13 +68,17 @@
 | :------ | :------ |
 | `adapters` | [`Adapter`](scanner.adapters.Adapter.md)[] |
 
+#### Returns
+
+[`Scanner`](scanner.Scanner.md)
+
 #### Overrides
 
 EventEmitter.constructor
 
 #### Defined in
 
-[lib/scanner/scanner.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/scanner.ts#L27)
+[lib/scanner/scanner.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/scanner.ts#L27)
 
 ## Properties
 
@@ -84,7 +88,7 @@ EventEmitter.constructor
 
 #### Defined in
 
-[lib/scanner/scanner.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/scanner.ts#L27)
+[lib/scanner/scanner.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/scanner.ts#L27)
 
 ___
 
@@ -94,7 +98,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/scanner.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/scanner.ts#L25)
+[lib/scanner/scanner.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/scanner.ts#L25)
 
 ___
 
@@ -102,13 +106,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 EventEmitter.captureRejectionSymbol
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -116,7 +128,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -124,7 +142,7 @@ EventEmitter.captureRejections
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -132,13 +150,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 EventEmitter.defaultMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -146,13 +202,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -160,13 +217,13 @@ EventEmitter.errorMonitor
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -186,7 +243,7 @@ EventEmitter.[captureRejectionSymbol]
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
@@ -217,7 +274,7 @@ EventEmitter.addListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -231,7 +288,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -284,7 +341,7 @@ EventEmitter.emit
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -296,7 +353,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -322,7 +380,7 @@ EventEmitter.eventNames
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -343,7 +401,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/scanner.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/scanner.ts#L46)
+[lib/scanner/scanner.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/scanner.ts#L46)
 
 ___
 
@@ -368,7 +426,7 @@ EventEmitter.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -376,10 +434,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -402,7 +459,7 @@ EventEmitter.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -440,7 +497,7 @@ EventEmitter.listeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -471,7 +528,7 @@ EventEmitter.off
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -496,6 +553,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -526,13 +584,13 @@ EventEmitter.on
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
 ### onAttach
 
-▸ `Private` **onAttach**(`drive`): `void`
+▸ **onAttach**(`drive`): `void`
 
 #### Parameters
 
@@ -546,13 +604,13 @@ ___
 
 #### Defined in
 
-[lib/scanner/scanner.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/scanner.ts#L36)
+[lib/scanner/scanner.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/scanner.ts#L36)
 
 ___
 
 ### onDetach
 
-▸ `Private` **onDetach**(`drive`): `void`
+▸ **onDetach**(`drive`): `void`
 
 #### Parameters
 
@@ -566,7 +624,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/scanner.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/scanner.ts#L41)
+[lib/scanner/scanner.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/scanner.ts#L41)
 
 ___
 
@@ -589,6 +647,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -619,7 +678,7 @@ EventEmitter.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -661,7 +720,7 @@ EventEmitter.prependListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -701,7 +760,7 @@ EventEmitter.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -713,6 +772,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -756,7 +816,7 @@ EventEmitter.rawListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -792,7 +852,7 @@ EventEmitter.removeAllListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -821,6 +881,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -861,6 +923,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -898,7 +961,7 @@ EventEmitter.removeListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -933,7 +996,7 @@ EventEmitter.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -947,7 +1010,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/scanner.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/scanner.ts#L57)
+[lib/scanner/scanner.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/scanner.ts#L57)
 
 ___
 
@@ -961,13 +1024,13 @@ ___
 
 #### Defined in
 
-[lib/scanner/scanner.ts:74](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/scanner.ts#L74)
+[lib/scanner/scanner.ts:74](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/scanner.ts#L74)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1014,7 +1077,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1022,13 +1085,13 @@ EventEmitter.addAbortListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1039,19 +1102,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1076,13 +1139,13 @@ EventEmitter.getEventListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1122,7 +1185,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1130,18 +1193,19 @@ EventEmitter.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1174,34 +1238,33 @@ EventEmitter.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1212,7 +1275,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1260,13 +1325,13 @@ EventEmitter.on
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1277,31 +1342,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1309,13 +1371,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1325,7 +1387,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1370,9 +1432,9 @@ EventEmitter.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1392,19 +1454,16 @@ EventEmitter.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1433,4 +1492,4 @@ EventEmitter.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/scanner.adapters.Adapter.md
+++ b/doc/classes/scanner.adapters.Adapter.md
@@ -61,7 +61,7 @@
 
 ### constructor
 
-• **new Adapter**(`options?`)
+• **new Adapter**(`options?`): [`Adapter`](scanner.adapters.Adapter.md)
 
 #### Parameters
 
@@ -69,13 +69,17 @@
 | :------ | :------ |
 | `options?` | `EventEmitterOptions` |
 
+#### Returns
+
+[`Adapter`](scanner.adapters.Adapter.md)
+
 #### Inherited from
 
 EventEmitter.constructor
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:113
+node_modules/@types/node/events.d.ts:110
 
 ## Properties
 
@@ -83,13 +87,21 @@ node_modules/@types/node/events.d.ts:113
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 EventEmitter.captureRejectionSymbol
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -97,7 +109,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -105,7 +123,7 @@ EventEmitter.captureRejections
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -113,13 +131,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 EventEmitter.defaultMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -127,13 +183,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -141,13 +198,13 @@ EventEmitter.errorMonitor
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -167,7 +224,7 @@ EventEmitter.[captureRejectionSymbol]
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
@@ -198,7 +255,7 @@ EventEmitter.addListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -212,7 +269,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -265,7 +322,7 @@ EventEmitter.emit
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -277,7 +334,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -303,7 +361,7 @@ EventEmitter.eventNames
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -328,7 +386,7 @@ EventEmitter.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -336,10 +394,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -362,7 +419,7 @@ EventEmitter.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -400,7 +457,7 @@ EventEmitter.listeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -431,7 +488,7 @@ EventEmitter.off
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -456,6 +513,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -486,7 +544,7 @@ EventEmitter.on
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -509,6 +567,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -539,7 +598,7 @@ EventEmitter.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -581,7 +640,7 @@ EventEmitter.prependListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -621,7 +680,7 @@ EventEmitter.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -633,6 +692,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -676,7 +736,7 @@ EventEmitter.rawListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -712,7 +772,7 @@ EventEmitter.removeAllListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -741,6 +801,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -781,6 +843,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -818,7 +881,7 @@ EventEmitter.removeListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -853,13 +916,13 @@ EventEmitter.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
 ### start
 
-▸ `Abstract` **start**(): `void`
+▸ **start**(): `void`
 
 #### Returns
 
@@ -867,13 +930,13 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/adapter.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/adapter.ts#L34)
+[lib/scanner/adapters/adapter.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/adapter.ts#L34)
 
 ___
 
 ### stop
 
-▸ `Abstract` **stop**(): `void`
+▸ **stop**(): `void`
 
 #### Returns
 
@@ -881,13 +944,13 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/adapter.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/adapter.ts#L35)
+[lib/scanner/adapters/adapter.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/adapter.ts#L35)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -934,7 +997,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -942,13 +1005,13 @@ EventEmitter.addAbortListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -959,19 +1022,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -996,13 +1059,13 @@ EventEmitter.getEventListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1042,7 +1105,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1050,18 +1113,19 @@ EventEmitter.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1094,34 +1158,33 @@ EventEmitter.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1132,7 +1195,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1180,13 +1245,13 @@ EventEmitter.on
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1197,31 +1262,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1229,13 +1291,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1245,7 +1307,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1290,9 +1352,9 @@ EventEmitter.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1312,19 +1374,16 @@ EventEmitter.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1353,4 +1412,4 @@ EventEmitter.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/scanner.adapters.BlockDeviceAdapter.md
+++ b/doc/classes/scanner.adapters.BlockDeviceAdapter.md
@@ -20,6 +20,7 @@
 
 - [drives](scanner.adapters.BlockDeviceAdapter.md#drives)
 - [includeSystemDrives](scanner.adapters.BlockDeviceAdapter.md#includesystemdrives)
+- [includeVitualDrives](scanner.adapters.BlockDeviceAdapter.md#includevitualdrives)
 - [oDirect](scanner.adapters.BlockDeviceAdapter.md#odirect)
 - [oWrite](scanner.adapters.BlockDeviceAdapter.md#owrite)
 - [ready](scanner.adapters.BlockDeviceAdapter.md#ready)
@@ -65,7 +66,7 @@
 
 ### constructor
 
-• **new BlockDeviceAdapter**(`«destructured»`)
+• **new BlockDeviceAdapter**(`«destructured»`): [`BlockDeviceAdapter`](scanner.adapters.BlockDeviceAdapter.md)
 
 #### Parameters
 
@@ -74,8 +75,13 @@
 | `«destructured»` | `Object` |
 | › `direct?` | `boolean` |
 | › `includeSystemDrives?` | () => `boolean` |
+| › `includeVirtualDrives?` | () => `boolean` |
 | › `unmountOnSuccess?` | `boolean` |
 | › `write?` | `boolean` |
+
+#### Returns
+
+[`BlockDeviceAdapter`](scanner.adapters.BlockDeviceAdapter.md)
 
 #### Overrides
 
@@ -83,7 +89,7 @@
 
 #### Defined in
 
-[lib/scanner/adapters/block-device.ts:73](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/block-device.ts#L73)
+[lib/scanner/adapters/block-device.ts:74](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/block-device.ts#L74)
 
 ## Properties
 
@@ -93,7 +99,7 @@
 
 #### Defined in
 
-[lib/scanner/adapters/block-device.ts:69](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/block-device.ts#L69)
+[lib/scanner/adapters/block-device.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/block-device.ts#L70)
 
 ___
 
@@ -111,7 +117,25 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/block-device.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/block-device.ts#L65)
+[lib/scanner/adapters/block-device.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/block-device.ts#L65)
+
+___
+
+### includeVitualDrives
+
+• **includeVitualDrives**: () => `boolean`
+
+#### Type declaration
+
+▸ (): `boolean`
+
+##### Returns
+
+`boolean`
+
+#### Defined in
+
+[lib/scanner/adapters/block-device.ts:66](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/block-device.ts#L66)
 
 ___
 
@@ -121,7 +145,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/block-device.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/block-device.ts#L68)
+[lib/scanner/adapters/block-device.ts:69](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/block-device.ts#L69)
 
 ___
 
@@ -131,7 +155,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/block-device.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/block-device.ts#L67)
+[lib/scanner/adapters/block-device.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/block-device.ts#L68)
 
 ___
 
@@ -141,7 +165,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/block-device.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/block-device.ts#L71)
+[lib/scanner/adapters/block-device.ts:72](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/block-device.ts#L72)
 
 ___
 
@@ -151,7 +175,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/block-device.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/block-device.ts#L70)
+[lib/scanner/adapters/block-device.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/block-device.ts#L71)
 
 ___
 
@@ -161,7 +185,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/block-device.ts:66](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/block-device.ts#L66)
+[lib/scanner/adapters/block-device.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/block-device.ts#L67)
 
 ___
 
@@ -169,13 +193,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [Adapter](scanner.adapters.Adapter.md).[captureRejectionSymbol](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -183,7 +215,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -191,7 +229,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -199,13 +237,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [Adapter](scanner.adapters.Adapter.md).[defaultMaxListeners](scanner.adapters.Adapter.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -213,13 +289,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -227,13 +304,13 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -253,7 +330,7 @@ node_modules/@types/node/events.d.ts:404
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
@@ -284,7 +361,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -298,7 +375,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -351,7 +428,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -363,7 +440,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -389,7 +467,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -414,13 +492,13 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
 ### listDrives
 
-▸ `Private` **listDrives**(): `Promise`<`Map`<`string`, [`DrivelistDrive`](../interfaces/scanner.adapters.DrivelistDrive.md)\>\>
+▸ **listDrives**(): `Promise`<`Map`<`string`, [`DrivelistDrive`](../interfaces/scanner.adapters.DrivelistDrive.md)\>\>
 
 #### Returns
 
@@ -428,7 +506,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/block-device.ts:137](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/block-device.ts#L137)
+[lib/scanner/adapters/block-device.ts:141](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/block-device.ts#L141)
 
 ___
 
@@ -436,10 +514,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -462,7 +539,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -500,7 +577,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -531,7 +608,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -556,6 +633,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -586,7 +664,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -609,6 +687,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -639,7 +718,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -681,7 +760,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -721,7 +800,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -733,6 +812,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -776,7 +856,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -812,7 +892,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -841,6 +921,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -881,6 +963,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -918,13 +1001,13 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
 ### scan
 
-▸ `Private` **scan**(): `Promise`<`void`\>
+▸ **scan**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -932,13 +1015,13 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/block-device.ts:113](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/block-device.ts#L113)
+[lib/scanner/adapters/block-device.ts:117](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/block-device.ts#L117)
 
 ___
 
 ### scanLoop
 
-▸ `Private` **scanLoop**(): `Promise`<`void`\>
+▸ **scanLoop**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -946,7 +1029,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/block-device.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/block-device.ts#L102)
+[lib/scanner/adapters/block-device.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/block-device.ts#L106)
 
 ___
 
@@ -981,7 +1064,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -999,7 +1082,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/block-device.ts:91](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/block-device.ts#L91)
+[lib/scanner/adapters/block-device.ts:95](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/block-device.ts#L95)
 
 ___
 
@@ -1017,13 +1100,13 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/block-device.ts:96](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/block-device.ts#L96)
+[lib/scanner/adapters/block-device.ts:100](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/block-device.ts#L100)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1070,7 +1153,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1078,13 +1161,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1095,19 +1178,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1132,13 +1215,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1178,7 +1261,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1186,18 +1269,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1230,34 +1314,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1268,7 +1351,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1316,13 +1401,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1333,31 +1418,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1365,13 +1447,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1381,7 +1463,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1426,9 +1508,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1448,19 +1530,16 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1489,4 +1568,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/scanner.adapters.UsbBBbootDeviceAdapter.md
+++ b/doc/classes/scanner.adapters.UsbBBbootDeviceAdapter.md
@@ -59,7 +59,11 @@
 
 ### constructor
 
-• **new UsbBBbootDeviceAdapter**()
+• **new UsbBBbootDeviceAdapter**(): [`UsbBBbootDeviceAdapter`](scanner.adapters.UsbBBbootDeviceAdapter.md)
+
+#### Returns
+
+[`UsbBBbootDeviceAdapter`](scanner.adapters.UsbBBbootDeviceAdapter.md)
 
 #### Overrides
 
@@ -67,7 +71,7 @@
 
 #### Defined in
 
-[lib/scanner/adapters/usb-bb-boot.ts:13](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/usb-bb-boot.ts#L13)
+[lib/scanner/adapters/usb-bb-boot.ts:13](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/usb-bb-boot.ts#L13)
 
 ## Properties
 
@@ -77,7 +81,7 @@
 
 #### Defined in
 
-[lib/scanner/adapters/usb-bb-boot.ts:10](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/usb-bb-boot.ts#L10)
+[lib/scanner/adapters/usb-bb-boot.ts:10](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/usb-bb-boot.ts#L10)
 
 ___
 
@@ -87,7 +91,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/usb-bb-boot.ts:11](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/usb-bb-boot.ts#L11)
+[lib/scanner/adapters/usb-bb-boot.ts:11](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/usb-bb-boot.ts#L11)
 
 ___
 
@@ -95,13 +99,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [Adapter](scanner.adapters.Adapter.md).[captureRejectionSymbol](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -109,7 +121,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -117,7 +135,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -125,13 +143,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [Adapter](scanner.adapters.Adapter.md).[defaultMaxListeners](scanner.adapters.Adapter.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -139,13 +195,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -153,13 +210,13 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -179,7 +236,7 @@ node_modules/@types/node/events.d.ts:404
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
@@ -210,7 +267,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -224,7 +281,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -277,7 +334,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -289,7 +346,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -315,7 +373,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -340,7 +398,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -348,10 +406,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -374,7 +431,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -412,7 +469,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -443,7 +500,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -468,6 +525,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -498,13 +556,13 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
 ### onAttach
 
-▸ `Private` **onAttach**(`device`): `void`
+▸ **onAttach**(`device`): `void`
 
 #### Parameters
 
@@ -518,13 +576,13 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/usb-bb-boot.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/usb-bb-boot.ts#L30)
+[lib/scanner/adapters/usb-bb-boot.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/usb-bb-boot.ts#L30)
 
 ___
 
 ### onDetach
 
-▸ `Private` **onDetach**(`device`): `void`
+▸ **onDetach**(`device`): `void`
 
 #### Parameters
 
@@ -538,7 +596,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/usb-bb-boot.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/usb-bb-boot.ts#L39)
+[lib/scanner/adapters/usb-bb-boot.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/usb-bb-boot.ts#L39)
 
 ___
 
@@ -561,6 +619,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -591,7 +650,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -633,7 +692,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -673,7 +732,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -685,6 +744,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -728,7 +788,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -764,7 +824,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -793,6 +853,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -833,6 +895,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -870,7 +933,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -905,7 +968,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -923,7 +986,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/usb-bb-boot.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/usb-bb-boot.ts#L22)
+[lib/scanner/adapters/usb-bb-boot.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/usb-bb-boot.ts#L22)
 
 ___
 
@@ -941,13 +1004,13 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/usb-bb-boot.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/usb-bb-boot.ts#L26)
+[lib/scanner/adapters/usb-bb-boot.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/usb-bb-boot.ts#L26)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -994,7 +1057,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1002,13 +1065,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1019,19 +1082,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1056,13 +1119,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1102,7 +1165,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1110,18 +1173,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1154,34 +1218,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1192,7 +1255,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1240,13 +1305,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1257,31 +1322,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1289,13 +1351,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1305,7 +1367,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1350,9 +1412,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1372,19 +1434,16 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1413,4 +1472,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/scanner.adapters.UsbbootDeviceAdapter.md
+++ b/doc/classes/scanner.adapters.UsbbootDeviceAdapter.md
@@ -59,7 +59,17 @@
 
 ### constructor
 
-• **new UsbbootDeviceAdapter**()
+• **new UsbbootDeviceAdapter**(`usbBootExtraDir?`): [`UsbbootDeviceAdapter`](scanner.adapters.UsbbootDeviceAdapter.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `usbBootExtraDir?` | `string` |
+
+#### Returns
+
+[`UsbbootDeviceAdapter`](scanner.adapters.UsbbootDeviceAdapter.md)
 
 #### Overrides
 
@@ -67,7 +77,7 @@
 
 #### Defined in
 
-[lib/scanner/adapters/usbboot.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/usbboot.ts#L30)
+[lib/scanner/adapters/usbboot.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/usbboot.ts#L30)
 
 ## Properties
 
@@ -77,7 +87,7 @@
 
 #### Defined in
 
-[lib/scanner/adapters/usbboot.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/usbboot.ts#L27)
+[lib/scanner/adapters/usbboot.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/usbboot.ts#L27)
 
 ___
 
@@ -87,7 +97,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/usbboot.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/usbboot.ts#L28)
+[lib/scanner/adapters/usbboot.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/usbboot.ts#L28)
 
 ___
 
@@ -95,13 +105,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [Adapter](scanner.adapters.Adapter.md).[captureRejectionSymbol](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -109,7 +127,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -117,7 +141,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -125,13 +149,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [Adapter](scanner.adapters.Adapter.md).[defaultMaxListeners](scanner.adapters.Adapter.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -139,13 +201,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -153,13 +216,13 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -179,7 +242,7 @@ node_modules/@types/node/events.d.ts:404
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
@@ -210,7 +273,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -224,7 +287,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -277,7 +340,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -289,7 +352,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -315,7 +379,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -340,7 +404,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -348,10 +412,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -374,7 +437,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -412,7 +475,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -443,7 +506,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -468,6 +531,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -498,13 +562,13 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
 ### onAttach
 
-▸ `Private` **onAttach**(`device`): `void`
+▸ **onAttach**(`device`): `void`
 
 #### Parameters
 
@@ -518,13 +582,13 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/usbboot.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/usbboot.ts#L53)
+[lib/scanner/adapters/usbboot.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/usbboot.ts#L53)
 
 ___
 
 ### onDetach
 
-▸ `Private` **onDetach**(`device`): `void`
+▸ **onDetach**(`device`): `void`
 
 #### Parameters
 
@@ -538,7 +602,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/usbboot.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/usbboot.ts#L62)
+[lib/scanner/adapters/usbboot.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/usbboot.ts#L62)
 
 ___
 
@@ -561,6 +625,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -591,7 +656,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -633,7 +698,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -673,7 +738,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -685,6 +750,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -728,7 +794,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -764,7 +830,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -793,6 +859,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -833,6 +901,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -870,7 +939,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -905,7 +974,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -923,7 +992,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/usbboot.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/usbboot.ts#L45)
+[lib/scanner/adapters/usbboot.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/usbboot.ts#L45)
 
 ___
 
@@ -941,13 +1010,13 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/usbboot.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/usbboot.ts#L49)
+[lib/scanner/adapters/usbboot.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/usbboot.ts#L49)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -994,7 +1063,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1002,13 +1071,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1019,19 +1088,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1056,13 +1125,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1102,7 +1171,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1110,18 +1179,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1154,34 +1224,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1192,7 +1261,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1240,13 +1311,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1257,31 +1328,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1289,13 +1357,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1305,7 +1373,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1350,9 +1418,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1372,19 +1440,16 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1413,4 +1478,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.BZip2Source.md
+++ b/doc/classes/sourceDestination.BZip2Source.md
@@ -84,7 +84,7 @@
 
 ### constructor
 
-• **new BZip2Source**(`source`)
+• **new BZip2Source**(`source`): [`BZip2Source`](sourceDestination.BZip2Source.md)
 
 #### Parameters
 
@@ -92,13 +92,17 @@
 | :------ | :------ |
 | `source` | [`SourceDestination`](sourceDestination.SourceDestination.md) |
 
+#### Returns
+
+[`BZip2Source`](sourceDestination.BZip2Source.md)
+
 #### Inherited from
 
 [CompressedSource](sourceDestination.CompressedSource.md).[constructor](sourceDestination.CompressedSource.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L22)
+[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L22)
 
 ## Properties
 
@@ -112,7 +116,7 @@
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L22)
+[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L22)
 
 ___
 
@@ -120,13 +124,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [CompressedSource](sourceDestination.CompressedSource.md).[captureRejectionSymbol](sourceDestination.CompressedSource.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -134,7 +146,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -142,7 +160,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -150,13 +168,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [CompressedSource](sourceDestination.CompressedSource.md).[defaultMaxListeners](sourceDestination.CompressedSource.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -164,13 +220,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -178,7 +235,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -192,7 +249,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -206,7 +263,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/bzip2.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/bzip2.ts#L24)
+[lib/source-destination/bzip2.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/bzip2.ts#L24)
 
 ___
 
@@ -220,13 +277,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L20)
+[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L20)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -246,13 +303,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -264,13 +321,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L30)
+[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L30)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -282,13 +339,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L106)
+[lib/source-destination/compressed-source.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L106)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -300,7 +357,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L26)
+[lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L26)
 
 ___
 
@@ -331,7 +388,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -349,7 +406,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L53)
+[lib/source-destination/compressed-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L53)
 
 ___
 
@@ -367,7 +424,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -385,7 +442,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -403,7 +460,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -421,7 +478,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L323)
+[lib/source-destination/source-destination.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L321)
 
 ___
 
@@ -439,7 +496,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -457,7 +514,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -481,7 +538,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L57)
+[lib/source-destination/compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L57)
 
 ___
 
@@ -505,7 +562,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -530,13 +587,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
 ### createTransform
 
-▸ `Protected` **createTransform**(): `Transform`
+▸ **createTransform**(): `Transform`
 
 #### Returns
 
@@ -548,7 +605,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/bzip2.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/bzip2.ts#L26)
+[lib/source-destination/bzip2.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/bzip2.ts#L26)
 
 ___
 
@@ -573,7 +630,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -598,7 +655,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
@@ -612,7 +669,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -665,7 +722,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -677,7 +734,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -703,7 +761,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -721,7 +779,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -739,7 +797,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
@@ -757,7 +815,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -782,7 +840,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -800,7 +858,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -818,13 +876,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
 ### getSize
 
-▸ `Protected` **getSize**(): `Promise`<`undefined` \| { `isEstimated`: ``true`` ; `size`: `number`  }\>
+▸ **getSize**(): `Promise`<`undefined` \| { `isEstimated`: ``true`` ; `size`: `number`  }\>
 
 #### Returns
 
@@ -836,13 +894,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/bzip2.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/bzip2.ts#L30)
+[lib/source-destination/bzip2.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/bzip2.ts#L30)
 
 ___
 
 ### getSizeFromPartitionTable
 
-▸ `Protected` **getSizeFromPartitionTable**(): `Promise`<`undefined` \| `number`\>
+▸ **getSizeFromPartitionTable**(): `Promise`<`undefined` \| `number`\>
 
 #### Returns
 
@@ -854,7 +912,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L87)
+[lib/source-destination/compressed-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L87)
 
 ___
 
@@ -862,10 +920,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -888,7 +945,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -926,7 +983,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -957,7 +1014,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -982,6 +1039,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1012,7 +1070,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1035,6 +1093,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1065,7 +1124,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1083,7 +1142,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1125,7 +1184,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1165,7 +1224,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1177,6 +1236,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1220,7 +1280,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1247,7 +1307,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L358)
+[lib/source-destination/source-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L356)
 
 ___
 
@@ -1283,7 +1343,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1312,6 +1372,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1352,6 +1414,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1389,7 +1452,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1424,7 +1487,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1451,13 +1514,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1504,7 +1567,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1512,13 +1575,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1529,19 +1592,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1566,13 +1629,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1612,7 +1675,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1620,18 +1683,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1664,34 +1728,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1702,7 +1765,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1750,13 +1815,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1767,31 +1832,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1799,13 +1861,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1815,7 +1877,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1860,9 +1922,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1882,13 +1944,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -1906,19 +1968,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1947,4 +2006,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.BalenaS3CompressedSource.md
+++ b/doc/classes/sourceDestination.BalenaS3CompressedSource.md
@@ -121,7 +121,7 @@
 
 ### constructor
 
-• **new BalenaS3CompressedSource**(`«destructured»`)
+• **new BalenaS3CompressedSource**(`«destructured»`): [`BalenaS3CompressedSource`](sourceDestination.BalenaS3CompressedSource.md)
 
 #### Parameters
 
@@ -129,13 +129,17 @@
 | :------ | :------ |
 | `«destructured»` | [`BalenaS3CompressedSourceOptions`](../interfaces/sourceDestination.BalenaS3CompressedSourceOptions.md) |
 
+#### Returns
+
+[`BalenaS3CompressedSource`](sourceDestination.BalenaS3CompressedSource.md)
+
 #### Overrides
 
 [BalenaS3SourceBase](sourceDestination.BalenaS3SourceBase.md).[constructor](sourceDestination.BalenaS3SourceBase.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:73](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L73)
+[lib/source-destination/balena-s3-compressed-source.ts:73](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L73)
 
 ## Properties
 
@@ -149,7 +153,7 @@
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L60)
+[lib/source-destination/balena-s3-source.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L60)
 
 ___
 
@@ -163,7 +167,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L54)
+[lib/source-destination/balena-s3-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L54)
 
 ___
 
@@ -177,7 +181,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L57)
+[lib/source-destination/balena-s3-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L57)
 
 ___
 
@@ -187,7 +191,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L62)
+[lib/source-destination/balena-s3-compressed-source.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L62)
 
 ___
 
@@ -197,7 +201,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L63)
+[lib/source-destination/balena-s3-compressed-source.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L63)
 
 ___
 
@@ -211,7 +215,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L56)
+[lib/source-destination/balena-s3-source.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L56)
 
 ___
 
@@ -221,7 +225,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L58)
+[lib/source-destination/balena-s3-compressed-source.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L58)
 
 ___
 
@@ -231,7 +235,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L71)
+[lib/source-destination/balena-s3-compressed-source.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L71)
 
 ___
 
@@ -241,7 +245,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L60)
+[lib/source-destination/balena-s3-compressed-source.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L60)
 
 ___
 
@@ -251,7 +255,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L59)
+[lib/source-destination/balena-s3-compressed-source.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L59)
 
 ___
 
@@ -265,7 +269,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L53)
+[lib/source-destination/balena-s3-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L53)
 
 ___
 
@@ -275,7 +279,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L57)
+[lib/source-destination/balena-s3-compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L57)
 
 ___
 
@@ -289,7 +293,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L59)
+[lib/source-destination/balena-s3-source.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L59)
 
 ___
 
@@ -299,7 +303,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L68)
+[lib/source-destination/balena-s3-compressed-source.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L68)
 
 ___
 
@@ -309,7 +313,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:69](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L69)
+[lib/source-destination/balena-s3-compressed-source.ts:69](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L69)
 
 ___
 
@@ -323,7 +327,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L55)
+[lib/source-destination/balena-s3-source.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L55)
 
 ___
 
@@ -337,7 +341,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L58)
+[lib/source-destination/balena-s3-source.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L58)
 
 ___
 
@@ -347,7 +351,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L70)
+[lib/source-destination/balena-s3-compressed-source.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L70)
 
 ___
 
@@ -357,7 +361,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L67)
+[lib/source-destination/balena-s3-compressed-source.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L67)
 
 ___
 
@@ -365,13 +369,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [BalenaS3SourceBase](sourceDestination.BalenaS3SourceBase.md).[captureRejectionSymbol](sourceDestination.BalenaS3SourceBase.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -379,7 +391,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -387,7 +405,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -395,13 +413,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [BalenaS3SourceBase](sourceDestination.BalenaS3SourceBase.md).[defaultMaxListeners](sourceDestination.BalenaS3SourceBase.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -409,13 +465,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -423,7 +480,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -437,7 +494,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -451,13 +508,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:307](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L307)
+[lib/source-destination/source-destination.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L305)
 
 ## Accessors
 
 ### imageSuffix
 
-• `Protected` `get` **imageSuffix**(): `string`
+• `get` **imageSuffix**(): `string`
 
 #### Returns
 
@@ -469,13 +526,13 @@ BalenaS3SourceBase.imageSuffix
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L106)
+[lib/source-destination/balena-s3-source.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L104)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -495,13 +552,13 @@ BalenaS3SourceBase.imageSuffix
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -513,13 +570,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:422](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L422)
+[lib/source-destination/source-destination.ts:420](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L420)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -531,13 +588,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L102)
+[lib/source-destination/balena-s3-compressed-source.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L102)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -549,7 +606,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:238](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L238)
+[lib/source-destination/balena-s3-compressed-source.ts:238](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L238)
 
 ___
 
@@ -580,7 +637,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -598,7 +655,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L110)
+[lib/source-destination/balena-s3-source.ts:108](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L108)
 
 ___
 
@@ -616,7 +673,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -634,7 +691,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -652,7 +709,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -670,7 +727,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L323)
+[lib/source-destination/source-destination.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L321)
 
 ___
 
@@ -688,7 +745,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -706,13 +763,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
 ### configure
 
-▸ `Private` **configure**(): `Promise`<`void`\>
+▸ **configure**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -720,13 +777,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:192](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L192)
+[lib/source-destination/balena-s3-compressed-source.ts:192](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L192)
 
 ___
 
 ### createGzipStream
 
-▸ `Private` **createGzipStream**(`fake`): `Promise`<`GzipStream`\>
+▸ **createGzipStream**(`fake`): `Promise`<`GzipStream`\>
 
 #### Parameters
 
@@ -740,7 +797,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L305)
+[lib/source-destination/balena-s3-compressed-source.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L305)
 
 ___
 
@@ -764,7 +821,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:316](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L316)
+[lib/source-destination/balena-s3-compressed-source.ts:316](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L316)
 
 ___
 
@@ -788,7 +845,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -813,13 +870,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
 ### createStream
 
-▸ `Private` **createStream**(`fake?`): `Promise`<`any`\>
+▸ **createStream**(`fake?`): `Promise`<`any`\>
 
 #### Parameters
 
@@ -833,7 +890,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:310](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L310)
+[lib/source-destination/balena-s3-compressed-source.ts:310](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L310)
 
 ___
 
@@ -858,7 +915,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -883,13 +940,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
 ### createZipStream
 
-▸ `Private` **createZipStream**(`fake`): `Promise`<`any`\>
+▸ **createZipStream**(`fake`): `Promise`<`any`\>
 
 #### Parameters
 
@@ -903,13 +960,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L298)
+[lib/source-destination/balena-s3-compressed-source.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L298)
 
 ___
 
 ### download
 
-▸ `Protected` **download**(`path`, `responseType?`): `Promise`<`AxiosResponse`<`any`, `any`\>\>
+▸ **download**(`path`, `responseType?`): `Promise`<`AxiosResponse`<`any`, `any`\>\>
 
 #### Parameters
 
@@ -928,7 +985,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:122](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L122)
+[lib/source-destination/balena-s3-source.ts:120](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L120)
 
 ___
 
@@ -942,7 +999,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -995,7 +1052,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -1007,7 +1064,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -1033,13 +1091,13 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
 ### extractDeflateToDisk
 
-▸ `Private` **extractDeflateToDisk**(`filename`): `Promise`<`BufferDisk`\>
+▸ **extractDeflateToDisk**(`filename`): `Promise`<`BufferDisk`\>
 
 #### Parameters
 
@@ -1053,13 +1111,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:182](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L182)
+[lib/source-destination/balena-s3-compressed-source.ts:182](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L182)
 
 ___
 
 ### findImagePart
 
-▸ `Private` **findImagePart**(`imageJSON`, `image`): `ImageJSONPart`
+▸ **findImagePart**(`imageJSON`, `image`): `ImageJSONPart`
 
 #### Parameters
 
@@ -1074,13 +1132,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:163](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L163)
+[lib/source-destination/balena-s3-compressed-source.ts:163](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L163)
 
 ___
 
 ### findPart
 
-▸ `Private` **findPart**(`definition`): `ImageJSONPart`
+▸ **findPart**(`definition`): `ImageJSONPart`
 
 #### Parameters
 
@@ -1094,13 +1152,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:171](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L171)
+[lib/source-destination/balena-s3-compressed-source.ts:171](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L171)
 
 ___
 
 ### findPartitionPart
 
-▸ `Private` **findPartitionPart**(`imageJSON`, `partition`): `ImageJSONPart`
+▸ **findPartitionPart**(`imageJSON`, `partition`): `ImageJSONPart`
 
 #### Parameters
 
@@ -1115,7 +1173,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L147)
+[lib/source-destination/balena-s3-compressed-source.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L147)
 
 ___
 
@@ -1133,7 +1191,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -1151,13 +1209,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
 ### getDeviceTypeJSON
 
-▸ `Private` **getDeviceTypeJSON**(): `Promise`<`DeviceTypeJSON`\>
+▸ **getDeviceTypeJSON**(): `Promise`<`DeviceTypeJSON`\>
 
 #### Returns
 
@@ -1165,13 +1223,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:133](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L133)
+[lib/source-destination/balena-s3-compressed-source.ts:133](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L133)
 
 ___
 
 ### getFilename
 
-▸ `Private` **getFilename**(): `string`
+▸ **getFilename**(): `string`
 
 #### Returns
 
@@ -1179,13 +1237,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:89](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L89)
+[lib/source-destination/balena-s3-compressed-source.ts:89](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L89)
 
 ___
 
 ### getImageJSON
 
-▸ `Private` **getImageJSON**(): `Promise`<[`ImageJSON`](../modules/sourceDestination.md#imagejson)\>
+▸ **getImageJSON**(): `Promise`<[`ImageJSON`](../modules/sourceDestination.md#imagejson)\>
 
 #### Returns
 
@@ -1193,7 +1251,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:127](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L127)
+[lib/source-destination/balena-s3-compressed-source.ts:127](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L127)
 
 ___
 
@@ -1211,7 +1269,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -1236,7 +1294,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -1254,13 +1312,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
 ### getOsVersion
 
-▸ `Private` **getOsVersion**(): `Promise`<`any`\>
+▸ **getOsVersion**(): `Promise`<`any`\>
 
 #### Returns
 
@@ -1268,13 +1326,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:122](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L122)
+[lib/source-destination/balena-s3-compressed-source.ts:122](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L122)
 
 ___
 
 ### getPartStream
 
-▸ `Private` **getPartStream**(`filename`): `Promise`<`ReadableStream`\>
+▸ **getPartStream**(`filename`): `Promise`<`ReadableStream`\>
 
 #### Parameters
 
@@ -1288,7 +1346,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:137](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L137)
+[lib/source-destination/balena-s3-compressed-source.ts:137](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L137)
 
 ___
 
@@ -1306,13 +1364,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
 ### getParts
 
-▸ `Private` **getParts**(`fake`): `Promise`<{ `filename`: `string` ; `parts`: { `crc`: `number` ; `filename`: `string` ; `len`: `number` ; `partitionIndex?`: `string` ; `stream`: `Buffer` \| `ReadableStream` ; `zLen`: `number`  }[]  }[]\>
+▸ **getParts**(`fake`): `Promise`<{ `filename`: `string` ; `parts`: { `crc`: `number` ; `filename`: `string` ; `len`: `number` ; `partitionIndex?`: `string` ; `stream`: `Buffer` \| `ReadableStream` ; `zLen`: `number`  }[]  }[]\>
 
 #### Parameters
 
@@ -1326,13 +1384,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:275](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L275)
+[lib/source-destination/balena-s3-compressed-source.ts:275](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L275)
 
 ___
 
 ### getSize
 
-▸ `Private` **getSize**(): `Promise`<`number`\>
+▸ **getSize**(): `Promise`<`number`\>
 
 #### Returns
 
@@ -1340,13 +1398,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:85](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L85)
+[lib/source-destination/balena-s3-compressed-source.ts:85](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L85)
 
 ___
 
 ### getSupervisorVersion
 
-▸ `Private` **getSupervisorVersion**(): `Promise`<{ `lastModified`: `Date` ; `supervisorVersion`: `any`  }\>
+▸ **getSupervisorVersion**(): `Promise`<{ `lastModified`: `Date` ; `supervisorVersion`: `any`  }\>
 
 #### Returns
 
@@ -1354,13 +1412,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:115](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L115)
+[lib/source-destination/balena-s3-compressed-source.ts:115](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L115)
 
 ___
 
 ### getUrl
 
-▸ `Protected` **getUrl**(`path`): `string`
+▸ **getUrl**(`path`): `string`
 
 #### Parameters
 
@@ -1378,7 +1436,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:126](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L126)
+[lib/source-destination/balena-s3-source.ts:124](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L124)
 
 ___
 
@@ -1386,10 +1444,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -1412,7 +1469,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -1450,7 +1507,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -1481,7 +1538,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -1506,6 +1563,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1536,7 +1594,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1559,6 +1617,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1589,7 +1648,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1607,7 +1666,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1649,7 +1708,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1689,7 +1748,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1701,6 +1760,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1744,7 +1804,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1771,7 +1831,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L358)
+[lib/source-destination/source-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L356)
 
 ___
 
@@ -1807,7 +1867,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1836,6 +1896,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1876,6 +1938,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1913,7 +1976,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1948,7 +2011,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1975,13 +2038,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -2028,7 +2091,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -2036,13 +2099,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -2053,19 +2116,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -2090,13 +2153,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -2136,7 +2199,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -2144,13 +2207,13 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### isESRVersion
 
-▸ `Static` **isESRVersion**(`buildId`): `boolean`
+▸ **isESRVersion**(`buildId`): `boolean`
 
 #### Parameters
 
@@ -2168,18 +2231,19 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:114](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L114)
+[lib/source-destination/balena-s3-source.ts:112](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L112)
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -2212,34 +2276,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -2250,7 +2313,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -2298,13 +2363,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -2315,31 +2380,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -2347,13 +2409,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -2363,7 +2425,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -2408,9 +2470,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -2430,13 +2492,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -2454,19 +2516,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -2495,4 +2554,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.BalenaS3Source.md
+++ b/doc/classes/sourceDestination.BalenaS3Source.md
@@ -99,7 +99,7 @@
 
 ### constructor
 
-• **new BalenaS3Source**(`«destructured»`)
+• **new BalenaS3Source**(`«destructured»`): [`BalenaS3Source`](sourceDestination.BalenaS3Source.md)
 
 #### Parameters
 
@@ -107,13 +107,17 @@
 | :------ | :------ |
 | `«destructured»` | [`BalenaS3SourceOptions`](../interfaces/sourceDestination.BalenaS3SourceOptions.md) |
 
+#### Returns
+
+[`BalenaS3Source`](sourceDestination.BalenaS3Source.md)
+
 #### Inherited from
 
 [BalenaS3SourceBase](sourceDestination.BalenaS3SourceBase.md).[constructor](sourceDestination.BalenaS3SourceBase.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L67)
+[lib/source-destination/balena-s3-source.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L67)
 
 ## Properties
 
@@ -127,7 +131,7 @@
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L60)
+[lib/source-destination/balena-s3-source.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L60)
 
 ___
 
@@ -141,7 +145,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L54)
+[lib/source-destination/balena-s3-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L54)
 
 ___
 
@@ -155,7 +159,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L57)
+[lib/source-destination/balena-s3-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L57)
 
 ___
 
@@ -169,7 +173,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L56)
+[lib/source-destination/balena-s3-source.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L56)
 
 ___
 
@@ -183,7 +187,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L53)
+[lib/source-destination/balena-s3-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L53)
 
 ___
 
@@ -197,7 +201,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L59)
+[lib/source-destination/balena-s3-source.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L59)
 
 ___
 
@@ -207,7 +211,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:161](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L161)
+[lib/source-destination/balena-s3-source.ts:159](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L159)
 
 ___
 
@@ -217,7 +221,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:160](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L160)
+[lib/source-destination/balena-s3-source.ts:158](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L158)
 
 ___
 
@@ -231,7 +235,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L55)
+[lib/source-destination/balena-s3-source.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L55)
 
 ___
 
@@ -241,7 +245,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:158](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L158)
+[lib/source-destination/balena-s3-source.ts:156](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L156)
 
 ___
 
@@ -255,7 +259,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L58)
+[lib/source-destination/balena-s3-source.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L58)
 
 ___
 
@@ -265,7 +269,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:159](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L159)
+[lib/source-destination/balena-s3-source.ts:157](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L157)
 
 ___
 
@@ -273,13 +277,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [BalenaS3SourceBase](sourceDestination.BalenaS3SourceBase.md).[captureRejectionSymbol](sourceDestination.BalenaS3SourceBase.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -287,7 +299,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -295,7 +313,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -303,13 +321,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [BalenaS3SourceBase](sourceDestination.BalenaS3SourceBase.md).[defaultMaxListeners](sourceDestination.BalenaS3SourceBase.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -317,13 +373,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -331,7 +388,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -345,7 +402,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -359,13 +416,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:307](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L307)
+[lib/source-destination/source-destination.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L305)
 
 ## Accessors
 
 ### imageSuffix
 
-• `Protected` `get` **imageSuffix**(): `string`
+• `get` **imageSuffix**(): `string`
 
 #### Returns
 
@@ -377,13 +434,13 @@ BalenaS3SourceBase.imageSuffix
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L106)
+[lib/source-destination/balena-s3-source.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L104)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -403,13 +460,13 @@ BalenaS3SourceBase.imageSuffix
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -421,13 +478,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:224](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L224)
+[lib/source-destination/balena-s3-source.ts:222](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L222)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -439,13 +496,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:204](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L204)
+[lib/source-destination/balena-s3-source.ts:202](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L202)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -457,7 +514,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:208](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L208)
+[lib/source-destination/balena-s3-source.ts:206](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L206)
 
 ___
 
@@ -488,7 +545,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -506,7 +563,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L110)
+[lib/source-destination/balena-s3-source.ts:108](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L108)
 
 ___
 
@@ -524,7 +581,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -542,7 +599,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -560,7 +617,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -578,7 +635,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:180](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L180)
+[lib/source-destination/balena-s3-source.ts:178](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L178)
 
 ___
 
@@ -596,7 +653,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -614,7 +671,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -638,7 +695,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:198](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L198)
+[lib/source-destination/balena-s3-source.ts:196](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L196)
 
 ___
 
@@ -662,7 +719,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -687,7 +744,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
@@ -712,7 +769,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -737,13 +794,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
 ### download
 
-▸ `Protected` **download**(`path`, `responseType?`): `Promise`<`AxiosResponse`<`any`, `any`\>\>
+▸ **download**(`path`, `responseType?`): `Promise`<`AxiosResponse`<`any`, `any`\>\>
 
 #### Parameters
 
@@ -762,7 +819,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:122](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L122)
+[lib/source-destination/balena-s3-source.ts:120](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L120)
 
 ___
 
@@ -776,7 +833,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -829,7 +886,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -841,7 +898,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -867,7 +925,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -885,7 +943,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -903,7 +961,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
@@ -921,7 +979,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -946,7 +1004,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -964,13 +1022,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
 ### getName
 
-▸ `Private` **getName**(): `Promise`<`Name`\>
+▸ **getName**(): `Promise`<`Name`\>
 
 #### Returns
 
@@ -978,7 +1036,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:163](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L163)
+[lib/source-destination/balena-s3-source.ts:161](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L161)
 
 ___
 
@@ -996,13 +1054,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
 ### getUrl
 
-▸ `Protected` **getUrl**(`path`): `string`
+▸ **getUrl**(`path`): `string`
 
 #### Parameters
 
@@ -1020,7 +1078,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:126](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L126)
+[lib/source-destination/balena-s3-source.ts:124](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L124)
 
 ___
 
@@ -1028,10 +1086,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -1054,7 +1111,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -1092,7 +1149,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -1123,7 +1180,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -1148,6 +1205,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1178,7 +1236,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1201,6 +1259,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1231,7 +1290,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1249,7 +1308,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1291,7 +1350,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1331,7 +1390,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1343,6 +1402,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1386,7 +1446,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1413,7 +1473,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:184](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L184)
+[lib/source-destination/balena-s3-source.ts:182](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L182)
 
 ___
 
@@ -1449,7 +1509,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1478,6 +1538,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1518,6 +1580,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1555,7 +1618,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1590,7 +1653,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1617,13 +1680,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1670,7 +1733,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1678,13 +1741,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1695,19 +1758,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1732,13 +1795,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1778,7 +1841,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1786,13 +1849,13 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### isESRVersion
 
-▸ `Static` **isESRVersion**(`buildId`): `boolean`
+▸ **isESRVersion**(`buildId`): `boolean`
 
 #### Parameters
 
@@ -1810,18 +1873,19 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:114](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L114)
+[lib/source-destination/balena-s3-source.ts:112](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L112)
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1854,34 +1918,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1892,7 +1955,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1940,13 +2005,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1957,31 +2022,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1989,13 +2051,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -2005,7 +2067,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -2050,9 +2112,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -2072,13 +2134,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -2096,19 +2158,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -2137,4 +2196,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.BalenaS3SourceBase.md
+++ b/doc/classes/sourceDestination.BalenaS3SourceBase.md
@@ -100,7 +100,7 @@
 
 ### constructor
 
-• **new BalenaS3SourceBase**(`«destructured»`)
+• **new BalenaS3SourceBase**(`«destructured»`): [`BalenaS3SourceBase`](sourceDestination.BalenaS3SourceBase.md)
 
 #### Parameters
 
@@ -108,13 +108,17 @@
 | :------ | :------ |
 | `«destructured»` | [`BalenaS3SourceOptions`](../interfaces/sourceDestination.BalenaS3SourceOptions.md) |
 
+#### Returns
+
+[`BalenaS3SourceBase`](sourceDestination.BalenaS3SourceBase.md)
+
 #### Overrides
 
 [SourceDestination](sourceDestination.SourceDestination.md).[constructor](sourceDestination.SourceDestination.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L67)
+[lib/source-destination/balena-s3-source.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L67)
 
 ## Properties
 
@@ -124,7 +128,7 @@
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L60)
+[lib/source-destination/balena-s3-source.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L60)
 
 ___
 
@@ -134,7 +138,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L54)
+[lib/source-destination/balena-s3-source.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L54)
 
 ___
 
@@ -144,7 +148,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L57)
+[lib/source-destination/balena-s3-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L57)
 
 ___
 
@@ -154,7 +158,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L56)
+[lib/source-destination/balena-s3-source.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L56)
 
 ___
 
@@ -164,7 +168,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L53)
+[lib/source-destination/balena-s3-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L53)
 
 ___
 
@@ -174,7 +178,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L59)
+[lib/source-destination/balena-s3-source.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L59)
 
 ___
 
@@ -184,7 +188,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L55)
+[lib/source-destination/balena-s3-source.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L55)
 
 ___
 
@@ -194,7 +198,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L58)
+[lib/source-destination/balena-s3-source.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L58)
 
 ___
 
@@ -202,13 +206,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[captureRejectionSymbol](sourceDestination.SourceDestination.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -216,7 +228,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -224,7 +242,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -232,13 +250,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[defaultMaxListeners](sourceDestination.SourceDestination.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -246,13 +302,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -260,7 +317,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -270,7 +327,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:61](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L61)
+[lib/source-destination/balena-s3-source.ts:61](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L61)
 
 ___
 
@@ -284,7 +341,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -298,13 +355,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:307](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L307)
+[lib/source-destination/source-destination.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L305)
 
 ## Accessors
 
 ### imageSuffix
 
-• `Protected` `get` **imageSuffix**(): `string`
+• `get` **imageSuffix**(): `string`
 
 #### Returns
 
@@ -312,13 +369,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L106)
+[lib/source-destination/balena-s3-source.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L104)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -338,13 +395,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -356,13 +413,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:422](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L422)
+[lib/source-destination/source-destination.ts:420](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L420)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -374,13 +431,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:354](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L354)
+[lib/source-destination/source-destination.ts:352](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L352)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -392,7 +449,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:418](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L418)
+[lib/source-destination/source-destination.ts:416](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L416)
 
 ___
 
@@ -423,7 +480,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -441,7 +498,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L110)
+[lib/source-destination/balena-s3-source.ts:108](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L108)
 
 ___
 
@@ -459,7 +516,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -477,7 +534,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -495,7 +552,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -513,7 +570,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L323)
+[lib/source-destination/source-destination.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L321)
 
 ___
 
@@ -531,7 +588,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -549,7 +606,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -573,7 +630,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:376](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L376)
+[lib/source-destination/source-destination.ts:374](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L374)
 
 ___
 
@@ -597,7 +654,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -622,7 +679,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
@@ -647,7 +704,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -672,13 +729,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
 ### download
 
-▸ `Protected` **download**(`path`, `responseType?`): `Promise`<`AxiosResponse`<`any`, `any`\>\>
+▸ **download**(`path`, `responseType?`): `Promise`<`AxiosResponse`<`any`, `any`\>\>
 
 #### Parameters
 
@@ -693,7 +750,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:122](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L122)
+[lib/source-destination/balena-s3-source.ts:120](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L120)
 
 ___
 
@@ -707,7 +764,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -760,7 +817,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -772,7 +829,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -798,7 +856,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -816,7 +874,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -834,7 +892,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
@@ -852,7 +910,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -877,7 +935,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -895,7 +953,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -913,13 +971,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
 ### getUrl
 
-▸ `Protected` **getUrl**(`path`): `string`
+▸ **getUrl**(`path`): `string`
 
 #### Parameters
 
@@ -933,13 +991,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:126](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L126)
+[lib/source-destination/balena-s3-source.ts:124](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L124)
 
 ___
 
 ### isESR
 
-▸ `Private` **isESR**(): `boolean`
+▸ **isESR**(): `boolean`
 
 #### Returns
 
@@ -947,7 +1005,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:118](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L118)
+[lib/source-destination/balena-s3-source.ts:116](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L116)
 
 ___
 
@@ -955,10 +1013,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -981,7 +1038,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -1019,7 +1076,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -1050,7 +1107,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -1075,6 +1132,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1105,7 +1163,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1128,6 +1186,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1158,7 +1217,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1176,7 +1235,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1218,7 +1277,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1258,7 +1317,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1270,6 +1329,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1313,7 +1373,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1340,7 +1400,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L358)
+[lib/source-destination/source-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L356)
 
 ___
 
@@ -1376,7 +1436,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1405,6 +1465,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1445,6 +1507,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1482,7 +1545,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1517,7 +1580,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1544,13 +1607,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1597,7 +1660,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1605,13 +1668,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1622,19 +1685,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1659,13 +1722,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1705,7 +1768,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1713,13 +1776,13 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### isESRVersion
 
-▸ `Static` **isESRVersion**(`buildId`): `boolean`
+▸ **isESRVersion**(`buildId`): `boolean`
 
 #### Parameters
 
@@ -1733,18 +1796,19 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:114](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L114)
+[lib/source-destination/balena-s3-source.ts:112](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L112)
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1777,34 +1841,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1815,7 +1878,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1863,13 +1928,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1880,31 +1945,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1912,13 +1974,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1928,7 +1990,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1973,9 +2035,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1995,13 +2057,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -2019,19 +2081,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -2060,4 +2119,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.BlockDevice.md
+++ b/doc/classes/sourceDestination.BlockDevice.md
@@ -108,7 +108,7 @@
 
 ### constructor
 
-• **new BlockDevice**(`«destructured»`)
+• **new BlockDevice**(`«destructured»`): [`BlockDevice`](sourceDestination.BlockDevice.md)
 
 #### Parameters
 
@@ -121,13 +121,17 @@
 | › `unmountOnSuccess?` | `boolean` |
 | › `write?` | `boolean` |
 
+#### Returns
+
+[`BlockDevice`](sourceDestination.BlockDevice.md)
+
 #### Overrides
 
 [File](sourceDestination.File.md).[constructor](sourceDestination.File.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L53)
+[lib/source-destination/block-device.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L53)
 
 ## Properties
 
@@ -137,7 +141,7 @@
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L51)
+[lib/source-destination/block-device.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L51)
 
 ___
 
@@ -147,7 +151,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L46)
+[lib/source-destination/block-device.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L46)
 
 ___
 
@@ -161,7 +165,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L49)
+[lib/source-destination/block-device.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L49)
 
 ___
 
@@ -175,7 +179,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L48)
+[lib/source-destination/file.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L48)
 
 ___
 
@@ -185,7 +189,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L50)
+[lib/source-destination/block-device.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L50)
 
 ___
 
@@ -195,7 +199,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L48)
+[lib/source-destination/block-device.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L48)
 
 ___
 
@@ -209,7 +213,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L47)
+[lib/source-destination/file.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L47)
 
 ___
 
@@ -223,7 +227,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L46)
+[lib/source-destination/file.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L46)
 
 ___
 
@@ -233,7 +237,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L47)
+[lib/source-destination/block-device.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L47)
 
 ___
 
@@ -241,13 +245,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [File](sourceDestination.File.md).[captureRejectionSymbol](sourceDestination.File.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -255,7 +267,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -263,7 +281,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -271,13 +289,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [File](sourceDestination.File.md).[defaultMaxListeners](sourceDestination.File.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -285,13 +341,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -299,7 +356,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -313,7 +370,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -327,7 +384,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:307](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L307)
+[lib/source-destination/source-destination.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L305)
 
 ## Accessors
 
@@ -345,7 +402,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:119](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L119)
+[lib/source-destination/block-device.ts:120](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L120)
 
 ___
 
@@ -363,7 +420,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:111](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L111)
+[lib/source-destination/block-device.ts:112](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L112)
 
 ___
 
@@ -381,7 +438,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:115](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L115)
+[lib/source-destination/block-device.ts:116](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L116)
 
 ___
 
@@ -399,7 +456,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:103](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L103)
+[lib/source-destination/block-device.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L104)
 
 ___
 
@@ -417,7 +474,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:123](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L123)
+[lib/source-destination/block-device.ts:124](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L124)
 
 ___
 
@@ -435,7 +492,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:107](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L107)
+[lib/source-destination/block-device.ts:108](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L108)
 
 ___
 
@@ -453,13 +510,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:127](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L127)
+[lib/source-destination/block-device.ts:128](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L128)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -483,13 +540,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -505,13 +562,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:199](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L199)
+[lib/source-destination/block-device.ts:200](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L200)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -527,13 +584,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:131](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L131)
+[lib/source-destination/block-device.ts:132](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L132)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -549,7 +606,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:179](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L179)
+[lib/source-destination/block-device.ts:180](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L180)
 
 ___
 
@@ -584,13 +641,13 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
 ### alignOffsetAfter
 
-▸ `Private` **alignOffsetAfter**(`offset`): `number`
+▸ **alignOffsetAfter**(`offset`): `number`
 
 #### Parameters
 
@@ -604,13 +661,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:220](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L220)
+[lib/source-destination/block-device.ts:221](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L221)
 
 ___
 
 ### alignOffsetBefore
 
-▸ `Private` **alignOffsetBefore**(`offset`): `number`
+▸ **alignOffsetBefore**(`offset`): `number`
 
 #### Parameters
 
@@ -624,13 +681,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:216](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L216)
+[lib/source-destination/block-device.ts:217](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L217)
 
 ___
 
 ### alignedRead
 
-▸ `Private` **alignedRead**(`buffer`, `bufferOffset`, `length`, `sourceOffset`): `Promise`<`ReadResult`\>
+▸ **alignedRead**(`buffer`, `bufferOffset`, `length`, `sourceOffset`): `Promise`<`ReadResult`\>
 
 #### Parameters
 
@@ -647,13 +704,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:224](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L224)
+[lib/source-destination/block-device.ts:225](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L225)
 
 ___
 
 ### alignedWrite
 
-▸ `Private` **alignedWrite**(`buffer`, `bufferOffset`, `length`, `fileOffset`): `Promise`<`WriteResult`\>
+▸ **alignedWrite**(`buffer`, `bufferOffset`, `length`, `fileOffset`): `Promise`<`WriteResult`\>
 
 #### Parameters
 
@@ -670,7 +727,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:257](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L257)
+[lib/source-destination/block-device.ts:258](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L258)
 
 ___
 
@@ -692,7 +749,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L71)
+[lib/source-destination/file.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L71)
 
 ___
 
@@ -714,7 +771,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -736,7 +793,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:146](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L146)
+[lib/source-destination/block-device.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L147)
 
 ___
 
@@ -758,7 +815,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:142](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L142)
+[lib/source-destination/block-device.ts:143](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L143)
 
 ___
 
@@ -780,7 +837,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L63)
+[lib/source-destination/file.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L63)
 
 ___
 
@@ -802,7 +859,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:138](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L138)
+[lib/source-destination/block-device.ts:139](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L139)
 
 ___
 
@@ -824,7 +881,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -852,7 +909,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L147)
+[lib/source-destination/file.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L147)
 
 ___
 
@@ -880,7 +937,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -909,7 +966,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:167](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L167)
+[lib/source-destination/block-device.ts:168](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L168)
 
 ___
 
@@ -938,7 +995,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -968,7 +1025,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L150)
+[lib/source-destination/block-device.ts:151](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L151)
 
 ___
 
@@ -982,7 +1039,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -1039,7 +1096,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -1051,7 +1108,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -1081,7 +1139,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -1103,7 +1161,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:78](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L78)
+[lib/source-destination/block-device.ts:78](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L78)
 
 ___
 
@@ -1125,7 +1183,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
@@ -1147,7 +1205,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -1176,7 +1234,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -1198,13 +1256,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
 ### getOpenFlags
 
-▸ `Protected` **getOpenFlags**(): `number`
+▸ **getOpenFlags**(): `number`
 
 #### Returns
 
@@ -1216,7 +1274,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L84)
+[lib/source-destination/block-device.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L84)
 
 ___
 
@@ -1238,7 +1296,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
@@ -1246,10 +1304,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -1276,7 +1333,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -1318,7 +1375,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -1353,13 +1410,13 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
 ### offsetIsAligned
 
-▸ `Private` **offsetIsAligned**(`offset`): `boolean`
+▸ **offsetIsAligned**(`offset`): `boolean`
 
 #### Parameters
 
@@ -1373,7 +1430,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:212](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L212)
+[lib/source-destination/block-device.ts:213](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L213)
 
 ___
 
@@ -1398,6 +1455,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1432,7 +1490,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1455,6 +1513,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1489,7 +1548,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1511,7 +1570,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1557,7 +1616,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1601,7 +1660,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1613,6 +1672,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1660,7 +1720,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1691,7 +1751,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:244](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L244)
+[lib/source-destination/block-device.ts:245](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L245)
 
 ___
 
@@ -1731,7 +1791,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1760,6 +1820,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1800,6 +1862,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1841,7 +1904,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1880,7 +1943,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1911,13 +1974,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/block-device.ts:273](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/block-device.ts#L273)
+[lib/source-destination/block-device.ts:274](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/block-device.ts#L274)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1964,7 +2027,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1972,13 +2035,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1989,19 +2052,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -2026,13 +2089,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -2072,7 +2135,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -2080,18 +2143,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -2124,34 +2188,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -2162,7 +2225,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -2210,13 +2275,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -2227,31 +2292,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -2259,13 +2321,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -2275,7 +2337,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -2320,9 +2382,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -2342,13 +2404,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -2366,19 +2428,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -2407,4 +2466,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.CompressedSource.md
+++ b/doc/classes/sourceDestination.CompressedSource.md
@@ -90,7 +90,7 @@
 
 ### constructor
 
-• **new CompressedSource**(`source`)
+• **new CompressedSource**(`source`): [`CompressedSource`](sourceDestination.CompressedSource.md)
 
 #### Parameters
 
@@ -98,13 +98,17 @@
 | :------ | :------ |
 | `source` | [`SourceDestination`](sourceDestination.SourceDestination.md) |
 
+#### Returns
+
+[`CompressedSource`](sourceDestination.CompressedSource.md)
+
 #### Inherited from
 
 [SourceSource](sourceDestination.SourceSource.md).[constructor](sourceDestination.SourceSource.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L22)
+[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L22)
 
 ## Properties
 
@@ -118,7 +122,7 @@
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L22)
+[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L22)
 
 ___
 
@@ -126,13 +130,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [SourceSource](sourceDestination.SourceSource.md).[captureRejectionSymbol](sourceDestination.SourceSource.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -140,7 +152,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -148,7 +166,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -156,13 +174,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [SourceSource](sourceDestination.SourceSource.md).[defaultMaxListeners](sourceDestination.SourceSource.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -170,13 +226,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -184,7 +241,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -198,7 +255,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -212,7 +269,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:307](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L307)
+[lib/source-destination/source-destination.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L305)
 
 ___
 
@@ -226,13 +283,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L20)
+[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L20)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -252,13 +309,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -270,13 +327,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L30)
+[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L30)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -288,13 +345,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L106)
+[lib/source-destination/compressed-source.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L106)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -306,7 +363,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L26)
+[lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L26)
 
 ___
 
@@ -337,7 +394,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -355,7 +412,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L53)
+[lib/source-destination/compressed-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L53)
 
 ___
 
@@ -373,7 +430,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -391,7 +448,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -409,7 +466,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -427,7 +484,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L323)
+[lib/source-destination/source-destination.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L321)
 
 ___
 
@@ -445,7 +502,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -463,7 +520,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -487,7 +544,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L57)
+[lib/source-destination/compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L57)
 
 ___
 
@@ -511,7 +568,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -536,13 +593,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
 ### createTransform
 
-▸ `Protected` `Abstract` **createTransform**(): `Transform`
+▸ **createTransform**(): `Transform`
 
 #### Returns
 
@@ -550,7 +607,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L45)
+[lib/source-destination/compressed-source.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L45)
 
 ___
 
@@ -575,7 +632,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -600,7 +657,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
@@ -614,7 +671,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -667,7 +724,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -679,7 +736,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -705,7 +763,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -723,7 +781,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -741,7 +799,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
@@ -759,7 +817,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -784,7 +842,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -802,7 +860,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -820,13 +878,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
 ### getSize
 
-▸ `Protected` **getSize**(): `Promise`<`undefined` \| { `isEstimated`: `boolean` ; `size`: `number`  }\>
+▸ **getSize**(): `Promise`<`undefined` \| { `isEstimated`: `boolean` ; `size`: `number`  }\>
 
 #### Returns
 
@@ -834,13 +892,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L47)
+[lib/source-destination/compressed-source.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L47)
 
 ___
 
 ### getSizeFromPartitionTable
 
-▸ `Protected` **getSizeFromPartitionTable**(): `Promise`<`undefined` \| `number`\>
+▸ **getSizeFromPartitionTable**(): `Promise`<`undefined` \| `number`\>
 
 #### Returns
 
@@ -848,7 +906,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L87)
+[lib/source-destination/compressed-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L87)
 
 ___
 
@@ -856,10 +914,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -882,7 +939,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -920,7 +977,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -951,7 +1008,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -976,6 +1033,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1006,7 +1064,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1029,6 +1087,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1059,7 +1118,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1077,7 +1136,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1119,7 +1178,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1159,7 +1218,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1171,6 +1230,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1214,7 +1274,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1241,7 +1301,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L358)
+[lib/source-destination/source-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L356)
 
 ___
 
@@ -1277,7 +1337,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1306,6 +1366,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1346,6 +1408,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1383,7 +1446,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1418,7 +1481,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1445,13 +1508,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1498,7 +1561,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1506,13 +1569,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1523,19 +1586,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1560,13 +1623,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1606,7 +1669,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1614,18 +1677,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1658,34 +1722,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1696,7 +1759,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1744,13 +1809,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1761,31 +1826,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1793,13 +1855,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1809,7 +1871,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1854,9 +1916,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1876,13 +1938,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -1900,19 +1962,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1941,4 +2000,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.ConfiguredSource.md
+++ b/doc/classes/sourceDestination.ConfiguredSource.md
@@ -91,7 +91,7 @@
 
 ### constructor
 
-• **new ConfiguredSource**(`«destructured»`)
+• **new ConfiguredSource**(`«destructured»`): [`ConfiguredSource`](sourceDestination.ConfiguredSource.md)
 
 #### Parameters
 
@@ -105,13 +105,17 @@
 | › `shouldTrimPartitions` | `boolean` |
 | › `source` | [`SourceDestination`](sourceDestination.SourceDestination.md) |
 
+#### Returns
+
+[`ConfiguredSource`](sourceDestination.ConfiguredSource.md)
+
 #### Overrides
 
 [SourceSource](sourceDestination.SourceSource.md).[constructor](sourceDestination.SourceSource.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:103](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L103)
+[lib/source-destination/configured-source/configured-source.ts:107](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L107)
 
 ## Properties
 
@@ -121,7 +125,7 @@
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:98](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L98)
+[lib/source-destination/configured-source/configured-source.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L102)
 
 ___
 
@@ -131,7 +135,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:99](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L99)
+[lib/source-destination/configured-source/configured-source.ts:103](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L103)
 
 ___
 
@@ -141,7 +145,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L101)
+[lib/source-destination/configured-source/configured-source.ts:105](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L105)
 
 ___
 
@@ -151,7 +155,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:97](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L97)
+[lib/source-destination/configured-source/configured-source.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L101)
 
 ___
 
@@ -161,7 +165,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:100](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L100)
+[lib/source-destination/configured-source/configured-source.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L104)
 
 ___
 
@@ -171,7 +175,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:96](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L96)
+[lib/source-destination/configured-source/configured-source.ts:100](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L100)
 
 ___
 
@@ -185,7 +189,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L22)
+[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L22)
 
 ___
 
@@ -193,13 +197,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [SourceSource](sourceDestination.SourceSource.md).[captureRejectionSymbol](sourceDestination.SourceSource.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -207,7 +219,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -215,7 +233,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -223,13 +241,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [SourceSource](sourceDestination.SourceSource.md).[defaultMaxListeners](sourceDestination.SourceSource.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -237,13 +293,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -251,7 +308,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -265,7 +322,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -279,7 +336,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:307](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L307)
+[lib/source-destination/source-destination.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L305)
 
 ___
 
@@ -293,13 +350,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L20)
+[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L20)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -319,13 +376,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -337,13 +394,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:301](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L301)
+[lib/source-destination/configured-source/configured-source.ts:309](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L309)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -355,13 +412,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:248](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L248)
+[lib/source-destination/configured-source/configured-source.ts:252](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L252)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -373,7 +430,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:290](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L290)
+[lib/source-destination/configured-source/configured-source.ts:298](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L298)
 
 ___
 
@@ -404,7 +461,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -422,7 +479,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:162](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L162)
+[lib/source-destination/configured-source/configured-source.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L166)
 
 ___
 
@@ -440,7 +497,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L166)
+[lib/source-destination/configured-source/configured-source.ts:170](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L170)
 
 ___
 
@@ -458,7 +515,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -476,7 +533,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -494,7 +551,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:158](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L158)
+[lib/source-destination/configured-source/configured-source.ts:162](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L162)
 
 ___
 
@@ -512,7 +569,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -530,7 +587,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -554,7 +611,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:179](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L179)
+[lib/source-destination/configured-source/configured-source.ts:183](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L183)
 
 ___
 
@@ -578,13 +635,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:226](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L226)
+[lib/source-destination/configured-source/configured-source.ts:230](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L230)
 
 ___
 
 ### createSparseReadStreamFromDisk
 
-▸ `Private` **createSparseReadStreamFromDisk**(`generateChecksums`, `alignment?`, `numBuffers?`): `Promise`<[`SparseReadStream`](sparseStream.SparseReadStream.md)\>
+▸ **createSparseReadStreamFromDisk**(`generateChecksums`, `alignment?`, `numBuffers?`): `Promise`<[`SparseReadStream`](sparseStream.SparseReadStream.md)\>
 
 #### Parameters
 
@@ -600,13 +657,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:191](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L191)
+[lib/source-destination/configured-source/configured-source.ts:195](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L195)
 
 ___
 
 ### createSparseReadStreamFromStream
 
-▸ `Private` **createSparseReadStreamFromStream**(`generateChecksums`, `alignment?`, `numBuffers?`): `Promise`<[`SparseFilterStream`](sparseStream.SparseFilterStream.md)\>
+▸ **createSparseReadStreamFromStream**(`generateChecksums`, `alignment?`, `numBuffers?`): `Promise`<[`SparseFilterStream`](sparseStream.SparseFilterStream.md)\>
 
 #### Parameters
 
@@ -622,7 +679,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:207](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L207)
+[lib/source-destination/configured-source/configured-source.ts:211](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L211)
 
 ___
 
@@ -647,7 +704,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
@@ -672,7 +729,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -697,7 +754,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
@@ -711,7 +768,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -764,7 +821,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -776,7 +833,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -802,7 +860,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -820,7 +878,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -838,13 +896,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:131](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L131)
+[lib/source-destination/configured-source/configured-source.ts:135](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L135)
 
 ___
 
 ### getBlocksWithChecksumType
 
-▸ `Private` **getBlocksWithChecksumType**(`generateChecksums`): `Promise`<[`BlocksWithChecksum`](../interfaces/sparseStream.BlocksWithChecksum.md)[]\>
+▸ **getBlocksWithChecksumType**(`generateChecksums`): `Promise`<[`BlocksWithChecksum`](../interfaces/sparseStream.BlocksWithChecksum.md)[]\>
 
 #### Parameters
 
@@ -858,7 +916,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:145](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L145)
+[lib/source-destination/configured-source/configured-source.ts:149](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L149)
 
 ___
 
@@ -876,7 +934,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -901,7 +959,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -919,7 +977,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -937,7 +995,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
@@ -945,10 +1003,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -971,7 +1028,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -1009,7 +1066,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -1040,7 +1097,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -1065,6 +1122,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1095,7 +1153,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1118,6 +1176,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1148,7 +1207,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1166,7 +1225,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1208,7 +1267,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1248,7 +1307,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1260,6 +1319,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1303,7 +1363,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1330,7 +1390,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:170](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L170)
+[lib/source-destination/configured-source/configured-source.ts:174](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L174)
 
 ___
 
@@ -1366,7 +1426,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1395,6 +1455,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1435,6 +1497,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1472,7 +1535,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1507,13 +1570,13 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
 ### trimPartitions
 
-▸ `Private` **trimPartitions**(): `Promise`<`void`\>
+▸ **trimPartitions**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -1521,7 +1584,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:255](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L255)
+[lib/source-destination/configured-source/configured-source.ts:259](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L259)
 
 ___
 
@@ -1548,13 +1611,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1601,7 +1664,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1609,13 +1672,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1626,19 +1689,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1663,13 +1726,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1709,7 +1772,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1717,18 +1780,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1761,34 +1825,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1799,7 +1862,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1847,13 +1912,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1864,31 +1929,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1896,13 +1958,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1912,7 +1974,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1957,9 +2019,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1979,13 +2041,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -2003,19 +2065,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -2044,4 +2103,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.CountingHashStream.md
+++ b/doc/classes/sourceDestination.CountingHashStream.md
@@ -120,7 +120,7 @@
 
 ### constructor
 
-• **new CountingHashStream**(`seed`, `outEnc`)
+• **new CountingHashStream**(`seed`, `outEnc`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
 #### Parameters
 
@@ -129,13 +129,17 @@
 | `seed` | `Buffer` |
 | `outEnc` | `string` \| `Buffer` |
 
+#### Returns
+
+[`CountingHashStream`](sourceDestination.CountingHashStream.md)
+
 #### Inherited from
 
 HashStream.constructor
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L47)
+[lib/source-destination/source-destination.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L47)
 
 ## Properties
 
@@ -145,7 +149,7 @@ HashStream.constructor
 
 If `false` then the stream will automatically end the writable side when the
 readable side ends. Set initially by the `allowHalfOpen` constructor option,
-which defaults to `false`.
+which defaults to `true`.
 
 This can be changed manually to change the half-open behavior of an existing`Duplex` stream instance, but must be changed before the `'end'` event is
 emitted.
@@ -160,7 +164,7 @@ HashStream.allowHalfOpen
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1060
+node_modules/@types/node/stream.d.ts:1068
 
 ___
 
@@ -170,7 +174,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L67)
+[lib/source-destination/source-destination.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L67)
 
 ___
 
@@ -184,7 +188,7 @@ HashStream.closed
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1049
+node_modules/@types/node/stream.d.ts:1057
 
 ___
 
@@ -204,7 +208,7 @@ HashStream.destroyed
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:145
+node_modules/@types/node/stream.d.ts:114
 
 ___
 
@@ -218,7 +222,7 @@ HashStream.errored
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1050
+node_modules/@types/node/stream.d.ts:1058
 
 ___
 
@@ -239,7 +243,7 @@ HashStream.readable
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:101
+node_modules/@types/node/stream.d.ts:70
 
 ___
 
@@ -259,7 +263,7 @@ HashStream.readableAborted
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:95
+node_modules/@types/node/stream.d.ts:64
 
 ___
 
@@ -279,7 +283,7 @@ HashStream.readableDidRead
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:107
+node_modules/@types/node/stream.d.ts:76
 
 ___
 
@@ -299,7 +303,7 @@ HashStream.readableEncoding
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:112
+node_modules/@types/node/stream.d.ts:81
 
 ___
 
@@ -319,7 +323,7 @@ HashStream.readableEnded
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:117
+node_modules/@types/node/stream.d.ts:86
 
 ___
 
@@ -340,7 +344,7 @@ HashStream.readableFlowing
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:123
+node_modules/@types/node/stream.d.ts:92
 
 ___
 
@@ -360,7 +364,7 @@ HashStream.readableHighWaterMark
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:128
+node_modules/@types/node/stream.d.ts:97
 
 ___
 
@@ -382,7 +386,7 @@ HashStream.readableLength
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:135
+node_modules/@types/node/stream.d.ts:104
 
 ___
 
@@ -402,7 +406,7 @@ HashStream.readableObjectMode
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:140
+node_modules/@types/node/stream.d.ts:109
 
 ___
 
@@ -416,7 +420,7 @@ HashStream.writable
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1041
+node_modules/@types/node/stream.d.ts:1049
 
 ___
 
@@ -430,7 +434,7 @@ HashStream.writableCorked
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1047
+node_modules/@types/node/stream.d.ts:1055
 
 ___
 
@@ -444,7 +448,7 @@ HashStream.writableEnded
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1042
+node_modules/@types/node/stream.d.ts:1050
 
 ___
 
@@ -458,7 +462,7 @@ HashStream.writableFinished
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1043
+node_modules/@types/node/stream.d.ts:1051
 
 ___
 
@@ -472,7 +476,7 @@ HashStream.writableHighWaterMark
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1044
+node_modules/@types/node/stream.d.ts:1052
 
 ___
 
@@ -486,7 +490,7 @@ HashStream.writableLength
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1045
+node_modules/@types/node/stream.d.ts:1053
 
 ___
 
@@ -500,7 +504,7 @@ HashStream.writableNeedDrain
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1048
+node_modules/@types/node/stream.d.ts:1056
 
 ___
 
@@ -514,7 +518,7 @@ HashStream.writableObjectMode
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1046
+node_modules/@types/node/stream.d.ts:1054
 
 ___
 
@@ -522,13 +526,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 HashStream.captureRejectionSymbol
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -536,7 +548,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -544,7 +562,7 @@ HashStream.captureRejections
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -552,13 +570,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 HashStream.defaultMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -566,13 +622,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -580,7 +637,7 @@ HashStream.errorMonitor
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ## Methods
 
@@ -596,7 +653,7 @@ Calls `readable.destroy()` with an `AbortError` and returns a promise that fulfi
 
 **`Since`**
 
-v18.18.0
+v20.4.0
 
 #### Inherited from
 
@@ -604,7 +661,7 @@ HashStream.[asyncDispose]
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:682
+node_modules/@types/node/stream.d.ts:651
 
 ___
 
@@ -622,13 +679,13 @@ HashStream.[asyncIterator]
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:677
+node_modules/@types/node/stream.d.ts:646
 
 ___
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -648,7 +705,7 @@ HashStream.[captureRejectionSymbol]
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
@@ -669,13 +726,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:69](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L69)
+[lib/source-destination/source-destination.ts:69](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L69)
 
 ___
 
 ### \_construct
 
-▸ `Optional` **_construct**(`callback`): `void`
+▸ **_construct**(`callback`): `void`
 
 #### Parameters
 
@@ -693,7 +750,7 @@ HashStream.\_construct
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:157
+node_modules/@types/node/stream.d.ts:126
 
 ___
 
@@ -706,7 +763,7 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `error` | ``null`` \| `Error` |
-| `callback` | (`error`: ``null`` \| `Error`) => `void` |
+| `callback` | (`error?`: ``null`` \| `Error`) => `void` |
 
 #### Returns
 
@@ -718,7 +775,7 @@ HashStream.\_destroy
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1103
+node_modules/@types/node/stream.d.ts:1111
 
 ___
 
@@ -742,7 +799,7 @@ HashStream.\_final
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1104
+node_modules/@types/node/stream.d.ts:1112
 
 ___
 
@@ -766,7 +823,7 @@ HashStream.\_flush
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L60)
+[lib/source-destination/source-destination.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L60)
 
 ___
 
@@ -790,7 +847,7 @@ HashStream.\_read
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:158
+node_modules/@types/node/stream.d.ts:127
 
 ___
 
@@ -816,7 +873,7 @@ HashStream.\_transform
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L86)
+[lib/source-destination/source-destination.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L86)
 
 ___
 
@@ -842,13 +899,13 @@ HashStream.\_write
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1095
+node_modules/@types/node/stream.d.ts:1103
 
 ___
 
 ### \_writev
 
-▸ `Optional` **_writev**(`chunks`, `callback`): `void`
+▸ **_writev**(`chunks`, `callback`): `void`
 
 #### Parameters
 
@@ -867,7 +924,7 @@ HashStream.\_writev
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1096
+node_modules/@types/node/stream.d.ts:1104
 
 ___
 
@@ -906,7 +963,7 @@ HashStream.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1128
+node_modules/@types/node/stream.d.ts:1160
 
 ▸ **addListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -927,7 +984,7 @@ HashStream.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1129
+node_modules/@types/node/stream.d.ts:1161
 
 ▸ **addListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -948,7 +1005,7 @@ HashStream.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1130
+node_modules/@types/node/stream.d.ts:1162
 
 ▸ **addListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -969,7 +1026,7 @@ HashStream.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1131
+node_modules/@types/node/stream.d.ts:1163
 
 ▸ **addListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -990,7 +1047,7 @@ HashStream.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1132
+node_modules/@types/node/stream.d.ts:1164
 
 ▸ **addListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -1011,7 +1068,7 @@ HashStream.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1133
+node_modules/@types/node/stream.d.ts:1165
 
 ▸ **addListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -1032,7 +1089,7 @@ HashStream.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1134
+node_modules/@types/node/stream.d.ts:1166
 
 ▸ **addListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -1053,7 +1110,7 @@ HashStream.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1135
+node_modules/@types/node/stream.d.ts:1167
 
 ▸ **addListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -1074,7 +1131,7 @@ HashStream.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1136
+node_modules/@types/node/stream.d.ts:1168
 
 ▸ **addListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -1095,7 +1152,7 @@ HashStream.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1137
+node_modules/@types/node/stream.d.ts:1169
 
 ▸ **addListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -1116,7 +1173,7 @@ HashStream.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1138
+node_modules/@types/node/stream.d.ts:1170
 
 ▸ **addListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -1137,7 +1194,7 @@ HashStream.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1139
+node_modules/@types/node/stream.d.ts:1171
 
 ___
 
@@ -1170,7 +1227,7 @@ HashStream.asIndexedPairs
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:572
+node_modules/@types/node/stream.d.ts:541
 
 ___
 
@@ -1220,7 +1277,7 @@ HashStream.cork
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1111
+node_modules/@types/node/stream.d.ts:1119
 
 ___
 
@@ -1256,7 +1313,7 @@ HashStream.destroy
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:609
+node_modules/@types/node/stream.d.ts:578
 
 ___
 
@@ -1289,7 +1346,7 @@ HashStream.drop
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:558
+node_modules/@types/node/stream.d.ts:527
 
 ___
 
@@ -1313,7 +1370,7 @@ HashStream.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1140
+node_modules/@types/node/stream.d.ts:1172
 
 ▸ **emit**(`event`, `chunk`): `boolean`
 
@@ -1334,7 +1391,7 @@ HashStream.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1141
+node_modules/@types/node/stream.d.ts:1173
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1354,7 +1411,7 @@ HashStream.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1142
+node_modules/@types/node/stream.d.ts:1174
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1374,7 +1431,7 @@ HashStream.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1143
+node_modules/@types/node/stream.d.ts:1175
 
 ▸ **emit**(`event`, `err`): `boolean`
 
@@ -1395,7 +1452,7 @@ HashStream.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1144
+node_modules/@types/node/stream.d.ts:1176
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1415,7 +1472,7 @@ HashStream.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1145
+node_modules/@types/node/stream.d.ts:1177
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1435,7 +1492,7 @@ HashStream.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1146
+node_modules/@types/node/stream.d.ts:1178
 
 ▸ **emit**(`event`, `src`): `boolean`
 
@@ -1456,7 +1513,7 @@ HashStream.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1147
+node_modules/@types/node/stream.d.ts:1179
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1476,7 +1533,7 @@ HashStream.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1148
+node_modules/@types/node/stream.d.ts:1180
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1496,7 +1553,7 @@ HashStream.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1149
+node_modules/@types/node/stream.d.ts:1181
 
 ▸ **emit**(`event`, `src`): `boolean`
 
@@ -1517,7 +1574,7 @@ HashStream.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1150
+node_modules/@types/node/stream.d.ts:1182
 
 ▸ **emit**(`event`, `...args`): `boolean`
 
@@ -1538,7 +1595,7 @@ HashStream.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1151
+node_modules/@types/node/stream.d.ts:1183
 
 ___
 
@@ -1562,7 +1619,7 @@ HashStream.end
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1108
+node_modules/@types/node/stream.d.ts:1116
 
 ▸ **end**(`chunk`, `cb?`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -1583,7 +1640,7 @@ HashStream.end
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1109
+node_modules/@types/node/stream.d.ts:1117
 
 ▸ **end**(`chunk`, `encoding?`, `cb?`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -1605,7 +1662,7 @@ HashStream.end
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1110
+node_modules/@types/node/stream.d.ts:1118
 
 ___
 
@@ -1617,7 +1674,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -1643,7 +1701,7 @@ HashStream.eventNames
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -1679,7 +1737,7 @@ HashStream.every
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:537
+node_modules/@types/node/stream.d.ts:506
 
 ___
 
@@ -1714,7 +1772,7 @@ HashStream.filter
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:465
+node_modules/@types/node/stream.d.ts:434
 
 ___
 
@@ -1757,7 +1815,7 @@ HashStream.find
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:520
+node_modules/@types/node/stream.d.ts:489
 
 ▸ **find**(`fn`, `options?`): `Promise`<`any`\>
 
@@ -1778,7 +1836,7 @@ HashStream.find
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:524
+node_modules/@types/node/stream.d.ts:493
 
 ___
 
@@ -1815,7 +1873,7 @@ HashStream.flatMap
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:551
+node_modules/@types/node/stream.d.ts:520
 
 ___
 
@@ -1857,7 +1915,7 @@ HashStream.forEach
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:484
+node_modules/@types/node/stream.d.ts:453
 
 ___
 
@@ -1882,7 +1940,7 @@ HashStream.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -1918,7 +1976,7 @@ HashStream.isPaused
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:318
+node_modules/@types/node/stream.d.ts:287
 
 ___
 
@@ -1951,7 +2009,7 @@ HashStream.iterator
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:448
+node_modules/@types/node/stream.d.ts:417
 
 ___
 
@@ -1959,10 +2017,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -1985,7 +2042,7 @@ HashStream.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -2023,7 +2080,7 @@ HashStream.listeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -2057,7 +2114,7 @@ HashStream.map
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:456
+node_modules/@types/node/stream.d.ts:425
 
 ___
 
@@ -2088,7 +2145,7 @@ HashStream.off
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -2113,7 +2170,7 @@ HashStream.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1152
+node_modules/@types/node/stream.d.ts:1184
 
 ▸ **on**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2134,7 +2191,7 @@ HashStream.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1153
+node_modules/@types/node/stream.d.ts:1185
 
 ▸ **on**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2155,7 +2212,7 @@ HashStream.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1154
+node_modules/@types/node/stream.d.ts:1186
 
 ▸ **on**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2176,7 +2233,7 @@ HashStream.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1155
+node_modules/@types/node/stream.d.ts:1187
 
 ▸ **on**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2197,7 +2254,7 @@ HashStream.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1156
+node_modules/@types/node/stream.d.ts:1188
 
 ▸ **on**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2218,7 +2275,7 @@ HashStream.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1157
+node_modules/@types/node/stream.d.ts:1189
 
 ▸ **on**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2239,7 +2296,7 @@ HashStream.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1158
+node_modules/@types/node/stream.d.ts:1190
 
 ▸ **on**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2260,7 +2317,7 @@ HashStream.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1159
+node_modules/@types/node/stream.d.ts:1191
 
 ▸ **on**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2281,7 +2338,7 @@ HashStream.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1160
+node_modules/@types/node/stream.d.ts:1192
 
 ▸ **on**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2302,7 +2359,7 @@ HashStream.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1161
+node_modules/@types/node/stream.d.ts:1193
 
 ▸ **on**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2323,7 +2380,7 @@ HashStream.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1162
+node_modules/@types/node/stream.d.ts:1194
 
 ▸ **on**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2344,7 +2401,7 @@ HashStream.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1163
+node_modules/@types/node/stream.d.ts:1195
 
 ___
 
@@ -2369,7 +2426,7 @@ HashStream.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1164
+node_modules/@types/node/stream.d.ts:1196
 
 ▸ **once**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2390,7 +2447,7 @@ HashStream.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1165
+node_modules/@types/node/stream.d.ts:1197
 
 ▸ **once**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2411,7 +2468,7 @@ HashStream.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1166
+node_modules/@types/node/stream.d.ts:1198
 
 ▸ **once**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2432,7 +2489,7 @@ HashStream.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1167
+node_modules/@types/node/stream.d.ts:1199
 
 ▸ **once**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2453,7 +2510,7 @@ HashStream.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1168
+node_modules/@types/node/stream.d.ts:1200
 
 ▸ **once**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2474,7 +2531,7 @@ HashStream.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1169
+node_modules/@types/node/stream.d.ts:1201
 
 ▸ **once**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2495,7 +2552,7 @@ HashStream.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1170
+node_modules/@types/node/stream.d.ts:1202
 
 ▸ **once**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2516,7 +2573,7 @@ HashStream.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1171
+node_modules/@types/node/stream.d.ts:1203
 
 ▸ **once**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2537,7 +2594,7 @@ HashStream.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1172
+node_modules/@types/node/stream.d.ts:1204
 
 ▸ **once**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2558,7 +2615,7 @@ HashStream.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1173
+node_modules/@types/node/stream.d.ts:1205
 
 ▸ **once**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2579,7 +2636,7 @@ HashStream.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1174
+node_modules/@types/node/stream.d.ts:1206
 
 ▸ **once**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2600,7 +2657,7 @@ HashStream.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1175
+node_modules/@types/node/stream.d.ts:1207
 
 ___
 
@@ -2641,7 +2698,7 @@ HashStream.pause
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:282
+node_modules/@types/node/stream.d.ts:251
 
 ___
 
@@ -2698,7 +2755,7 @@ HashStream.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1176
+node_modules/@types/node/stream.d.ts:1208
 
 ▸ **prependListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2719,7 +2776,7 @@ HashStream.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1177
+node_modules/@types/node/stream.d.ts:1209
 
 ▸ **prependListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2740,7 +2797,7 @@ HashStream.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1178
+node_modules/@types/node/stream.d.ts:1210
 
 ▸ **prependListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2761,7 +2818,7 @@ HashStream.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1179
+node_modules/@types/node/stream.d.ts:1211
 
 ▸ **prependListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2782,7 +2839,7 @@ HashStream.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1180
+node_modules/@types/node/stream.d.ts:1212
 
 ▸ **prependListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2803,7 +2860,7 @@ HashStream.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1181
+node_modules/@types/node/stream.d.ts:1213
 
 ▸ **prependListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2824,7 +2881,7 @@ HashStream.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1182
+node_modules/@types/node/stream.d.ts:1214
 
 ▸ **prependListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2845,7 +2902,7 @@ HashStream.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1183
+node_modules/@types/node/stream.d.ts:1215
 
 ▸ **prependListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2866,7 +2923,7 @@ HashStream.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1184
+node_modules/@types/node/stream.d.ts:1216
 
 ▸ **prependListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2887,7 +2944,7 @@ HashStream.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1185
+node_modules/@types/node/stream.d.ts:1217
 
 ▸ **prependListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2908,7 +2965,7 @@ HashStream.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1186
+node_modules/@types/node/stream.d.ts:1218
 
 ▸ **prependListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2929,7 +2986,7 @@ HashStream.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1187
+node_modules/@types/node/stream.d.ts:1219
 
 ___
 
@@ -2954,7 +3011,7 @@ HashStream.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1188
+node_modules/@types/node/stream.d.ts:1220
 
 ▸ **prependOnceListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2975,7 +3032,7 @@ HashStream.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1189
+node_modules/@types/node/stream.d.ts:1221
 
 ▸ **prependOnceListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -2996,7 +3053,7 @@ HashStream.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1190
+node_modules/@types/node/stream.d.ts:1222
 
 ▸ **prependOnceListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3017,7 +3074,7 @@ HashStream.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1191
+node_modules/@types/node/stream.d.ts:1223
 
 ▸ **prependOnceListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3038,7 +3095,7 @@ HashStream.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1192
+node_modules/@types/node/stream.d.ts:1224
 
 ▸ **prependOnceListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3059,7 +3116,7 @@ HashStream.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1193
+node_modules/@types/node/stream.d.ts:1225
 
 ▸ **prependOnceListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3080,7 +3137,7 @@ HashStream.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1194
+node_modules/@types/node/stream.d.ts:1226
 
 ▸ **prependOnceListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3101,7 +3158,7 @@ HashStream.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1195
+node_modules/@types/node/stream.d.ts:1227
 
 ▸ **prependOnceListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3122,7 +3179,7 @@ HashStream.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1196
+node_modules/@types/node/stream.d.ts:1228
 
 ▸ **prependOnceListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3143,7 +3200,7 @@ HashStream.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1197
+node_modules/@types/node/stream.d.ts:1229
 
 ▸ **prependOnceListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3164,7 +3221,7 @@ HashStream.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1198
+node_modules/@types/node/stream.d.ts:1230
 
 ▸ **prependOnceListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3185,7 +3242,7 @@ HashStream.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1199
+node_modules/@types/node/stream.d.ts:1231
 
 ___
 
@@ -3210,7 +3267,7 @@ HashStream.push
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:438
+node_modules/@types/node/stream.d.ts:407
 
 ___
 
@@ -3222,6 +3279,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -3265,7 +3323,7 @@ HashStream.rawListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -3366,7 +3424,7 @@ HashStream.read
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:235
+node_modules/@types/node/stream.d.ts:204
 
 ___
 
@@ -3413,7 +3471,7 @@ HashStream.reduce
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:587
+node_modules/@types/node/stream.d.ts:556
 
 ▸ **reduce**<`T`\>(`fn`, `initial`, `options?`): `Promise`<`T`\>
 
@@ -3441,7 +3499,7 @@ HashStream.reduce
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:592
+node_modules/@types/node/stream.d.ts:561
 
 ___
 
@@ -3477,7 +3535,7 @@ HashStream.removeAllListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -3502,7 +3560,7 @@ HashStream.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1200
+node_modules/@types/node/stream.d.ts:1232
 
 ▸ **removeListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3523,7 +3581,7 @@ HashStream.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1201
+node_modules/@types/node/stream.d.ts:1233
 
 ▸ **removeListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3544,7 +3602,7 @@ HashStream.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1202
+node_modules/@types/node/stream.d.ts:1234
 
 ▸ **removeListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3565,7 +3623,7 @@ HashStream.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1203
+node_modules/@types/node/stream.d.ts:1235
 
 ▸ **removeListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3586,7 +3644,7 @@ HashStream.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1204
+node_modules/@types/node/stream.d.ts:1236
 
 ▸ **removeListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3607,7 +3665,7 @@ HashStream.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1205
+node_modules/@types/node/stream.d.ts:1237
 
 ▸ **removeListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3628,7 +3686,7 @@ HashStream.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1206
+node_modules/@types/node/stream.d.ts:1238
 
 ▸ **removeListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3649,7 +3707,7 @@ HashStream.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1207
+node_modules/@types/node/stream.d.ts:1239
 
 ▸ **removeListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3670,7 +3728,7 @@ HashStream.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1208
+node_modules/@types/node/stream.d.ts:1240
 
 ▸ **removeListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3691,7 +3749,7 @@ HashStream.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1209
+node_modules/@types/node/stream.d.ts:1241
 
 ▸ **removeListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3712,7 +3770,7 @@ HashStream.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1210
+node_modules/@types/node/stream.d.ts:1242
 
 ▸ **removeListener**(`event`, `listener`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
@@ -3733,7 +3791,7 @@ HashStream.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1211
+node_modules/@types/node/stream.d.ts:1243
 
 ___
 
@@ -3771,7 +3829,7 @@ HashStream.resume
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:301
+node_modules/@types/node/stream.d.ts:270
 
 ___
 
@@ -3795,7 +3853,7 @@ HashStream.setDefaultEncoding
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1107
+node_modules/@types/node/stream.d.ts:1115
 
 ___
 
@@ -3844,7 +3902,7 @@ HashStream.setEncoding
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:260
+node_modules/@types/node/stream.d.ts:229
 
 ___
 
@@ -3879,7 +3937,7 @@ HashStream.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -3915,7 +3973,7 @@ HashStream.some
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:506
+node_modules/@types/node/stream.d.ts:475
 
 ___
 
@@ -3948,7 +4006,7 @@ HashStream.take
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:565
+node_modules/@types/node/stream.d.ts:534
 
 ___
 
@@ -3983,7 +4041,7 @@ HashStream.toArray
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:496
+node_modules/@types/node/stream.d.ts:465
 
 ___
 
@@ -4001,7 +4059,7 @@ HashStream.uncork
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1112
+node_modules/@types/node/stream.d.ts:1120
 
 ___
 
@@ -4018,7 +4076,7 @@ If the `destination` is specified, but no pipe is set up for it, then
 the method does nothing.
 
 ```js
-const fs = require('fs');
+const fs = require('node:fs');
 const readable = getReadableStreamSomehow();
 const writable = fs.createWriteStream('file.txt');
 // All the data from readable goes into 'file.txt',
@@ -4052,7 +4110,7 @@ HashStream.unpipe
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:345
+node_modules/@types/node/stream.d.ts:314
 
 ___
 
@@ -4080,7 +4138,7 @@ use of a `Transform` stream instead. See the `API for stream implementers` secti
 // Pull off a header delimited by \n\n.
 // Use unshift() if we get too much.
 // Call the callback with (error, header, stream).
-const { StringDecoder } = require('string_decoder');
+const { StringDecoder } = require('node:string_decoder');
 function parseHeader(stream, callback) {
   stream.on('error', callback);
   stream.on('readable', onReadable);
@@ -4124,7 +4182,7 @@ process of performing a read.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `chunk` | `any` | Chunk of data to unshift onto the read queue. For streams not operating in object mode, `chunk` must be a string, `Buffer`, `Uint8Array` or `null`. For object mode streams, `chunk` may be any JavaScript value. |
+| `chunk` | `any` | Chunk of data to unshift onto the read queue. For streams not operating in object mode, `chunk` must be a string, `Buffer`, `Uint8Array`, or `null`. For object mode streams, `chunk` may be any JavaScript value. |
 | `encoding?` | `BufferEncoding` | Encoding of string chunks. Must be a valid `Buffer` encoding, such as `'utf8'` or `'ascii'`. |
 
 #### Returns
@@ -4141,7 +4199,7 @@ HashStream.unshift
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:411
+node_modules/@types/node/stream.d.ts:380
 
 ___
 
@@ -4149,8 +4207,8 @@ ___
 
 ▸ **wrap**(`stream`): [`CountingHashStream`](sourceDestination.CountingHashStream.md)
 
-Prior to Node.js 0.10, streams did not implement the entire `stream` module API
-as it is currently defined. (See `Compatibility` for more information.)
+Prior to Node.js 0.10, streams did not implement the entire `node:stream`module API as it is currently defined. (See `Compatibility` for more
+information.)
 
 When using an older Node.js library that emits `'data'` events and has a [pause](../interfaces/sourceDestination.SourceTransform.md#pause) method that is advisory only, the`readable.wrap()` method can be used to create a `Readable`
 stream that uses
@@ -4162,7 +4220,7 @@ libraries.
 
 ```js
 const { OldReader } = require('./old-api-module.js');
-const { Readable } = require('stream');
+const { Readable } = require('node:stream');
 const oreader = new OldReader();
 const myReader = new Readable().wrap(oreader);
 
@@ -4191,7 +4249,7 @@ HashStream.wrap
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:437
+node_modules/@types/node/stream.d.ts:406
 
 ___
 
@@ -4217,7 +4275,7 @@ HashStream.write
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1105
+node_modules/@types/node/stream.d.ts:1113
 
 ▸ **write**(`chunk`, `cb?`): `boolean`
 
@@ -4238,13 +4296,13 @@ HashStream.write
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1106
+node_modules/@types/node/stream.d.ts:1114
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -4291,7 +4349,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -4299,13 +4357,13 @@ HashStream.addAbortListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### from
 
-▸ `Static` **from**(`src`): `Duplex`
+▸ **from**(`src`): `Duplex`
 
 A utility method for creating duplex streams.
 
@@ -4329,7 +4387,7 @@ A utility method for creating duplex streams.
 
 | Name | Type |
 | :------ | :------ |
-| `src` | `string` \| `Object` \| `ArrayBuffer` \| `Promise`<`any`\> \| `AsyncGeneratorFunction` \| `Blob` \| `Stream` \| `Iterable`<`any`\> \| `AsyncIterable`<`any`\> |
+| `src` | `string` \| `Object` \| `ArrayBuffer` \| `Promise`<`any`\> \| `AsyncGeneratorFunction` \| `Stream` \| `Blob` \| `Iterable`<`any`\> \| `AsyncIterable`<`any`\> |
 
 #### Returns
 
@@ -4345,26 +4403,28 @@ HashStream.from
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1083
+node_modules/@types/node/stream.d.ts:1091
 
 ___
 
 ### fromWeb
 
-▸ `Static` **fromWeb**(`readableStream`, `options?`): `Readable`
+▸ **fromWeb**(`duplexStream`, `options?`): `Duplex`
 
-A utility method for creating a `Readable` from a web `ReadableStream`.
+A utility method for creating a `Duplex` from a web `ReadableStream` and `WritableStream`.
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `readableStream` | `ReadableStream`<`any`\> |
-| `options?` | `Pick`<`ReadableOptions`, ``"signal"`` \| ``"encoding"`` \| ``"highWaterMark"`` \| ``"objectMode"``\> |
+| `duplexStream` | `Object` |
+| `duplexStream.readable` | `ReadableStream`<`any`\> |
+| `duplexStream.writable` | `WritableStream`<`any`\> |
+| `options?` | `Pick`<`DuplexOptions`, ``"signal"`` \| ``"encoding"`` \| ``"highWaterMark"`` \| ``"objectMode"`` \| ``"decodeStrings"`` \| ``"allowHalfOpen"``\> |
 
 #### Returns
 
-`Readable`
+`Duplex`
 
 **`Since`**
 
@@ -4376,13 +4436,13 @@ HashStream.fromWeb
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:75
+node_modules/@types/node/stream.d.ts:1135
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -4393,19 +4453,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -4430,13 +4490,13 @@ HashStream.getEventListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -4476,7 +4536,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -4484,13 +4544,13 @@ HashStream.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### isDisturbed
 
-▸ `Static` **isDisturbed**(`stream`): `boolean`
+▸ **isDisturbed**(`stream`): `boolean`
 
 Returns whether the stream has been read from or cancelled.
 
@@ -4498,7 +4558,7 @@ Returns whether the stream has been read from or cancelled.
 
 | Name | Type |
 | :------ | :------ |
-| `stream` | `ReadableStream` \| `Readable` |
+| `stream` | `Readable` \| `ReadableStream` |
 
 #### Returns
 
@@ -4514,18 +4574,19 @@ HashStream.isDisturbed
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:83
+node_modules/@types/node/stream.d.ts:58
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -4558,34 +4619,33 @@ HashStream.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -4596,7 +4656,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -4644,13 +4706,13 @@ HashStream.on
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -4661,31 +4723,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -4693,13 +4752,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -4709,7 +4768,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -4754,9 +4813,9 @@ HashStream.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -4776,19 +4835,16 @@ HashStream.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -4817,25 +4873,30 @@ HashStream.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352
 
 ___
 
 ### toWeb
 
-▸ `Static` **toWeb**(`streamReadable`): `ReadableStream`<`any`\>
+▸ **toWeb**(`streamDuplex`): `Object`
 
-A utility method for creating a web `ReadableStream` from a `Readable`.
+A utility method for creating a web `ReadableStream` and `WritableStream` from a `Duplex`.
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `streamReadable` | `Readable` |
+| `streamDuplex` | `Duplex` |
 
 #### Returns
 
-`ReadableStream`<`any`\>
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `readable` | `ReadableStream`<`any`\> |
+| `writable` | `WritableStream`<`any`\> |
 
 **`Since`**
 
@@ -4847,4 +4908,4 @@ HashStream.toWeb
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:89
+node_modules/@types/node/stream.d.ts:1126

--- a/doc/classes/sourceDestination.CountingWritable.md
+++ b/doc/classes/sourceDestination.CountingWritable.md
@@ -81,7 +81,7 @@
 
 ### constructor
 
-• **new CountingWritable**(`opts?`)
+• **new CountingWritable**(`opts?`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
 #### Parameters
 
@@ -89,13 +89,17 @@
 | :------ | :------ |
 | `opts?` | `WritableOptions` |
 
+#### Returns
+
+[`CountingWritable`](sourceDestination.CountingWritable.md)
+
 #### Inherited from
 
 Writable.constructor
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:782
+node_modules/@types/node/stream.d.ts:715
 
 ## Properties
 
@@ -105,7 +109,7 @@ node_modules/@types/node/stream.d.ts:782
 
 #### Defined in
 
-[lib/source-destination/progress.ts:95](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/progress.ts#L95)
+[lib/source-destination/progress.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/progress.ts#L101)
 
 ___
 
@@ -113,7 +117,7 @@ ___
 
 • `Readonly` **closed**: `boolean`
 
-Is true after 'close' has been emitted.
+Is `true` after `'close'` has been emitted.
 
 **`Since`**
 
@@ -125,7 +129,7 @@ Writable.closed
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:771
+node_modules/@types/node/stream.d.ts:704
 
 ___
 
@@ -145,7 +149,7 @@ Writable.destroyed
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:766
+node_modules/@types/node/stream.d.ts:699
 
 ___
 
@@ -165,7 +169,7 @@ Writable.errored
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:776
+node_modules/@types/node/stream.d.ts:709
 
 ___
 
@@ -175,7 +179,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/progress.ts:96](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/progress.ts#L96)
+[lib/source-destination/progress.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/progress.ts#L102)
 
 ___
 
@@ -184,7 +188,7 @@ ___
 • `Readonly` **writable**: `boolean`
 
 Is `true` if it is safe to call `writable.write()`, which means
-the stream has not been destroyed, errored or ended.
+the stream has not been destroyed, errored, or ended.
 
 **`Since`**
 
@@ -196,7 +200,7 @@ Writable.writable
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:727
+node_modules/@types/node/stream.d.ts:660
 
 ___
 
@@ -217,7 +221,7 @@ Writable.writableCorked
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:761
+node_modules/@types/node/stream.d.ts:694
 
 ___
 
@@ -238,7 +242,7 @@ Writable.writableEnded
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:733
+node_modules/@types/node/stream.d.ts:666
 
 ___
 
@@ -258,7 +262,7 @@ Writable.writableFinished
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:738
+node_modules/@types/node/stream.d.ts:671
 
 ___
 
@@ -278,7 +282,7 @@ Writable.writableHighWaterMark
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:743
+node_modules/@types/node/stream.d.ts:676
 
 ___
 
@@ -300,7 +304,7 @@ Writable.writableLength
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:750
+node_modules/@types/node/stream.d.ts:683
 
 ___
 
@@ -308,7 +312,7 @@ ___
 
 • `Readonly` **writableNeedDrain**: `boolean`
 
-Is `true` if the stream's buffer has been full and stream will emit 'drain'.
+Is `true` if the stream's buffer has been full and stream will emit `'drain'`.
 
 **`Since`**
 
@@ -320,7 +324,7 @@ Writable.writableNeedDrain
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:781
+node_modules/@types/node/stream.d.ts:714
 
 ___
 
@@ -340,7 +344,7 @@ Writable.writableObjectMode
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:755
+node_modules/@types/node/stream.d.ts:688
 
 ___
 
@@ -348,13 +352,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 Writable.captureRejectionSymbol
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -362,7 +374,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -370,7 +388,7 @@ Writable.captureRejections
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -378,13 +396,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 Writable.defaultMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -392,13 +448,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -406,13 +463,13 @@ Writable.errorMonitor
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -432,13 +489,13 @@ Writable.[captureRejectionSymbol]
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_construct
 
-▸ `Optional` **_construct**(`callback`): `void`
+▸ **_construct**(`callback`): `void`
 
 #### Parameters
 
@@ -456,7 +513,7 @@ Writable.\_construct
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:791
+node_modules/@types/node/stream.d.ts:724
 
 ___
 
@@ -481,7 +538,7 @@ Writable.\_destroy
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:792
+node_modules/@types/node/stream.d.ts:725
 
 ___
 
@@ -505,7 +562,7 @@ Writable.\_final
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:793
+node_modules/@types/node/stream.d.ts:726
 
 ___
 
@@ -531,13 +588,13 @@ Writable.\_write
 
 #### Defined in
 
-[lib/source-destination/progress.ts:98](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/progress.ts#L98)
+[lib/source-destination/progress.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/progress.ts#L104)
 
 ___
 
 ### \_writev
 
-▸ `Optional` **_writev**(`chunks`, `callback`): `void`
+▸ **_writev**(`chunks`, `callback`): `void`
 
 #### Parameters
 
@@ -556,7 +613,7 @@ Writable.\_writev
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:784
+node_modules/@types/node/stream.d.ts:717
 
 ___
 
@@ -590,7 +647,7 @@ Writable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:959
+node_modules/@types/node/stream.d.ts:892
 
 ▸ **addListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -611,7 +668,7 @@ Writable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:960
+node_modules/@types/node/stream.d.ts:893
 
 ▸ **addListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -632,7 +689,7 @@ Writable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:961
+node_modules/@types/node/stream.d.ts:894
 
 ▸ **addListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -653,7 +710,7 @@ Writable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:962
+node_modules/@types/node/stream.d.ts:895
 
 ▸ **addListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -674,7 +731,7 @@ Writable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:963
+node_modules/@types/node/stream.d.ts:896
 
 ▸ **addListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -695,7 +752,7 @@ Writable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:964
+node_modules/@types/node/stream.d.ts:897
 
 ▸ **addListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -716,7 +773,7 @@ Writable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:965
+node_modules/@types/node/stream.d.ts:898
 
 ___
 
@@ -782,7 +839,7 @@ Writable.cork
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:897
+node_modules/@types/node/stream.d.ts:830
 
 ___
 
@@ -823,7 +880,7 @@ Writable.destroy
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:948
+node_modules/@types/node/stream.d.ts:881
 
 ___
 
@@ -847,7 +904,7 @@ Writable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:966
+node_modules/@types/node/stream.d.ts:899
 
 ▸ **emit**(`event`): `boolean`
 
@@ -867,7 +924,7 @@ Writable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:967
+node_modules/@types/node/stream.d.ts:900
 
 ▸ **emit**(`event`, `err`): `boolean`
 
@@ -888,7 +945,7 @@ Writable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:968
+node_modules/@types/node/stream.d.ts:901
 
 ▸ **emit**(`event`): `boolean`
 
@@ -908,7 +965,7 @@ Writable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:969
+node_modules/@types/node/stream.d.ts:902
 
 ▸ **emit**(`event`, `src`): `boolean`
 
@@ -929,7 +986,7 @@ Writable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:970
+node_modules/@types/node/stream.d.ts:903
 
 ▸ **emit**(`event`, `src`): `boolean`
 
@@ -950,7 +1007,7 @@ Writable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:971
+node_modules/@types/node/stream.d.ts:904
 
 ▸ **emit**(`event`, `...args`): `boolean`
 
@@ -971,7 +1028,7 @@ Writable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:972
+node_modules/@types/node/stream.d.ts:905
 
 ___
 
@@ -988,7 +1045,7 @@ Calling the [write](sourceDestination.CountingWritable.md#write) method after ca
 
 ```js
 // Write 'hello, ' and then end with 'world!'.
-const fs = require('fs');
+const fs = require('node:fs');
 const file = fs.createWriteStream('example.txt');
 file.write('hello, ');
 file.end('world!');
@@ -1015,7 +1072,7 @@ Writable.end
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:880
+node_modules/@types/node/stream.d.ts:813
 
 ▸ **end**(`chunk`, `cb?`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1036,7 +1093,7 @@ Writable.end
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:881
+node_modules/@types/node/stream.d.ts:814
 
 ▸ **end**(`chunk`, `encoding`, `cb?`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1058,7 +1115,7 @@ Writable.end
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:882
+node_modules/@types/node/stream.d.ts:815
 
 ___
 
@@ -1070,7 +1127,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -1096,7 +1154,7 @@ Writable.eventNames
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -1121,7 +1179,7 @@ Writable.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -1129,10 +1187,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -1155,7 +1212,7 @@ Writable.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -1193,7 +1250,7 @@ Writable.listeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -1224,7 +1281,7 @@ Writable.off
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -1249,7 +1306,7 @@ Writable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:973
+node_modules/@types/node/stream.d.ts:906
 
 ▸ **on**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1270,7 +1327,7 @@ Writable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:974
+node_modules/@types/node/stream.d.ts:907
 
 ▸ **on**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1291,7 +1348,7 @@ Writable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:975
+node_modules/@types/node/stream.d.ts:908
 
 ▸ **on**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1312,7 +1369,7 @@ Writable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:976
+node_modules/@types/node/stream.d.ts:909
 
 ▸ **on**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1333,7 +1390,7 @@ Writable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:977
+node_modules/@types/node/stream.d.ts:910
 
 ▸ **on**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1354,7 +1411,7 @@ Writable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:978
+node_modules/@types/node/stream.d.ts:911
 
 ▸ **on**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1375,7 +1432,7 @@ Writable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:979
+node_modules/@types/node/stream.d.ts:912
 
 ___
 
@@ -1400,7 +1457,7 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:980
+node_modules/@types/node/stream.d.ts:913
 
 ▸ **once**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1421,7 +1478,7 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:981
+node_modules/@types/node/stream.d.ts:914
 
 ▸ **once**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1442,7 +1499,7 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:982
+node_modules/@types/node/stream.d.ts:915
 
 ▸ **once**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1463,7 +1520,7 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:983
+node_modules/@types/node/stream.d.ts:916
 
 ▸ **once**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1484,7 +1541,7 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:984
+node_modules/@types/node/stream.d.ts:917
 
 ▸ **once**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1505,7 +1562,7 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:985
+node_modules/@types/node/stream.d.ts:918
 
 ▸ **once**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1526,7 +1583,7 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:986
+node_modules/@types/node/stream.d.ts:919
 
 ___
 
@@ -1583,7 +1640,7 @@ Writable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:987
+node_modules/@types/node/stream.d.ts:920
 
 ▸ **prependListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1604,7 +1661,7 @@ Writable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:988
+node_modules/@types/node/stream.d.ts:921
 
 ▸ **prependListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1625,7 +1682,7 @@ Writable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:989
+node_modules/@types/node/stream.d.ts:922
 
 ▸ **prependListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1646,7 +1703,7 @@ Writable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:990
+node_modules/@types/node/stream.d.ts:923
 
 ▸ **prependListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1667,7 +1724,7 @@ Writable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:991
+node_modules/@types/node/stream.d.ts:924
 
 ▸ **prependListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1688,7 +1745,7 @@ Writable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:992
+node_modules/@types/node/stream.d.ts:925
 
 ▸ **prependListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1709,7 +1766,7 @@ Writable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:993
+node_modules/@types/node/stream.d.ts:926
 
 ___
 
@@ -1734,7 +1791,7 @@ Writable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:994
+node_modules/@types/node/stream.d.ts:927
 
 ▸ **prependOnceListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1755,7 +1812,7 @@ Writable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:995
+node_modules/@types/node/stream.d.ts:928
 
 ▸ **prependOnceListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1776,7 +1833,7 @@ Writable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:996
+node_modules/@types/node/stream.d.ts:929
 
 ▸ **prependOnceListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1797,7 +1854,7 @@ Writable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:997
+node_modules/@types/node/stream.d.ts:930
 
 ▸ **prependOnceListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1818,7 +1875,7 @@ Writable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:998
+node_modules/@types/node/stream.d.ts:931
 
 ▸ **prependOnceListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1839,7 +1896,7 @@ Writable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:999
+node_modules/@types/node/stream.d.ts:932
 
 ▸ **prependOnceListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1860,7 +1917,7 @@ Writable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1000
+node_modules/@types/node/stream.d.ts:933
 
 ___
 
@@ -1872,6 +1929,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1915,7 +1973,7 @@ Writable.rawListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1951,7 +2009,7 @@ Writable.removeAllListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1976,7 +2034,7 @@ Writable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1001
+node_modules/@types/node/stream.d.ts:934
 
 ▸ **removeListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -1997,7 +2055,7 @@ Writable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1002
+node_modules/@types/node/stream.d.ts:935
 
 ▸ **removeListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -2018,7 +2076,7 @@ Writable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1003
+node_modules/@types/node/stream.d.ts:936
 
 ▸ **removeListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -2039,7 +2097,7 @@ Writable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1004
+node_modules/@types/node/stream.d.ts:937
 
 ▸ **removeListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -2060,7 +2118,7 @@ Writable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1005
+node_modules/@types/node/stream.d.ts:938
 
 ▸ **removeListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -2081,7 +2139,7 @@ Writable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1006
+node_modules/@types/node/stream.d.ts:939
 
 ▸ **removeListener**(`event`, `listener`): [`CountingWritable`](sourceDestination.CountingWritable.md)
 
@@ -2102,7 +2160,7 @@ Writable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1007
+node_modules/@types/node/stream.d.ts:940
 
 ___
 
@@ -2132,7 +2190,7 @@ Writable.setDefaultEncoding
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:857
+node_modules/@types/node/stream.d.ts:790
 
 ___
 
@@ -2167,7 +2225,7 @@ Writable.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -2220,7 +2278,7 @@ Writable.uncork
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:931
+node_modules/@types/node/stream.d.ts:864
 
 ___
 
@@ -2300,7 +2358,7 @@ Writable.write
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:850
+node_modules/@types/node/stream.d.ts:783
 
 ▸ **write**(`chunk`, `encoding`, `callback?`): `boolean`
 
@@ -2322,13 +2380,13 @@ Writable.write
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:851
+node_modules/@types/node/stream.d.ts:784
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -2375,7 +2433,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -2383,13 +2441,13 @@ Writable.addAbortListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### fromWeb
 
-▸ `Static` **fromWeb**(`writableStream`, `options?`): `Writable`
+▸ **fromWeb**(`writableStream`, `options?`): `Writable`
 
 A utility method for creating a `Writable` from a web `WritableStream`.
 
@@ -2414,13 +2472,13 @@ Writable.fromWeb
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:712
+node_modules/@types/node/stream.d.ts:1006
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -2431,19 +2489,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -2468,13 +2526,13 @@ Writable.getEventListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -2514,7 +2572,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -2522,18 +2580,19 @@ Writable.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -2566,34 +2625,33 @@ Writable.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -2604,7 +2662,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -2652,13 +2712,13 @@ Writable.on
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -2669,31 +2729,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -2701,13 +2758,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -2717,7 +2774,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -2762,9 +2819,9 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -2784,19 +2841,16 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -2825,13 +2879,13 @@ Writable.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352
 
 ___
 
 ### toWeb
 
-▸ `Static` **toWeb**(`streamWritable`): `WritableStream`<`any`\>
+▸ **toWeb**(`streamWritable`): `WritableStream`<`any`\>
 
 A utility method for creating a web `WritableStream` from a `Writable`.
 
@@ -2855,4 +2909,4 @@ Writable.toWeb
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:721
+node_modules/@types/node/stream.d.ts:1015

--- a/doc/classes/sourceDestination.DmgSource.md
+++ b/doc/classes/sourceDestination.DmgSource.md
@@ -83,7 +83,7 @@
 
 ### constructor
 
-• **new DmgSource**(`source`)
+• **new DmgSource**(`source`): [`DmgSource`](sourceDestination.DmgSource.md)
 
 #### Parameters
 
@@ -91,13 +91,17 @@
 | :------ | :------ |
 | `source` | [`SourceDestination`](sourceDestination.SourceDestination.md) |
 
+#### Returns
+
+[`DmgSource`](sourceDestination.DmgSource.md)
+
 #### Overrides
 
 [SourceSource](sourceDestination.SourceSource.md).[constructor](sourceDestination.SourceSource.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/dmg.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/dmg.ts#L56)
+[lib/source-destination/dmg.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/dmg.ts#L56)
 
 ## Properties
 
@@ -107,7 +111,7 @@
 
 #### Defined in
 
-[lib/source-destination/dmg.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/dmg.ts#L54)
+[lib/source-destination/dmg.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/dmg.ts#L54)
 
 ___
 
@@ -121,7 +125,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L22)
+[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L22)
 
 ___
 
@@ -129,13 +133,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [SourceSource](sourceDestination.SourceSource.md).[captureRejectionSymbol](sourceDestination.SourceSource.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -143,7 +155,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -151,7 +169,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -159,13 +177,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [SourceSource](sourceDestination.SourceSource.md).[defaultMaxListeners](sourceDestination.SourceSource.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -173,13 +229,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -187,7 +244,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -201,7 +258,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -211,7 +268,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/dmg.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/dmg.ts#L44)
+[lib/source-destination/dmg.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/dmg.ts#L44)
 
 ___
 
@@ -225,7 +282,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/dmg.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/dmg.ts#L53)
+[lib/source-destination/dmg.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/dmg.ts#L53)
 
 ___
 
@@ -239,13 +296,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/dmg.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/dmg.ts#L52)
+[lib/source-destination/dmg.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/dmg.ts#L52)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -265,13 +322,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -283,13 +340,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L30)
+[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L30)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -301,13 +358,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/dmg.ts:144](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/dmg.ts#L144)
+[lib/source-destination/dmg.ts:144](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/dmg.ts#L144)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -319,7 +376,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/dmg.ts:152](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/dmg.ts#L152)
+[lib/source-destination/dmg.ts:152](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/dmg.ts#L152)
 
 ___
 
@@ -350,7 +407,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -368,7 +425,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/dmg.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/dmg.ts#L60)
+[lib/source-destination/dmg.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/dmg.ts#L60)
 
 ___
 
@@ -386,7 +443,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/dmg.ts:64](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/dmg.ts#L64)
+[lib/source-destination/dmg.ts:64](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/dmg.ts#L64)
 
 ___
 
@@ -404,7 +461,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -422,7 +479,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -440,7 +497,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L323)
+[lib/source-destination/source-destination.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L321)
 
 ___
 
@@ -458,7 +515,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -476,7 +533,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -500,7 +557,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/dmg.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/dmg.ts#L68)
+[lib/source-destination/dmg.ts:68](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/dmg.ts#L68)
 
 ___
 
@@ -524,7 +581,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/dmg.ts:81](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/dmg.ts#L81)
+[lib/source-destination/dmg.ts:81](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/dmg.ts#L81)
 
 ___
 
@@ -549,7 +606,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
@@ -574,7 +631,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -599,7 +656,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
@@ -613,7 +670,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -666,7 +723,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -678,7 +735,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -704,7 +762,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -722,7 +780,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -740,7 +798,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/dmg.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/dmg.ts#L104)
+[lib/source-destination/dmg.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/dmg.ts#L104)
 
 ___
 
@@ -758,7 +816,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -783,7 +841,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -801,7 +859,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -819,7 +877,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
@@ -827,10 +885,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -853,7 +910,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -891,7 +948,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -922,7 +979,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -947,6 +1004,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -977,7 +1035,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1000,6 +1058,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1030,7 +1089,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1048,7 +1107,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1090,7 +1149,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1130,7 +1189,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1142,6 +1201,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1185,7 +1245,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1212,7 +1272,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L358)
+[lib/source-destination/source-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L356)
 
 ___
 
@@ -1248,7 +1308,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1277,6 +1337,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1317,6 +1379,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1354,7 +1417,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1389,7 +1452,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1416,13 +1479,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1469,7 +1532,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1477,13 +1540,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1494,19 +1557,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1531,13 +1594,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1577,7 +1640,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1585,18 +1648,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1629,34 +1693,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1667,7 +1730,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1715,13 +1780,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1732,31 +1797,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1764,13 +1826,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1780,7 +1842,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1825,9 +1887,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1847,13 +1909,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -1871,19 +1933,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1912,4 +1971,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.DriverlessDevice.md
+++ b/doc/classes/sourceDestination.DriverlessDevice.md
@@ -93,7 +93,7 @@
 
 ### constructor
 
-• **new DriverlessDevice**(`driverlessDevice`)
+• **new DriverlessDevice**(`driverlessDevice`): [`DriverlessDevice`](sourceDestination.DriverlessDevice.md)
 
 #### Parameters
 
@@ -101,13 +101,17 @@
 | :------ | :------ |
 | `driverlessDevice` | `DriverlessDevice` |
 
+#### Returns
+
+[`DriverlessDevice`](sourceDestination.DriverlessDevice.md)
+
 #### Overrides
 
 [SourceDestination](sourceDestination.SourceDestination.md).[constructor](sourceDestination.SourceDestination.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/driverless.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/driverless.ts#L37)
+[lib/source-destination/driverless.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/driverless.ts#L37)
 
 ## Properties
 
@@ -117,7 +121,7 @@
 
 #### Defined in
 
-[lib/source-destination/driverless.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/driverless.ts#L26)
+[lib/source-destination/driverless.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/driverless.ts#L26)
 
 ___
 
@@ -131,7 +135,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/driverless.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/driverless.ts#L35)
+[lib/source-destination/driverless.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/driverless.ts#L35)
 
 ___
 
@@ -145,7 +149,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/driverless.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/driverless.ts#L28)
+[lib/source-destination/driverless.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/driverless.ts#L28)
 
 ___
 
@@ -162,7 +166,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/driverless.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/driverless.ts#L34)
+[lib/source-destination/driverless.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/driverless.ts#L34)
 
 ___
 
@@ -176,7 +180,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/driverless.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/driverless.ts#L29)
+[lib/source-destination/driverless.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/driverless.ts#L29)
 
 ___
 
@@ -190,7 +194,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/driverless.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/driverless.ts#L33)
+[lib/source-destination/driverless.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/driverless.ts#L33)
 
 ___
 
@@ -204,7 +208,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/driverless.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/driverless.ts#L30)
+[lib/source-destination/driverless.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/driverless.ts#L30)
 
 ___
 
@@ -218,7 +222,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/driverless.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/driverless.ts#L31)
+[lib/source-destination/driverless.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/driverless.ts#L31)
 
 ___
 
@@ -232,7 +236,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/driverless.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/driverless.ts#L27)
+[lib/source-destination/driverless.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/driverless.ts#L27)
 
 ___
 
@@ -246,7 +250,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/driverless.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/driverless.ts#L32)
+[lib/source-destination/driverless.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/driverless.ts#L32)
 
 ___
 
@@ -254,13 +258,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[captureRejectionSymbol](sourceDestination.SourceDestination.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -268,7 +280,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -276,7 +294,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -284,13 +302,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[defaultMaxListeners](sourceDestination.SourceDestination.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -298,13 +354,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -312,7 +369,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -326,7 +383,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -340,13 +397,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:307](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L307)
+[lib/source-destination/source-destination.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L305)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -370,13 +427,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -392,13 +449,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:422](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L422)
+[lib/source-destination/source-destination.ts:420](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L420)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -414,13 +471,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:354](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L354)
+[lib/source-destination/source-destination.ts:352](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L352)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -436,7 +493,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:418](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L418)
+[lib/source-destination/source-destination.ts:416](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L416)
 
 ___
 
@@ -471,7 +528,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -493,7 +550,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L331)
+[lib/source-destination/source-destination.ts:329](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L329)
 
 ___
 
@@ -515,7 +572,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -537,7 +594,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -559,7 +616,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -581,7 +638,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L323)
+[lib/source-destination/source-destination.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L321)
 
 ___
 
@@ -603,7 +660,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -625,7 +682,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -653,7 +710,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:376](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L376)
+[lib/source-destination/source-destination.ts:374](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L374)
 
 ___
 
@@ -681,7 +738,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -710,7 +767,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
@@ -739,7 +796,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -768,7 +825,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
@@ -782,7 +839,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -839,7 +896,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -851,7 +908,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -881,7 +939,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -903,7 +961,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -925,7 +983,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
@@ -947,7 +1005,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -976,7 +1034,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -998,7 +1056,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -1020,7 +1078,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
@@ -1028,10 +1086,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -1058,7 +1115,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -1100,7 +1157,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -1135,7 +1192,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -1160,6 +1217,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1194,7 +1252,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1217,6 +1275,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1251,7 +1310,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1273,7 +1332,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1319,7 +1378,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1363,7 +1422,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1375,6 +1434,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1422,7 +1482,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1453,7 +1513,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L358)
+[lib/source-destination/source-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L356)
 
 ___
 
@@ -1493,7 +1553,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1522,6 +1582,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1562,6 +1624,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1603,7 +1666,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1642,7 +1705,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1673,13 +1736,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1726,7 +1789,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1734,13 +1797,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1751,19 +1814,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1788,13 +1851,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1834,7 +1897,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1842,18 +1905,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1886,34 +1950,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1924,7 +1987,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1972,13 +2037,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1989,31 +2054,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -2021,13 +2083,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -2037,7 +2099,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -2082,9 +2144,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -2104,13 +2166,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -2128,19 +2190,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -2169,4 +2228,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.File.md
+++ b/doc/classes/sourceDestination.File.md
@@ -85,7 +85,7 @@
 
 ### constructor
 
-• **new File**(`«destructured»`)
+• **new File**(`«destructured»`): [`File`](sourceDestination.File.md)
 
 #### Parameters
 
@@ -95,13 +95,17 @@
 | › `path` | `string` |
 | › `write?` | `boolean` |
 
+#### Returns
+
+[`File`](sourceDestination.File.md)
+
 #### Overrides
 
 [SourceDestination](sourceDestination.SourceDestination.md).[constructor](sourceDestination.SourceDestination.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/file.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L50)
+[lib/source-destination/file.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L50)
 
 ## Properties
 
@@ -111,7 +115,7 @@
 
 #### Defined in
 
-[lib/source-destination/file.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L48)
+[lib/source-destination/file.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L48)
 
 ___
 
@@ -121,7 +125,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L47)
+[lib/source-destination/file.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L47)
 
 ___
 
@@ -131,7 +135,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L46)
+[lib/source-destination/file.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L46)
 
 ___
 
@@ -139,13 +143,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[captureRejectionSymbol](sourceDestination.SourceDestination.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -153,7 +165,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -161,7 +179,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -169,13 +187,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[defaultMaxListeners](sourceDestination.SourceDestination.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -183,13 +239,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -197,7 +254,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -211,7 +268,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -225,13 +282,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:307](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L307)
+[lib/source-destination/source-destination.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L305)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -251,13 +308,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -269,13 +326,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:216](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L216)
+[lib/source-destination/file.ts:215](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L215)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -287,13 +344,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L83)
+[lib/source-destination/file.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L83)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -305,7 +362,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:206](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L206)
+[lib/source-destination/file.ts:205](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L205)
 
 ___
 
@@ -336,7 +393,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -354,7 +411,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L71)
+[lib/source-destination/file.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L71)
 
 ___
 
@@ -372,7 +429,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -390,7 +447,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L79)
+[lib/source-destination/file.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L79)
 
 ___
 
@@ -408,7 +465,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L75)
+[lib/source-destination/file.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L75)
 
 ___
 
@@ -426,7 +483,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L63)
+[lib/source-destination/file.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L63)
 
 ___
 
@@ -444,7 +501,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L67)
+[lib/source-destination/file.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L67)
 
 ___
 
@@ -462,7 +519,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -486,7 +543,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L147)
+[lib/source-destination/file.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L147)
 
 ___
 
@@ -510,7 +567,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -535,7 +592,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:195](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L195)
+[lib/source-destination/file.ts:194](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L194)
 
 ___
 
@@ -560,7 +617,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -585,7 +642,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:180](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L180)
+[lib/source-destination/file.ts:180](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L180)
 
 ___
 
@@ -599,7 +656,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -652,7 +709,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -664,7 +721,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -690,7 +748,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -708,7 +766,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -726,7 +784,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
@@ -744,7 +802,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -769,7 +827,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -787,13 +845,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
 ### getOpenFlags
 
-▸ `Protected` **getOpenFlags**(): `number`
+▸ **getOpenFlags**(): `number`
 
 #### Returns
 
@@ -801,7 +859,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L56)
+[lib/source-destination/file.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L56)
 
 ___
 
@@ -819,7 +877,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
@@ -827,10 +885,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -853,7 +910,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -891,7 +948,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -922,7 +979,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -947,6 +1004,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -977,7 +1035,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1000,6 +1058,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1030,7 +1089,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1048,7 +1107,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1090,7 +1149,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1130,7 +1189,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1142,6 +1201,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1185,7 +1245,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1212,7 +1272,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:90](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L90)
+[lib/source-destination/file.ts:90](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L90)
 
 ___
 
@@ -1248,7 +1308,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1277,6 +1337,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1317,6 +1379,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1354,7 +1417,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1389,7 +1452,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1416,13 +1479,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:138](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L138)
+[lib/source-destination/file.ts:138](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L138)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1469,7 +1532,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1477,13 +1540,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1494,19 +1557,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1531,13 +1594,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1577,7 +1640,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1585,18 +1648,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1629,34 +1693,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1667,7 +1730,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1715,13 +1780,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1732,31 +1797,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1764,13 +1826,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1780,7 +1842,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1825,9 +1887,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1847,13 +1909,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -1871,19 +1933,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1912,4 +1971,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.GZipSource.md
+++ b/doc/classes/sourceDestination.GZipSource.md
@@ -84,7 +84,7 @@
 
 ### constructor
 
-• **new GZipSource**(`source`)
+• **new GZipSource**(`source`): [`GZipSource`](sourceDestination.GZipSource.md)
 
 #### Parameters
 
@@ -92,13 +92,17 @@
 | :------ | :------ |
 | `source` | [`SourceDestination`](sourceDestination.SourceDestination.md) |
 
+#### Returns
+
+[`GZipSource`](sourceDestination.GZipSource.md)
+
 #### Inherited from
 
 [CompressedSource](sourceDestination.CompressedSource.md).[constructor](sourceDestination.CompressedSource.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L22)
+[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L22)
 
 ## Properties
 
@@ -112,7 +116,7 @@
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L22)
+[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L22)
 
 ___
 
@@ -120,13 +124,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [CompressedSource](sourceDestination.CompressedSource.md).[captureRejectionSymbol](sourceDestination.CompressedSource.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -134,7 +146,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -142,7 +160,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -150,13 +168,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [CompressedSource](sourceDestination.CompressedSource.md).[defaultMaxListeners](sourceDestination.CompressedSource.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -164,13 +220,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -178,7 +235,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -192,7 +249,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -206,7 +263,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/gzip.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/gzip.ts#L26)
+[lib/source-destination/gzip.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/gzip.ts#L26)
 
 ___
 
@@ -220,13 +277,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L20)
+[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L20)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -246,13 +303,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -264,13 +321,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L30)
+[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L30)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -282,13 +339,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L106)
+[lib/source-destination/compressed-source.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L106)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -300,7 +357,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L26)
+[lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L26)
 
 ___
 
@@ -331,7 +388,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -349,7 +406,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L53)
+[lib/source-destination/compressed-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L53)
 
 ___
 
@@ -367,7 +424,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -385,7 +442,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -403,7 +460,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -421,7 +478,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L323)
+[lib/source-destination/source-destination.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L321)
 
 ___
 
@@ -439,7 +496,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -457,7 +514,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -481,7 +538,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L57)
+[lib/source-destination/compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L57)
 
 ___
 
@@ -505,7 +562,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -530,13 +587,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
 ### createTransform
 
-▸ `Protected` **createTransform**(): `Transform`
+▸ **createTransform**(): `Transform`
 
 #### Returns
 
@@ -548,7 +605,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/gzip.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/gzip.ts#L28)
+[lib/source-destination/gzip.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/gzip.ts#L28)
 
 ___
 
@@ -573,7 +630,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -598,7 +655,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
@@ -612,7 +669,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -665,7 +722,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -677,7 +734,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -703,7 +761,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -721,7 +779,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -739,7 +797,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
@@ -757,7 +815,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -782,7 +840,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -800,7 +858,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -818,13 +876,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
 ### getSize
 
-▸ `Protected` **getSize**(): `Promise`<`undefined` \| { `isEstimated`: ``true`` ; `size`: `number`  }\>
+▸ **getSize**(): `Promise`<`undefined` \| { `isEstimated`: ``true`` ; `size`: `number`  }\>
 
 #### Returns
 
@@ -836,13 +894,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/gzip.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/gzip.ts#L32)
+[lib/source-destination/gzip.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/gzip.ts#L32)
 
 ___
 
 ### getSizeFromPartitionTable
 
-▸ `Protected` **getSizeFromPartitionTable**(): `Promise`<`undefined` \| `number`\>
+▸ **getSizeFromPartitionTable**(): `Promise`<`undefined` \| `number`\>
 
 #### Returns
 
@@ -854,7 +912,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L87)
+[lib/source-destination/compressed-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L87)
 
 ___
 
@@ -862,10 +920,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -888,7 +945,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -926,7 +983,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -957,7 +1014,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -982,6 +1039,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1012,7 +1070,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1035,6 +1093,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1065,7 +1124,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1083,7 +1142,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1125,7 +1184,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1165,7 +1224,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1177,6 +1236,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1220,7 +1280,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1247,7 +1307,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L358)
+[lib/source-destination/source-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L356)
 
 ___
 
@@ -1283,7 +1343,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1312,6 +1372,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1352,6 +1414,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1389,7 +1452,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1424,7 +1487,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1451,13 +1514,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1504,7 +1567,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1512,13 +1575,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1529,19 +1592,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1566,13 +1629,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1612,7 +1675,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1620,18 +1683,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1664,34 +1728,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1702,7 +1765,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1750,13 +1815,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1767,31 +1832,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1799,13 +1861,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1815,7 +1877,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1860,9 +1922,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1882,13 +1944,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -1906,19 +1968,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1947,4 +2006,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.Http.md
+++ b/doc/classes/sourceDestination.Http.md
@@ -90,7 +90,7 @@
 
 ### constructor
 
-• **new Http**(`«destructured»`)
+• **new Http**(`«destructured»`): [`Http`](sourceDestination.Http.md)
 
 #### Parameters
 
@@ -102,13 +102,17 @@
 | › `axiosInstance?` | `AxiosInstance` |
 | › `url` | `string` |
 
+#### Returns
+
+[`Http`](sourceDestination.Http.md)
+
 #### Overrides
 
 [SourceDestination](sourceDestination.SourceDestination.md).[constructor](sourceDestination.SourceDestination.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/http.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/http.ts#L48)
+[lib/source-destination/http.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/http.ts#L45)
 
 ## Properties
 
@@ -118,7 +122,7 @@
 
 #### Defined in
 
-[lib/source-destination/http.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/http.ts#L43)
+[lib/source-destination/http.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/http.ts#L40)
 
 ___
 
@@ -128,7 +132,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/http.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/http.ts#L41)
+[lib/source-destination/http.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/http.ts#L38)
 
 ___
 
@@ -138,7 +142,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/http.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/http.ts#L46)
+[lib/source-destination/http.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/http.ts#L43)
 
 ___
 
@@ -148,7 +152,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/http.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/http.ts#L45)
+[lib/source-destination/http.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/http.ts#L42)
 
 ___
 
@@ -158,7 +162,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/http.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/http.ts#L38)
+[lib/source-destination/http.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/http.ts#L35)
 
 ___
 
@@ -168,7 +172,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/http.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/http.ts#L44)
+[lib/source-destination/http.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/http.ts#L41)
 
 ___
 
@@ -178,7 +182,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/http.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/http.ts#L40)
+[lib/source-destination/http.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/http.ts#L37)
 
 ___
 
@@ -188,7 +192,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/http.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/http.ts#L42)
+[lib/source-destination/http.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/http.ts#L39)
 
 ___
 
@@ -198,7 +202,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/http.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/http.ts#L39)
+[lib/source-destination/http.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/http.ts#L36)
 
 ___
 
@@ -206,13 +210,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[captureRejectionSymbol](sourceDestination.SourceDestination.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -220,7 +232,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -228,7 +246,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -236,13 +254,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[defaultMaxListeners](sourceDestination.SourceDestination.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -250,13 +306,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -264,7 +321,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -278,7 +335,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -292,13 +349,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:307](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L307)
+[lib/source-destination/source-destination.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L305)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -318,13 +375,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -336,13 +393,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:422](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L422)
+[lib/source-destination/source-destination.ts:420](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L420)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -354,13 +411,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/http.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/http.ts#L110)
+[lib/source-destination/http.ts:108](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/http.ts#L108)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -372,7 +429,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:418](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L418)
+[lib/source-destination/source-destination.ts:416](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L416)
 
 ___
 
@@ -403,7 +460,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -421,7 +478,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/http.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/http.ts#L106)
+[lib/source-destination/http.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/http.ts#L104)
 
 ___
 
@@ -439,7 +496,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -457,7 +514,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -475,7 +532,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -493,7 +550,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/http.ts:98](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/http.ts#L98)
+[lib/source-destination/http.ts:96](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/http.ts#L96)
 
 ___
 
@@ -511,7 +568,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -529,7 +586,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -553,7 +610,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/http.ts:155](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/http.ts#L155)
+[lib/source-destination/http.ts:153](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/http.ts#L153)
 
 ___
 
@@ -577,7 +634,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -602,7 +659,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
@@ -627,7 +684,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -652,7 +709,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
@@ -666,7 +723,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -719,7 +776,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -731,7 +788,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -757,7 +815,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -775,7 +833,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -793,13 +851,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
 ### getInfo
 
-▸ `Private` **getInfo**(): `Promise`<`void`\>
+▸ **getInfo**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -807,7 +865,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/http.ts:69](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/http.ts#L69)
+[lib/source-destination/http.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/http.ts#L67)
 
 ___
 
@@ -825,7 +883,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -850,7 +908,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -868,7 +926,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -886,13 +944,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
 ### getRange
 
-▸ `Private` **getRange**(`start?`, `end?`): `string`
+▸ **getRange**(`start?`, `end?`): `string`
 
 #### Parameters
 
@@ -907,7 +965,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/http.ts:125](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/http.ts#L125)
+[lib/source-destination/http.ts:123](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/http.ts#L123)
 
 ___
 
@@ -915,10 +973,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -941,7 +998,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -979,7 +1036,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -1010,7 +1067,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -1035,6 +1092,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1065,7 +1123,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1088,6 +1146,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1118,7 +1177,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1136,7 +1195,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1178,7 +1237,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1218,7 +1277,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1230,6 +1289,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1273,7 +1333,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1300,7 +1360,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/http.ts:134](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/http.ts#L134)
+[lib/source-destination/http.ts:132](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/http.ts#L132)
 
 ___
 
@@ -1336,7 +1396,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1365,6 +1425,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1405,6 +1467,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1442,7 +1505,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1477,7 +1540,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1504,13 +1567,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1557,7 +1620,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1565,13 +1628,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1582,19 +1645,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1619,13 +1682,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1665,7 +1728,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1673,18 +1736,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1717,34 +1781,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1755,7 +1818,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1803,13 +1868,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1820,31 +1885,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1852,13 +1914,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1868,7 +1930,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1913,9 +1975,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1935,13 +1997,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -1959,19 +2021,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -2000,4 +2059,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.MultiDestination.md
+++ b/doc/classes/sourceDestination.MultiDestination.md
@@ -88,7 +88,7 @@
 
 ### constructor
 
-• **new MultiDestination**(`destinations`)
+• **new MultiDestination**(`destinations`): [`MultiDestination`](sourceDestination.MultiDestination.md)
 
 #### Parameters
 
@@ -96,13 +96,17 @@
 | :------ | :------ |
 | `destinations` | [`SourceDestination`](sourceDestination.SourceDestination.md)[] |
 
+#### Returns
+
+[`MultiDestination`](sourceDestination.MultiDestination.md)
+
 #### Overrides
 
 [SourceDestination](sourceDestination.SourceDestination.md).[constructor](sourceDestination.SourceDestination.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:112](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L112)
+[lib/source-destination/multi-destination.ts:112](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L112)
 
 ## Properties
 
@@ -112,7 +116,7 @@
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:109](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L109)
+[lib/source-destination/multi-destination.ts:109](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L109)
 
 ___
 
@@ -122,7 +126,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L110)
+[lib/source-destination/multi-destination.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L110)
 
 ___
 
@@ -130,13 +134,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[captureRejectionSymbol](sourceDestination.SourceDestination.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -144,7 +156,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -152,7 +170,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -160,13 +178,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[defaultMaxListeners](sourceDestination.SourceDestination.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -174,13 +230,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -188,7 +245,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -202,7 +259,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -216,7 +273,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:307](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L307)
+[lib/source-destination/source-destination.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L305)
 
 ## Accessors
 
@@ -230,13 +287,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:154](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L154)
+[lib/source-destination/multi-destination.ts:154](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L154)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -256,13 +313,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -274,13 +331,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L357)
+[lib/source-destination/multi-destination.ts:357](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L357)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -292,13 +349,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:354](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L354)
+[lib/source-destination/source-destination.ts:352](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L352)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -310,7 +367,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L345)
+[lib/source-destination/multi-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L345)
 
 ___
 
@@ -341,13 +398,13 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
 ### can
 
-▸ `Private` **can**(`methodName`): `Promise`<`boolean`\>
+▸ **can**(`methodName`): `Promise`<`boolean`\>
 
 #### Parameters
 
@@ -361,7 +418,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:158](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L158)
+[lib/source-destination/multi-destination.ts:158](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L158)
 
 ___
 
@@ -379,7 +436,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:184](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L184)
+[lib/source-destination/multi-destination.ts:184](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L184)
 
 ___
 
@@ -397,7 +454,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:188](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L188)
+[lib/source-destination/multi-destination.ts:188](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L188)
 
 ___
 
@@ -415,7 +472,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:196](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L196)
+[lib/source-destination/multi-destination.ts:196](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L196)
 
 ___
 
@@ -433,7 +490,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:192](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L192)
+[lib/source-destination/multi-destination.ts:192](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L192)
 
 ___
 
@@ -451,7 +508,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:176](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L176)
+[lib/source-destination/multi-destination.ts:176](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L176)
 
 ___
 
@@ -469,7 +526,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:180](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L180)
+[lib/source-destination/multi-destination.ts:180](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L180)
 
 ___
 
@@ -487,7 +544,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -511,7 +568,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:231](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L231)
+[lib/source-destination/multi-destination.ts:231](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L231)
 
 ___
 
@@ -535,7 +592,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:238](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L238)
+[lib/source-destination/multi-destination.ts:238](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L238)
 
 ___
 
@@ -559,13 +616,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:332](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L332)
+[lib/source-destination/multi-destination.ts:332](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L332)
 
 ___
 
 ### createStream
 
-▸ `Private` **createStream**(`methodName`, `...args`): `Promise`<`WritableStream`\>
+▸ **createStream**(`methodName`, `...args`): `Promise`<`WritableStream`\>
 
 #### Parameters
 
@@ -580,9 +637,9 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:247](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L247)
+[lib/source-destination/multi-destination.ts:247](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L247)
 
-▸ `Private` **createStream**(`methodName`, `...args`): `Promise`<[`SparseWritable`](../interfaces/sparseStream.SparseWritable.md)\>
+▸ **createStream**(`methodName`, `...args`): `Promise`<[`SparseWritable`](../interfaces/sparseStream.SparseWritable.md)\>
 
 #### Parameters
 
@@ -597,7 +654,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:252](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L252)
+[lib/source-destination/multi-destination.ts:252](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L252)
 
 ___
 
@@ -622,7 +679,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:338](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L338)
+[lib/source-destination/multi-destination.ts:338](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L338)
 
 ___
 
@@ -646,7 +703,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L326)
+[lib/source-destination/multi-destination.ts:326](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L326)
 
 ___
 
@@ -668,7 +725,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:135](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L135)
+[lib/source-destination/multi-destination.ts:135](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L135)
 
 ___
 
@@ -682,7 +739,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -735,7 +792,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -747,7 +804,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -773,7 +831,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -791,7 +849,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:122](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L122)
+[lib/source-destination/multi-destination.ts:122](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L122)
 
 ___
 
@@ -809,7 +867,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
@@ -827,7 +885,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -852,7 +910,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -870,7 +928,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -888,7 +946,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
@@ -896,10 +954,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -922,7 +979,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -960,7 +1017,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -991,7 +1048,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -1016,6 +1073,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1046,7 +1104,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1069,6 +1127,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1099,7 +1158,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1117,7 +1176,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1159,7 +1218,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1199,7 +1258,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1211,6 +1270,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1254,7 +1314,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1281,7 +1341,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:200](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L200)
+[lib/source-destination/multi-destination.ts:200](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L200)
 
 ___
 
@@ -1317,7 +1377,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1346,6 +1406,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1386,6 +1448,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1423,7 +1486,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1458,7 +1521,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1485,13 +1548,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:215](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L215)
+[lib/source-destination/multi-destination.ts:215](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L215)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1538,7 +1601,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1546,13 +1609,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1563,19 +1626,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1600,13 +1663,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1646,7 +1709,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1654,18 +1717,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1698,34 +1762,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1736,7 +1799,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1784,13 +1849,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1801,31 +1866,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1833,13 +1895,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1849,7 +1911,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1894,9 +1956,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1916,13 +1978,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -1940,19 +2002,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1981,4 +2040,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.MultiDestinationError.md
+++ b/doc/classes/sourceDestination.MultiDestinationError.md
@@ -34,7 +34,7 @@
 
 ### constructor
 
-• **new MultiDestinationError**(`error`, `destination`)
+• **new MultiDestinationError**(`error`, `destination`): [`MultiDestinationError`](sourceDestination.MultiDestinationError.md)
 
 #### Parameters
 
@@ -43,13 +43,17 @@
 | `error` | `Error` |
 | `destination` | [`SourceDestination`](sourceDestination.SourceDestination.md) |
 
+#### Returns
+
+[`MultiDestinationError`](sourceDestination.MultiDestinationError.md)
+
 #### Overrides
 
 Error.constructor
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L40)
+[lib/source-destination/multi-destination.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L40)
 
 ## Properties
 
@@ -59,7 +63,7 @@ Error.constructor
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L42)
+[lib/source-destination/multi-destination.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L42)
 
 ___
 
@@ -69,7 +73,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L41)
+[lib/source-destination/multi-destination.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L41)
 
 ___
 
@@ -146,7 +150,7 @@ Error.prepareStackTrace
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:11
+node_modules/@types/node/globals.d.ts:28
 
 ___
 
@@ -160,13 +164,13 @@ Error.stackTraceLimit
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:13
+node_modules/@types/node/globals.d.ts:30
 
 ## Methods
 
 ### captureStackTrace
 
-▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
+▸ **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
 
 Create .stack property on a target object
 
@@ -187,4 +191,4 @@ Error.captureStackTrace
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:4
+node_modules/@types/node/globals.d.ts:21

--- a/doc/classes/sourceDestination.MultiDestinationVerifier.md
+++ b/doc/classes/sourceDestination.MultiDestinationVerifier.md
@@ -60,7 +60,7 @@
 
 ### constructor
 
-• **new MultiDestinationVerifier**(`source`, `checksumOrBlocks`, `size?`)
+• **new MultiDestinationVerifier**(`source`, `checksumOrBlocks`, `size?`): [`MultiDestinationVerifier`](sourceDestination.MultiDestinationVerifier.md)
 
 #### Parameters
 
@@ -70,13 +70,17 @@
 | `checksumOrBlocks` | `string` \| [`BlocksWithChecksum`](../interfaces/sparseStream.BlocksWithChecksum.md)[] |
 | `size?` | `number` |
 
+#### Returns
+
+[`MultiDestinationVerifier`](sourceDestination.MultiDestinationVerifier.md)
+
 #### Overrides
 
 [Verifier](sourceDestination.Verifier.md).[constructor](sourceDestination.Verifier.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L52)
+[lib/source-destination/multi-destination.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L52)
 
 ## Properties
 
@@ -90,7 +94,7 @@
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L166)
+[lib/source-destination/source-destination.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L166)
 
 ___
 
@@ -100,7 +104,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L50)
+[lib/source-destination/multi-destination.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L50)
 
 ___
 
@@ -110,7 +114,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L49)
+[lib/source-destination/multi-destination.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L49)
 
 ___
 
@@ -118,13 +122,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [Verifier](sourceDestination.Verifier.md).[captureRejectionSymbol](sourceDestination.Verifier.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -132,7 +144,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -140,7 +158,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -148,13 +166,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [Verifier](sourceDestination.Verifier.md).[defaultMaxListeners](sourceDestination.Verifier.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -162,13 +218,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -176,13 +233,13 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -202,7 +259,7 @@ node_modules/@types/node/events.d.ts:404
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
@@ -233,7 +290,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -247,7 +304,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -300,13 +357,13 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
 ### emitProgress
 
-▸ `Private` **emitProgress**(): `void`
+▸ **emitProgress**(): `void`
 
 #### Returns
 
@@ -314,7 +371,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L83)
+[lib/source-destination/multi-destination.ts:83](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L83)
 
 ___
 
@@ -326,7 +383,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -352,7 +410,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -377,13 +435,13 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
 ### handleEventsAndPipe
 
-▸ `Protected` **handleEventsAndPipe**(`stream`, `meter`): `void`
+▸ **handleEventsAndPipe**(`stream`, `meter`): `void`
 
 #### Parameters
 
@@ -402,7 +460,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:175](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L175)
+[lib/source-destination/source-destination.ts:175](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L175)
 
 ___
 
@@ -410,10 +468,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -436,7 +493,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -474,7 +531,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -505,7 +562,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -530,6 +587,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -560,7 +618,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -583,6 +641,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -613,13 +672,13 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
 ### oneVerifierFinished
 
-▸ `Private` **oneVerifierFinished**(`verifier`): `void`
+▸ **oneVerifierFinished**(`verifier`): `void`
 
 #### Parameters
 
@@ -633,7 +692,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L71)
+[lib/source-destination/multi-destination.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L71)
 
 ___
 
@@ -675,7 +734,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -715,7 +774,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -727,6 +786,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -770,7 +830,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -806,7 +866,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -835,6 +895,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -875,6 +937,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -912,7 +975,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -930,7 +993,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/multi-destination.ts:92](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/multi-destination.ts#L92)
+[lib/source-destination/multi-destination.ts:92](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/multi-destination.ts#L92)
 
 ___
 
@@ -965,13 +1028,13 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1018,7 +1081,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1026,13 +1089,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1043,19 +1106,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1080,13 +1143,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1126,7 +1189,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1134,18 +1197,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1178,34 +1242,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1216,7 +1279,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1264,13 +1329,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1281,31 +1346,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1313,13 +1375,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1329,7 +1391,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1374,9 +1436,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1396,19 +1458,16 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1437,4 +1496,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.RandomAccessZipSource.md
+++ b/doc/classes/sourceDestination.RandomAccessZipSource.md
@@ -93,7 +93,7 @@
 
 ### constructor
 
-• **new RandomAccessZipSource**(`source`, `match?`)
+• **new RandomAccessZipSource**(`source`, `match?`): [`RandomAccessZipSource`](sourceDestination.RandomAccessZipSource.md)
 
 #### Parameters
 
@@ -102,13 +102,17 @@
 | `source` | [`SourceDestination`](sourceDestination.SourceDestination.md) | `undefined` |
 | `match` | (`filename`: `string`) => `boolean` | `matchSupportedExtensions` |
 
+#### Returns
+
+[`RandomAccessZipSource`](sourceDestination.RandomAccessZipSource.md)
+
 #### Overrides
 
 [SourceSource](sourceDestination.SourceSource.md).[constructor](sourceDestination.SourceSource.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/zip.ts:164](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L164)
+[lib/source-destination/zip.ts:164](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L164)
 
 ## Properties
 
@@ -118,7 +122,7 @@
 
 #### Defined in
 
-[lib/source-destination/zip.ts:162](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L162)
+[lib/source-destination/zip.ts:162](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L162)
 
 ___
 
@@ -142,7 +146,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L166)
+[lib/source-destination/zip.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L166)
 
 ___
 
@@ -152,7 +156,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:161](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L161)
+[lib/source-destination/zip.ts:161](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L161)
 
 ___
 
@@ -166,7 +170,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L22)
+[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L22)
 
 ___
 
@@ -176,7 +180,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:160](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L160)
+[lib/source-destination/zip.ts:160](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L160)
 
 ___
 
@@ -184,13 +188,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [SourceSource](sourceDestination.SourceSource.md).[captureRejectionSymbol](sourceDestination.SourceSource.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -198,7 +210,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -206,7 +224,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -214,13 +232,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [SourceSource](sourceDestination.SourceSource.md).[defaultMaxListeners](sourceDestination.SourceSource.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -228,13 +284,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -242,7 +299,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -256,7 +313,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -266,7 +323,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L150)
+[lib/source-destination/zip.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L150)
 
 ___
 
@@ -280,7 +337,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:307](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L307)
+[lib/source-destination/source-destination.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L305)
 
 ___
 
@@ -294,13 +351,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L20)
+[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L20)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -320,13 +377,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -338,7 +395,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L30)
+[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L30)
 
 ___
 
@@ -356,13 +413,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L319)
+[lib/source-destination/zip.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L319)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -374,7 +431,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:226](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L226)
+[lib/source-destination/zip.ts:226](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L226)
 
 ___
 
@@ -405,7 +462,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -423,7 +480,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:196](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L196)
+[lib/source-destination/zip.ts:196](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L196)
 
 ___
 
@@ -441,7 +498,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:200](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L200)
+[lib/source-destination/zip.ts:200](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L200)
 
 ___
 
@@ -459,7 +516,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -477,7 +534,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -495,7 +552,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L323)
+[lib/source-destination/source-destination.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L321)
 
 ___
 
@@ -513,7 +570,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -531,7 +588,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -555,7 +612,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:270](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L270)
+[lib/source-destination/zip.ts:270](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L270)
 
 ___
 
@@ -579,7 +636,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:296](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L296)
+[lib/source-destination/zip.ts:296](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L296)
 
 ___
 
@@ -604,7 +661,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
@@ -629,7 +686,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -654,7 +711,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
@@ -668,7 +725,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -721,7 +778,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -733,7 +790,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -759,7 +817,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -777,7 +835,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -795,13 +853,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
 ### getEntries
 
-▸ `Private` **getEntries**(): `Promise`<`Entry`[]\>
+▸ **getEntries**(): `Promise`<`Entry`[]\>
 
 #### Returns
 
@@ -809,13 +867,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:205](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L205)
+[lib/source-destination/zip.ts:205](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L205)
 
 ___
 
 ### getEntryByName
 
-▸ `Private` **getEntryByName**(`name`): `Promise`<`undefined` \| `Entry`\>
+▸ **getEntryByName**(`name`): `Promise`<`undefined` \| `Entry`\>
 
 #### Parameters
 
@@ -829,13 +887,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L232)
+[lib/source-destination/zip.ts:232](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L232)
 
 ___
 
 ### getImageEntry
 
-▸ `Private` **getImageEntry**(): `Promise`<`Entry`\>
+▸ **getImageEntry**(): `Promise`<`Entry`\>
 
 #### Returns
 
@@ -843,7 +901,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:210](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L210)
+[lib/source-destination/zip.ts:210](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L210)
 
 ___
 
@@ -861,13 +919,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
 ### getJson
 
-▸ `Private` **getJson**(`name`): `Promise`<`any`\>
+▸ **getJson**(`name`): `Promise`<`any`\>
 
 #### Parameters
 
@@ -881,7 +939,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:263](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L263)
+[lib/source-destination/zip.ts:263](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L263)
 
 ___
 
@@ -906,7 +964,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -924,7 +982,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -942,13 +1000,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
 ### getStream
 
-▸ `Private` **getStream**(`name`): `Promise`<`undefined` \| `ReadableStream`\>
+▸ **getStream**(`name`): `Promise`<`undefined` \| `ReadableStream`\>
 
 #### Parameters
 
@@ -962,13 +1020,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:241](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L241)
+[lib/source-destination/zip.ts:241](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L241)
 
 ___
 
 ### getString
 
-▸ `Private` **getString**(`name`): `Promise`<`undefined` \| `string`\>
+▸ **getString**(`name`): `Promise`<`undefined` \| `string`\>
 
 #### Parameters
 
@@ -982,13 +1040,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:255](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L255)
+[lib/source-destination/zip.ts:255](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L255)
 
 ___
 
 ### init
 
-▸ `Private` **init**(): `Promise`<`void`\>
+▸ **init**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -996,7 +1054,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:172](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L172)
+[lib/source-destination/zip.ts:172](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L172)
 
 ___
 
@@ -1004,10 +1062,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -1030,7 +1087,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -1068,7 +1125,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -1099,7 +1156,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -1124,6 +1181,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1154,7 +1212,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1177,6 +1235,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1207,7 +1266,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1225,7 +1284,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1267,7 +1326,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1307,7 +1366,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1319,6 +1378,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1362,7 +1422,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1389,7 +1449,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L358)
+[lib/source-destination/source-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L356)
 
 ___
 
@@ -1425,7 +1485,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1454,6 +1514,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1494,6 +1556,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1531,7 +1594,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1566,7 +1629,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1593,13 +1656,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1646,7 +1709,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1654,13 +1717,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1671,19 +1734,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1708,13 +1771,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1754,7 +1817,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1762,18 +1825,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1806,34 +1870,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1844,7 +1907,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1892,13 +1957,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1909,31 +1974,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1941,13 +2003,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1957,7 +2019,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -2002,9 +2064,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -2024,13 +2086,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -2048,19 +2110,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -2089,4 +2148,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.SingleUseStreamSource.md
+++ b/doc/classes/sourceDestination.SingleUseStreamSource.md
@@ -81,7 +81,7 @@
 
 ### constructor
 
-• **new SingleUseStreamSource**(`stream`)
+• **new SingleUseStreamSource**(`stream`): [`SingleUseStreamSource`](sourceDestination.SingleUseStreamSource.md)
 
 #### Parameters
 
@@ -89,13 +89,17 @@
 | :------ | :------ |
 | `stream` | `ReadableStream` |
 
+#### Returns
+
+[`SingleUseStreamSource`](sourceDestination.SingleUseStreamSource.md)
+
 #### Overrides
 
 [SourceDestination](sourceDestination.SourceDestination.md).[constructor](sourceDestination.SourceDestination.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/single-use-stream-source.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/single-use-stream-source.ts#L28)
+[lib/source-destination/single-use-stream-source.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/single-use-stream-source.ts#L28)
 
 ## Properties
 
@@ -105,7 +109,7 @@
 
 #### Defined in
 
-[lib/source-destination/single-use-stream-source.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/single-use-stream-source.ts#L28)
+[lib/source-destination/single-use-stream-source.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/single-use-stream-source.ts#L28)
 
 ___
 
@@ -115,7 +119,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/single-use-stream-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/single-use-stream-source.ts#L26)
+[lib/source-destination/single-use-stream-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/single-use-stream-source.ts#L26)
 
 ___
 
@@ -123,13 +127,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[captureRejectionSymbol](sourceDestination.SourceDestination.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -137,7 +149,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -145,7 +163,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -153,13 +171,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[defaultMaxListeners](sourceDestination.SourceDestination.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -167,13 +223,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -181,7 +238,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -195,7 +252,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -209,13 +266,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:307](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L307)
+[lib/source-destination/source-destination.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L305)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -235,13 +292,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -253,13 +310,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:422](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L422)
+[lib/source-destination/source-destination.ts:420](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L420)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -271,13 +328,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:354](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L354)
+[lib/source-destination/source-destination.ts:352](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L352)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -289,7 +346,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:418](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L418)
+[lib/source-destination/source-destination.ts:416](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L416)
 
 ___
 
@@ -320,7 +377,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -338,7 +395,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/single-use-stream-source.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/single-use-stream-source.ts#L32)
+[lib/source-destination/single-use-stream-source.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/single-use-stream-source.ts#L32)
 
 ___
 
@@ -356,7 +413,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -374,7 +431,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -392,7 +449,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -410,7 +467,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L323)
+[lib/source-destination/source-destination.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L321)
 
 ___
 
@@ -428,7 +485,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -446,7 +503,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -470,7 +527,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/single-use-stream-source.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/single-use-stream-source.ts#L36)
+[lib/source-destination/single-use-stream-source.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/single-use-stream-source.ts#L36)
 
 ___
 
@@ -494,7 +551,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -519,7 +576,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
@@ -544,7 +601,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -569,7 +626,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
@@ -583,7 +640,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -636,7 +693,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -648,7 +705,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -674,7 +732,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -692,7 +750,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -710,7 +768,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
@@ -728,7 +786,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -753,7 +811,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -771,7 +829,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -789,7 +847,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
@@ -797,10 +855,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -823,7 +880,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -861,7 +918,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -892,7 +949,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -917,6 +974,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -947,7 +1005,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -970,6 +1028,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1000,7 +1059,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1018,7 +1077,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1060,7 +1119,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1100,7 +1159,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1112,6 +1171,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1155,7 +1215,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1182,7 +1242,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L358)
+[lib/source-destination/source-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L356)
 
 ___
 
@@ -1218,7 +1278,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1247,6 +1307,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1287,6 +1349,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1324,7 +1387,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1359,7 +1422,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1386,13 +1449,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1439,7 +1502,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1447,13 +1510,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1464,19 +1527,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1501,13 +1564,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1547,7 +1610,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1555,18 +1618,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1599,34 +1663,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1637,7 +1700,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1685,13 +1750,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1702,31 +1767,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1734,13 +1796,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1750,7 +1812,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1795,9 +1857,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1817,13 +1879,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -1841,19 +1903,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1882,4 +1941,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.SourceDestination.md
+++ b/doc/classes/sourceDestination.SourceDestination.md
@@ -105,7 +105,7 @@
 
 ### constructor
 
-• **new SourceDestination**(`options?`)
+• **new SourceDestination**(`options?`): [`SourceDestination`](sourceDestination.SourceDestination.md)
 
 #### Parameters
 
@@ -113,13 +113,17 @@
 | :------ | :------ |
 | `options?` | `EventEmitterOptions` |
 
+#### Returns
+
+[`SourceDestination`](sourceDestination.SourceDestination.md)
+
 #### Inherited from
 
 EventEmitter.constructor
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:113
+node_modules/@types/node/events.d.ts:110
 
 ## Properties
 
@@ -129,7 +133,7 @@ node_modules/@types/node/events.d.ts:113
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L311)
+[lib/source-destination/source-destination.ts:309](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L309)
 
 ___
 
@@ -139,7 +143,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:310](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L310)
+[lib/source-destination/source-destination.ts:308](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L308)
 
 ___
 
@@ -147,13 +151,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 EventEmitter.captureRejectionSymbol
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -161,7 +173,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -169,7 +187,7 @@ EventEmitter.captureRejections
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -177,13 +195,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 EventEmitter.defaultMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -191,13 +247,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -205,7 +262,7 @@ EventEmitter.errorMonitor
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -215,7 +272,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -225,7 +282,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:307](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L307)
+[lib/source-destination/source-destination.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L305)
 
 ___
 
@@ -235,13 +292,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:308](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L308)
+[lib/source-destination/source-destination.ts:306](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L306)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -261,13 +318,13 @@ EventEmitter.[captureRejectionSymbol]
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -275,13 +332,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:422](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L422)
+[lib/source-destination/source-destination.ts:420](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L420)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -289,13 +346,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:354](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L354)
+[lib/source-destination/source-destination.ts:352](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L352)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -303,7 +360,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:418](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L418)
+[lib/source-destination/source-destination.ts:416](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L416)
 
 ___
 
@@ -334,7 +391,7 @@ EventEmitter.addListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -348,7 +405,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L331)
+[lib/source-destination/source-destination.ts:329](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L329)
 
 ___
 
@@ -362,7 +419,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -376,7 +433,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -390,7 +447,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -404,7 +461,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L323)
+[lib/source-destination/source-destination.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L321)
 
 ___
 
@@ -418,7 +475,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -432,7 +489,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -452,7 +509,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:376](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L376)
+[lib/source-destination/source-destination.ts:374](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L374)
 
 ___
 
@@ -472,7 +529,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -493,7 +550,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
@@ -514,7 +571,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -535,7 +592,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
@@ -549,7 +606,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -602,7 +659,7 @@ EventEmitter.emit
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -614,7 +671,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -640,7 +698,7 @@ EventEmitter.eventNames
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -654,7 +712,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -668,7 +726,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
@@ -682,13 +740,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
 ### getInnerSourceHelper
 
-▸ `Private` **getInnerSourceHelper**(`mimetype?`): `Promise`<[`SourceDestination`](sourceDestination.SourceDestination.md)\>
+▸ **getInnerSourceHelper**(`mimetype?`): `Promise`<[`SourceDestination`](sourceDestination.SourceDestination.md)\>
 
 #### Parameters
 
@@ -702,7 +760,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:484](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L484)
+[lib/source-destination/source-destination.ts:482](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L482)
 
 ___
 
@@ -727,7 +785,7 @@ EventEmitter.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -741,13 +799,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
 ### getMimeTypeFromContent
 
-▸ `Private` **getMimeTypeFromContent**(): `Promise`<`undefined` \| `string`\>
+▸ **getMimeTypeFromContent**(): `Promise`<`undefined` \| `string`\>
 
 #### Returns
 
@@ -755,13 +813,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:460](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L460)
+[lib/source-destination/source-destination.ts:458](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L458)
 
 ___
 
 ### getMimeTypeFromName
 
-▸ `Private` **getMimeTypeFromName**(): `Promise`<`undefined` \| `string`\>
+▸ **getMimeTypeFromName**(): `Promise`<`undefined` \| `string`\>
 
 #### Returns
 
@@ -769,7 +827,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:449](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L449)
+[lib/source-destination/source-destination.ts:447](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L447)
 
 ___
 
@@ -783,7 +841,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
@@ -791,10 +849,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -817,7 +874,7 @@ EventEmitter.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -855,7 +912,7 @@ EventEmitter.listeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -886,7 +943,7 @@ EventEmitter.off
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -911,6 +968,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -941,7 +999,7 @@ EventEmitter.on
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -964,6 +1022,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -994,7 +1053,7 @@ EventEmitter.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1008,7 +1067,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1050,7 +1109,7 @@ EventEmitter.prependListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1090,7 +1149,7 @@ EventEmitter.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1102,6 +1161,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1145,7 +1205,7 @@ EventEmitter.rawListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1168,7 +1228,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L358)
+[lib/source-destination/source-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L356)
 
 ___
 
@@ -1204,7 +1264,7 @@ EventEmitter.removeAllListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1233,6 +1293,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1273,6 +1335,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1310,7 +1373,7 @@ EventEmitter.removeListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1345,7 +1408,7 @@ EventEmitter.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1368,13 +1431,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1421,7 +1484,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1429,13 +1492,13 @@ EventEmitter.addAbortListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1446,19 +1509,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1483,13 +1546,13 @@ EventEmitter.getEventListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1529,7 +1592,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1537,18 +1600,19 @@ EventEmitter.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1581,34 +1645,33 @@ EventEmitter.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1619,7 +1682,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1667,13 +1732,13 @@ EventEmitter.on
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1684,31 +1749,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1716,13 +1778,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1732,7 +1794,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1777,9 +1839,9 @@ EventEmitter.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1799,13 +1861,13 @@ EventEmitter.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -1819,19 +1881,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1860,4 +1919,4 @@ EventEmitter.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.SourceDestinationFs.md
+++ b/doc/classes/sourceDestination.SourceDestinationFs.md
@@ -25,7 +25,7 @@
 
 ### constructor
 
-• **new SourceDestinationFs**(`source`)
+• **new SourceDestinationFs**(`source`): [`SourceDestinationFs`](sourceDestination.SourceDestinationFs.md)
 
 #### Parameters
 
@@ -33,9 +33,13 @@
 | :------ | :------ |
 | `source` | [`SourceDestination`](sourceDestination.SourceDestination.md) |
 
+#### Returns
+
+[`SourceDestinationFs`](sourceDestination.SourceDestinationFs.md)
+
 #### Defined in
 
-[lib/source-destination/source-destination.ts:112](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L112)
+[lib/source-destination/source-destination.ts:112](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L112)
 
 ## Properties
 
@@ -45,7 +49,7 @@
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:112](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L112)
+[lib/source-destination/source-destination.ts:112](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L112)
 
 ## Methods
 
@@ -66,7 +70,7 @@
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:122](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L122)
+[lib/source-destination/source-destination.ts:122](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L122)
 
 ___
 
@@ -87,7 +91,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:126](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L126)
+[lib/source-destination/source-destination.ts:126](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L126)
 
 ___
 
@@ -109,7 +113,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:114](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L114)
+[lib/source-destination/source-destination.ts:114](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L114)
 
 ___
 
@@ -134,4 +138,4 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:142](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L142)
+[lib/source-destination/source-destination.ts:142](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L142)

--- a/doc/classes/sourceDestination.SourceDisk.md
+++ b/doc/classes/sourceDestination.SourceDisk.md
@@ -46,7 +46,7 @@
 
 ### constructor
 
-• **new SourceDisk**(`source`)
+• **new SourceDisk**(`source`): [`SourceDisk`](sourceDestination.SourceDisk.md)
 
 #### Parameters
 
@@ -54,13 +54,17 @@
 | :------ | :------ |
 | `source` | [`SourceDestination`](sourceDestination.SourceDestination.md) |
 
+#### Returns
+
+[`SourceDisk`](sourceDestination.SourceDisk.md)
+
 #### Overrides
 
 Disk.constructor
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L48)
+[lib/source-destination/configured-source/configured-source.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L52)
 
 ## Properties
 
@@ -154,13 +158,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L48)
+[lib/source-destination/configured-source/configured-source.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L52)
 
 ## Methods
 
 ### \_flush
 
-▸ `Protected` **_flush**(): `Promise`<`void`\>
+▸ **_flush**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -172,13 +176,13 @@ Disk.\_flush
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:90](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L90)
+[lib/source-destination/configured-source/configured-source.ts:94](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L94)
 
 ___
 
 ### \_getCapacity
 
-▸ `Protected` **_getCapacity**(): `Promise`<`number`\>
+▸ **_getCapacity**(): `Promise`<`number`\>
 
 #### Returns
 
@@ -190,13 +194,13 @@ Disk.\_getCapacity
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L63)
+[lib/source-destination/configured-source/configured-source.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L67)
 
 ___
 
 ### \_read
 
-▸ `Protected` **_read**(`buffer`, `bufferOffset`, `length`, `fileOffset`): `Promise`<`ReadResult`\>
+▸ **_read**(`buffer`, `bufferOffset`, `length`, `fileOffset`): `Promise`<`ReadResult`\>
 
 #### Parameters
 
@@ -217,13 +221,13 @@ Disk.\_read
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:72](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L72)
+[lib/source-destination/configured-source/configured-source.ts:76](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L76)
 
 ___
 
 ### \_write
 
-▸ `Protected` **_write**(`_buffer`, `_bufferOffset`, `_length`, `_fileOffset`): `Promise`<`WriteResult`\>
+▸ **_write**(`_buffer`, `_bufferOffset`, `_length`, `_fileOffset`): `Promise`<`WriteResult`\>
 
 #### Parameters
 
@@ -244,7 +248,7 @@ Disk.\_write
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:81](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L81)
+[lib/source-destination/configured-source/configured-source.ts:85](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L85)
 
 ___
 

--- a/doc/classes/sourceDestination.SourceSource.md
+++ b/doc/classes/sourceDestination.SourceSource.md
@@ -93,7 +93,7 @@
 
 ### constructor
 
-• **new SourceSource**(`source`)
+• **new SourceSource**(`source`): [`SourceSource`](sourceDestination.SourceSource.md)
 
 #### Parameters
 
@@ -101,13 +101,17 @@
 | :------ | :------ |
 | `source` | [`SourceDestination`](sourceDestination.SourceDestination.md) |
 
+#### Returns
+
+[`SourceSource`](sourceDestination.SourceSource.md)
+
 #### Overrides
 
 [SourceDestination](sourceDestination.SourceDestination.md).[constructor](sourceDestination.SourceDestination.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L22)
+[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L22)
 
 ## Properties
 
@@ -117,7 +121,7 @@
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L22)
+[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L22)
 
 ___
 
@@ -125,13 +129,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[captureRejectionSymbol](sourceDestination.SourceDestination.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -139,7 +151,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -147,7 +165,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -155,13 +173,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[defaultMaxListeners](sourceDestination.SourceDestination.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -169,13 +225,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -183,7 +240,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -197,7 +254,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -211,7 +268,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:307](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L307)
+[lib/source-destination/source-destination.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L305)
 
 ___
 
@@ -221,13 +278,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L20)
+[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L20)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -247,13 +304,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -265,13 +322,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L30)
+[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L30)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -283,13 +340,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:354](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L354)
+[lib/source-destination/source-destination.ts:352](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L352)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -301,7 +358,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L26)
+[lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L26)
 
 ___
 
@@ -332,7 +389,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -350,7 +407,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L331)
+[lib/source-destination/source-destination.ts:329](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L329)
 
 ___
 
@@ -368,7 +425,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -386,7 +443,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -404,7 +461,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -422,7 +479,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L323)
+[lib/source-destination/source-destination.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L321)
 
 ___
 
@@ -440,7 +497,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -458,7 +515,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -482,7 +539,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:376](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L376)
+[lib/source-destination/source-destination.ts:374](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L374)
 
 ___
 
@@ -506,7 +563,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -531,7 +588,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
@@ -556,7 +613,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -581,7 +638,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
@@ -595,7 +652,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -648,7 +705,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -660,7 +717,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -686,7 +744,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -704,7 +762,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -722,7 +780,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
@@ -740,7 +798,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -765,7 +823,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -783,7 +841,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -801,7 +859,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
@@ -809,10 +867,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -835,7 +892,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -873,7 +930,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -904,7 +961,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -929,6 +986,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -959,7 +1017,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -982,6 +1040,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1012,7 +1071,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1030,7 +1089,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1072,7 +1131,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1112,7 +1171,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1124,6 +1183,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1167,7 +1227,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1194,7 +1254,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L358)
+[lib/source-destination/source-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L356)
 
 ___
 
@@ -1230,7 +1290,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1259,6 +1319,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1299,6 +1361,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1336,7 +1399,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1371,7 +1434,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1398,13 +1461,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1451,7 +1514,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1459,13 +1522,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1476,19 +1539,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1513,13 +1576,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1559,7 +1622,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1567,18 +1630,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1611,34 +1675,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1649,7 +1712,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1697,13 +1762,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1714,31 +1779,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1746,13 +1808,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1762,7 +1824,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1807,9 +1869,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1829,13 +1891,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -1853,19 +1915,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1894,4 +1953,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.SparseStreamVerifier.md
+++ b/doc/classes/sourceDestination.SparseStreamVerifier.md
@@ -58,7 +58,7 @@
 
 ### constructor
 
-• **new SparseStreamVerifier**(`source`, `blocks`)
+• **new SparseStreamVerifier**(`source`, `blocks`): [`SparseStreamVerifier`](sourceDestination.SparseStreamVerifier.md)
 
 #### Parameters
 
@@ -67,13 +67,17 @@
 | `source` | [`SourceDestination`](sourceDestination.SourceDestination.md) |
 | `blocks` | [`BlocksWithChecksum`](../interfaces/sparseStream.BlocksWithChecksum.md)[] |
 
+#### Returns
+
+[`SparseStreamVerifier`](sourceDestination.SparseStreamVerifier.md)
+
 #### Overrides
 
 [Verifier](sourceDestination.Verifier.md).[constructor](sourceDestination.Verifier.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:227](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L227)
+[lib/source-destination/source-destination.ts:227](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L227)
 
 ## Properties
 
@@ -83,7 +87,7 @@
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:229](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L229)
+[lib/source-destination/source-destination.ts:229](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L229)
 
 ___
 
@@ -97,7 +101,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L166)
+[lib/source-destination/source-destination.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L166)
 
 ___
 
@@ -107,7 +111,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:228](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L228)
+[lib/source-destination/source-destination.ts:228](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L228)
 
 ___
 
@@ -115,13 +119,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [Verifier](sourceDestination.Verifier.md).[captureRejectionSymbol](sourceDestination.Verifier.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -129,7 +141,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -137,7 +155,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -145,13 +163,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [Verifier](sourceDestination.Verifier.md).[defaultMaxListeners](sourceDestination.Verifier.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -159,13 +215,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -173,13 +230,13 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -199,7 +256,7 @@ node_modules/@types/node/events.d.ts:404
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
@@ -230,7 +287,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -244,7 +301,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -297,7 +354,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -309,7 +366,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -335,7 +393,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -360,13 +418,13 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
 ### handleEventsAndPipe
 
-▸ `Protected` **handleEventsAndPipe**(`stream`, `meter`): `void`
+▸ **handleEventsAndPipe**(`stream`, `meter`): `void`
 
 #### Parameters
 
@@ -385,7 +443,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:175](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L175)
+[lib/source-destination/source-destination.ts:175](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L175)
 
 ___
 
@@ -393,10 +451,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -419,7 +476,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -457,7 +514,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -488,7 +545,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -513,6 +570,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -543,7 +601,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -566,6 +624,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -596,7 +655,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -638,7 +697,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -678,7 +737,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -690,6 +749,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -733,7 +793,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -769,7 +829,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -798,6 +858,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -838,6 +900,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -875,7 +938,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -893,7 +956,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:234](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L234)
+[lib/source-destination/source-destination.ts:234](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L234)
 
 ___
 
@@ -928,13 +991,13 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -981,7 +1044,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -989,13 +1052,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1006,19 +1069,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1043,13 +1106,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1089,7 +1152,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1097,18 +1160,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1141,34 +1205,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1179,7 +1242,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1227,13 +1292,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1244,31 +1309,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1276,13 +1338,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1292,7 +1354,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1337,9 +1399,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1359,19 +1421,16 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1400,4 +1459,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.StreamVerifier.md
+++ b/doc/classes/sourceDestination.StreamVerifier.md
@@ -59,7 +59,7 @@
 
 ### constructor
 
-• **new StreamVerifier**(`source`, `checksum`, `size`)
+• **new StreamVerifier**(`source`, `checksum`, `size`): [`StreamVerifier`](sourceDestination.StreamVerifier.md)
 
 #### Parameters
 
@@ -69,13 +69,17 @@
 | `checksum` | `string` |
 | `size` | `number` |
 
+#### Returns
+
+[`StreamVerifier`](sourceDestination.StreamVerifier.md)
+
 #### Overrides
 
 [Verifier](sourceDestination.Verifier.md).[constructor](sourceDestination.Verifier.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:194](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L194)
+[lib/source-destination/source-destination.ts:194](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L194)
 
 ## Properties
 
@@ -85,7 +89,7 @@
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:196](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L196)
+[lib/source-destination/source-destination.ts:196](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L196)
 
 ___
 
@@ -99,7 +103,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L166)
+[lib/source-destination/source-destination.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L166)
 
 ___
 
@@ -109,7 +113,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:197](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L197)
+[lib/source-destination/source-destination.ts:197](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L197)
 
 ___
 
@@ -119,7 +123,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:195](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L195)
+[lib/source-destination/source-destination.ts:195](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L195)
 
 ___
 
@@ -127,13 +131,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [Verifier](sourceDestination.Verifier.md).[captureRejectionSymbol](sourceDestination.Verifier.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -141,7 +153,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -149,7 +167,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -157,13 +175,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [Verifier](sourceDestination.Verifier.md).[defaultMaxListeners](sourceDestination.Verifier.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -171,13 +227,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -185,13 +242,13 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -211,7 +268,7 @@ node_modules/@types/node/events.d.ts:404
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
@@ -242,7 +299,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -256,7 +313,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -309,7 +366,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -321,7 +378,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -347,7 +405,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -372,13 +430,13 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
 ### handleEventsAndPipe
 
-▸ `Protected` **handleEventsAndPipe**(`stream`, `meter`): `void`
+▸ **handleEventsAndPipe**(`stream`, `meter`): `void`
 
 #### Parameters
 
@@ -397,7 +455,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:175](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L175)
+[lib/source-destination/source-destination.ts:175](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L175)
 
 ___
 
@@ -405,10 +463,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -431,7 +488,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -469,7 +526,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -500,7 +557,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -525,6 +582,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -555,7 +613,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -578,6 +636,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -608,7 +667,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -650,7 +709,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -690,7 +749,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -702,6 +761,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -745,7 +805,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -781,7 +841,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -810,6 +870,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -850,6 +912,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -887,7 +950,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -905,7 +968,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:202](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L202)
+[lib/source-destination/source-destination.ts:202](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L202)
 
 ___
 
@@ -940,13 +1003,13 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -993,7 +1056,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1001,13 +1064,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1018,19 +1081,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1055,13 +1118,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1101,7 +1164,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1109,18 +1172,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1153,34 +1217,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1191,7 +1254,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1239,13 +1304,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1256,31 +1321,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1288,13 +1350,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1304,7 +1366,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1349,9 +1411,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1371,19 +1433,16 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1412,4 +1471,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.StreamZipSource.md
+++ b/doc/classes/sourceDestination.StreamZipSource.md
@@ -84,7 +84,7 @@
 
 ### constructor
 
-• **new StreamZipSource**(`source`, `match?`)
+• **new StreamZipSource**(`source`, `match?`): [`StreamZipSource`](sourceDestination.StreamZipSource.md)
 
 #### Parameters
 
@@ -93,13 +93,17 @@
 | `source` | [`SourceDestination`](sourceDestination.SourceDestination.md) | `undefined` |
 | `match` | (`filename`: `string`) => `boolean` | `matchSupportedExtensions` |
 
+#### Returns
+
+[`StreamZipSource`](sourceDestination.StreamZipSource.md)
+
 #### Overrides
 
 [SourceSource](sourceDestination.SourceSource.md).[constructor](sourceDestination.SourceSource.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/zip.ts:73](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L73)
+[lib/source-destination/zip.ts:73](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L73)
 
 ## Properties
 
@@ -109,7 +113,7 @@
 
 #### Defined in
 
-[lib/source-destination/zip.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L71)
+[lib/source-destination/zip.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L71)
 
 ___
 
@@ -133,7 +137,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L75)
+[lib/source-destination/zip.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L75)
 
 ___
 
@@ -147,7 +151,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L22)
+[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L22)
 
 ___
 
@@ -155,13 +159,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [SourceSource](sourceDestination.SourceSource.md).[captureRejectionSymbol](sourceDestination.SourceSource.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -169,7 +181,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -177,7 +195,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -185,13 +203,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [SourceSource](sourceDestination.SourceSource.md).[defaultMaxListeners](sourceDestination.SourceSource.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -199,13 +255,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -213,7 +270,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -227,7 +284,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -241,7 +298,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:307](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L307)
+[lib/source-destination/source-destination.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L305)
 
 ___
 
@@ -255,13 +312,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L20)
+[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L20)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -281,13 +338,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -299,13 +356,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L30)
+[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L30)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -317,13 +374,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:118](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L118)
+[lib/source-destination/zip.ts:118](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L118)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -335,7 +392,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L26)
+[lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L26)
 
 ___
 
@@ -366,7 +423,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -384,7 +441,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L80)
+[lib/source-destination/zip.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L80)
 
 ___
 
@@ -402,7 +459,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -420,7 +477,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -438,7 +495,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -456,7 +513,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L323)
+[lib/source-destination/source-destination.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L321)
 
 ___
 
@@ -474,7 +531,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -492,7 +549,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -516,7 +573,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L102)
+[lib/source-destination/zip.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L102)
 
 ___
 
@@ -540,7 +597,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -565,7 +622,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
@@ -590,7 +647,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -615,7 +672,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
@@ -629,7 +686,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -682,7 +739,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -694,7 +751,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -720,7 +778,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -738,7 +796,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -756,13 +814,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
 ### getEntry
 
-▸ `Private` **getEntry**(): `Promise`<`ZipStreamEntry`\>
+▸ **getEntry**(): `Promise`<`ZipStreamEntry`\>
 
 #### Returns
 
@@ -770,7 +828,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L84)
+[lib/source-destination/zip.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L84)
 
 ___
 
@@ -788,7 +846,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -813,7 +871,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -831,7 +889,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -849,7 +907,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
@@ -857,10 +915,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -883,7 +940,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -921,7 +978,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -952,7 +1009,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -977,6 +1034,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1007,7 +1065,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1030,6 +1088,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1060,7 +1119,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1078,7 +1137,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1120,7 +1179,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1160,7 +1219,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1172,6 +1231,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1215,7 +1275,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1242,7 +1302,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L358)
+[lib/source-destination/source-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L356)
 
 ___
 
@@ -1278,7 +1338,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1307,6 +1367,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1347,6 +1409,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1384,7 +1447,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1419,7 +1482,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1446,13 +1509,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1499,7 +1562,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1507,13 +1570,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1524,19 +1587,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1561,13 +1624,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1607,7 +1670,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1615,18 +1678,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1659,34 +1723,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1697,7 +1760,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1745,13 +1810,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1762,31 +1827,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1794,13 +1856,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1810,7 +1872,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1855,9 +1917,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1877,13 +1939,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -1901,19 +1963,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1942,4 +2001,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.UsbBBbootDrive.md
+++ b/doc/classes/sourceDestination.UsbBBbootDrive.md
@@ -97,7 +97,7 @@
 
 ### constructor
 
-• **new UsbBBbootDrive**(`usbDevice`)
+• **new UsbBBbootDrive**(`usbDevice`): [`UsbBBbootDrive`](sourceDestination.UsbBBbootDrive.md)
 
 #### Parameters
 
@@ -105,13 +105,17 @@
 | :------ | :------ |
 | `usbDevice` | `UsbBBbootDevice` |
 
+#### Returns
+
+[`UsbBBbootDrive`](sourceDestination.UsbBBbootDrive.md)
+
 #### Overrides
 
 [SourceDestination](sourceDestination.SourceDestination.md).[constructor](sourceDestination.SourceDestination.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/usb-bb-boot.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usb-bb-boot.ts#L24)
+[lib/source-destination/usb-bb-boot.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usb-bb-boot.ts#L24)
 
 ## Properties
 
@@ -125,7 +129,7 @@
 
 #### Defined in
 
-[lib/source-destination/usb-bb-boot.ts:16](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usb-bb-boot.ts#L16)
+[lib/source-destination/usb-bb-boot.ts:16](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usb-bb-boot.ts#L16)
 
 ___
 
@@ -139,7 +143,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usb-bb-boot.ts:12](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usb-bb-boot.ts#L12)
+[lib/source-destination/usb-bb-boot.ts:12](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usb-bb-boot.ts#L12)
 
 ___
 
@@ -153,7 +157,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usb-bb-boot.ts:13](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usb-bb-boot.ts#L13)
+[lib/source-destination/usb-bb-boot.ts:13](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usb-bb-boot.ts#L13)
 
 ___
 
@@ -163,7 +167,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usb-bb-boot.ts:19](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usb-bb-boot.ts#L19)
+[lib/source-destination/usb-bb-boot.ts:19](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usb-bb-boot.ts#L19)
 
 ___
 
@@ -173,7 +177,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usb-bb-boot.ts:11](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usb-bb-boot.ts#L11)
+[lib/source-destination/usb-bb-boot.ts:11](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usb-bb-boot.ts#L11)
 
 ___
 
@@ -187,7 +191,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usb-bb-boot.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usb-bb-boot.ts#L21)
+[lib/source-destination/usb-bb-boot.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usb-bb-boot.ts#L21)
 
 ___
 
@@ -197,7 +201,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usb-bb-boot.ts:14](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usb-bb-boot.ts#L14)
+[lib/source-destination/usb-bb-boot.ts:14](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usb-bb-boot.ts#L14)
 
 ___
 
@@ -207,7 +211,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usb-bb-boot.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usb-bb-boot.ts#L18)
+[lib/source-destination/usb-bb-boot.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usb-bb-boot.ts#L18)
 
 ___
 
@@ -221,7 +225,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usb-bb-boot.ts:15](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usb-bb-boot.ts#L15)
+[lib/source-destination/usb-bb-boot.ts:15](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usb-bb-boot.ts#L15)
 
 ___
 
@@ -235,7 +239,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usb-bb-boot.ts:17](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usb-bb-boot.ts#L17)
+[lib/source-destination/usb-bb-boot.ts:17](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usb-bb-boot.ts#L17)
 
 ___
 
@@ -245,7 +249,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usb-bb-boot.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usb-bb-boot.ts#L22)
+[lib/source-destination/usb-bb-boot.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usb-bb-boot.ts#L22)
 
 ___
 
@@ -259,7 +263,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usb-bb-boot.ts:10](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usb-bb-boot.ts#L10)
+[lib/source-destination/usb-bb-boot.ts:10](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usb-bb-boot.ts#L10)
 
 ___
 
@@ -273,7 +277,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usb-bb-boot.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usb-bb-boot.ts#L20)
+[lib/source-destination/usb-bb-boot.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usb-bb-boot.ts#L20)
 
 ___
 
@@ -283,7 +287,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usb-bb-boot.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usb-bb-boot.ts#L24)
+[lib/source-destination/usb-bb-boot.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usb-bb-boot.ts#L24)
 
 ___
 
@@ -291,13 +295,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[captureRejectionSymbol](sourceDestination.SourceDestination.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -305,7 +317,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -313,7 +331,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -321,13 +339,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[defaultMaxListeners](sourceDestination.SourceDestination.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -335,13 +391,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -349,7 +406,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -363,7 +420,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -377,13 +434,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:307](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L307)
+[lib/source-destination/source-destination.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L305)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -407,13 +464,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -429,13 +486,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:422](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L422)
+[lib/source-destination/source-destination.ts:420](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L420)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -451,13 +508,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:354](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L354)
+[lib/source-destination/source-destination.ts:352](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L352)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -473,7 +530,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:418](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L418)
+[lib/source-destination/source-destination.ts:416](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L416)
 
 ___
 
@@ -508,7 +565,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -530,7 +587,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L331)
+[lib/source-destination/source-destination.ts:329](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L329)
 
 ___
 
@@ -552,7 +609,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -574,7 +631,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -596,7 +653,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -618,7 +675,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L323)
+[lib/source-destination/source-destination.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L321)
 
 ___
 
@@ -640,7 +697,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -662,7 +719,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -690,7 +747,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:376](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L376)
+[lib/source-destination/source-destination.ts:374](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L374)
 
 ___
 
@@ -718,7 +775,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -747,7 +804,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
@@ -776,7 +833,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -805,7 +862,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
@@ -819,7 +876,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -876,7 +933,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -888,7 +945,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -918,7 +976,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -940,7 +998,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -962,7 +1020,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
@@ -984,7 +1042,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -1013,7 +1071,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -1035,7 +1093,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -1057,7 +1115,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
@@ -1065,10 +1123,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -1095,7 +1152,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -1137,7 +1194,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -1172,7 +1229,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -1197,6 +1254,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1231,7 +1289,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1254,6 +1312,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1288,7 +1347,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1310,7 +1369,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1356,7 +1415,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1400,7 +1459,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1412,6 +1471,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1459,7 +1519,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1490,7 +1550,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L358)
+[lib/source-destination/source-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L356)
 
 ___
 
@@ -1530,7 +1590,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1559,6 +1619,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1599,6 +1661,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1640,7 +1703,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1679,7 +1742,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1710,13 +1773,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1763,7 +1826,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1771,13 +1834,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1788,19 +1851,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1825,13 +1888,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1871,7 +1934,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1879,18 +1942,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1923,34 +1987,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1961,7 +2024,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -2009,13 +2074,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -2026,31 +2091,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -2058,13 +2120,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -2074,7 +2136,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -2119,9 +2181,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -2141,13 +2203,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -2165,19 +2227,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -2206,4 +2265,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.UsbbootDrive.md
+++ b/doc/classes/sourceDestination.UsbbootDrive.md
@@ -97,7 +97,7 @@
 
 ### constructor
 
-• **new UsbbootDrive**(`usbDevice`)
+• **new UsbbootDrive**(`usbDevice`): [`UsbbootDrive`](sourceDestination.UsbbootDrive.md)
 
 #### Parameters
 
@@ -105,13 +105,17 @@
 | :------ | :------ |
 | `usbDevice` | `UsbbootDevice` |
 
+#### Returns
+
+[`UsbbootDrive`](sourceDestination.UsbbootDrive.md)
+
 #### Overrides
 
 [SourceDestination](sourceDestination.SourceDestination.md).[constructor](sourceDestination.SourceDestination.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/usbboot.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usbboot.ts#L40)
+[lib/source-destination/usbboot.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usbboot.ts#L40)
 
 ## Properties
 
@@ -125,7 +129,7 @@
 
 #### Defined in
 
-[lib/source-destination/usbboot.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usbboot.ts#L32)
+[lib/source-destination/usbboot.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usbboot.ts#L32)
 
 ___
 
@@ -139,7 +143,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usbboot.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usbboot.ts#L28)
+[lib/source-destination/usbboot.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usbboot.ts#L28)
 
 ___
 
@@ -153,7 +157,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usbboot.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usbboot.ts#L29)
+[lib/source-destination/usbboot.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usbboot.ts#L29)
 
 ___
 
@@ -163,7 +167,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usbboot.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usbboot.ts#L35)
+[lib/source-destination/usbboot.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usbboot.ts#L35)
 
 ___
 
@@ -173,7 +177,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usbboot.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usbboot.ts#L27)
+[lib/source-destination/usbboot.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usbboot.ts#L27)
 
 ___
 
@@ -187,7 +191,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usbboot.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usbboot.ts#L37)
+[lib/source-destination/usbboot.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usbboot.ts#L37)
 
 ___
 
@@ -197,7 +201,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usbboot.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usbboot.ts#L30)
+[lib/source-destination/usbboot.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usbboot.ts#L30)
 
 ___
 
@@ -207,7 +211,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usbboot.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usbboot.ts#L34)
+[lib/source-destination/usbboot.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usbboot.ts#L34)
 
 ___
 
@@ -221,7 +225,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usbboot.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usbboot.ts#L31)
+[lib/source-destination/usbboot.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usbboot.ts#L31)
 
 ___
 
@@ -235,7 +239,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usbboot.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usbboot.ts#L33)
+[lib/source-destination/usbboot.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usbboot.ts#L33)
 
 ___
 
@@ -245,7 +249,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usbboot.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usbboot.ts#L38)
+[lib/source-destination/usbboot.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usbboot.ts#L38)
 
 ___
 
@@ -259,7 +263,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usbboot.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usbboot.ts#L26)
+[lib/source-destination/usbboot.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usbboot.ts#L26)
 
 ___
 
@@ -273,7 +277,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usbboot.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usbboot.ts#L36)
+[lib/source-destination/usbboot.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usbboot.ts#L36)
 
 ___
 
@@ -283,7 +287,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/usbboot.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/usbboot.ts#L40)
+[lib/source-destination/usbboot.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/usbboot.ts#L40)
 
 ___
 
@@ -291,13 +295,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[captureRejectionSymbol](sourceDestination.SourceDestination.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -305,7 +317,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -313,7 +331,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -321,13 +339,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [SourceDestination](sourceDestination.SourceDestination.md).[defaultMaxListeners](sourceDestination.SourceDestination.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -335,13 +391,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -349,7 +406,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -363,7 +420,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -377,13 +434,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:307](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L307)
+[lib/source-destination/source-destination.ts:305](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L305)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -407,13 +464,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -429,13 +486,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:422](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L422)
+[lib/source-destination/source-destination.ts:420](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L420)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -451,13 +508,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:354](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L354)
+[lib/source-destination/source-destination.ts:352](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L352)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -473,7 +530,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:418](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L418)
+[lib/source-destination/source-destination.ts:416](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L416)
 
 ___
 
@@ -508,7 +565,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -530,7 +587,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L331)
+[lib/source-destination/source-destination.ts:329](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L329)
 
 ___
 
@@ -552,7 +609,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -574,7 +631,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -596,7 +653,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -618,7 +675,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L323)
+[lib/source-destination/source-destination.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L321)
 
 ___
 
@@ -640,7 +697,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -662,7 +719,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -690,7 +747,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:376](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L376)
+[lib/source-destination/source-destination.ts:374](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L374)
 
 ___
 
@@ -718,7 +775,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -747,7 +804,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
@@ -776,7 +833,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -805,7 +862,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
@@ -819,7 +876,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -876,7 +933,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -888,7 +945,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -918,7 +976,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -940,7 +998,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -962,7 +1020,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
@@ -984,7 +1042,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -1013,7 +1071,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -1035,7 +1093,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -1057,7 +1115,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
@@ -1065,10 +1123,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -1095,7 +1152,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -1137,7 +1194,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -1172,7 +1229,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -1197,6 +1254,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1231,7 +1289,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1254,6 +1312,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1288,7 +1347,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1310,7 +1369,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1356,7 +1415,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1400,7 +1459,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1412,6 +1471,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1459,7 +1519,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1490,7 +1550,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L358)
+[lib/source-destination/source-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L356)
 
 ___
 
@@ -1530,7 +1590,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1559,6 +1619,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1599,6 +1661,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1640,7 +1703,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1679,7 +1742,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1710,13 +1773,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1763,7 +1826,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1771,13 +1834,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1788,19 +1851,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1825,13 +1888,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1871,7 +1934,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1879,18 +1942,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1923,34 +1987,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1961,7 +2024,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -2009,13 +2074,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -2026,31 +2091,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -2058,13 +2120,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -2074,7 +2136,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -2119,9 +2181,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -2141,13 +2203,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -2165,19 +2227,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -2206,4 +2265,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.Verifier.md
+++ b/doc/classes/sourceDestination.Verifier.md
@@ -62,7 +62,7 @@
 
 ### constructor
 
-• **new Verifier**(`options?`)
+• **new Verifier**(`options?`): [`Verifier`](sourceDestination.Verifier.md)
 
 #### Parameters
 
@@ -70,13 +70,17 @@
 | :------ | :------ |
 | `options?` | `EventEmitterOptions` |
 
+#### Returns
+
+[`Verifier`](sourceDestination.Verifier.md)
+
 #### Inherited from
 
 EventEmitter.constructor
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:113
+node_modules/@types/node/events.d.ts:110
 
 ## Properties
 
@@ -86,7 +90,7 @@ node_modules/@types/node/events.d.ts:113
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L166)
+[lib/source-destination/source-destination.ts:166](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L166)
 
 ___
 
@@ -94,13 +98,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 EventEmitter.captureRejectionSymbol
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -108,7 +120,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -116,7 +134,7 @@ EventEmitter.captureRejections
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -124,13 +142,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 EventEmitter.defaultMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -138,13 +194,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -152,13 +209,13 @@ EventEmitter.errorMonitor
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -178,7 +235,7 @@ EventEmitter.[captureRejectionSymbol]
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
@@ -209,7 +266,7 @@ EventEmitter.addListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -223,7 +280,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -276,7 +333,7 @@ EventEmitter.emit
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -288,7 +345,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -314,7 +372,7 @@ EventEmitter.eventNames
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -339,13 +397,13 @@ EventEmitter.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
 ### handleEventsAndPipe
 
-▸ `Protected` **handleEventsAndPipe**(`stream`, `meter`): `void`
+▸ **handleEventsAndPipe**(`stream`, `meter`): `void`
 
 #### Parameters
 
@@ -360,7 +418,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:175](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L175)
+[lib/source-destination/source-destination.ts:175](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L175)
 
 ___
 
@@ -368,10 +426,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -394,7 +451,7 @@ EventEmitter.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -432,7 +489,7 @@ EventEmitter.listeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -463,7 +520,7 @@ EventEmitter.off
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -488,6 +545,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -518,7 +576,7 @@ EventEmitter.on
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -541,6 +599,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -571,7 +630,7 @@ EventEmitter.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -613,7 +672,7 @@ EventEmitter.prependListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -653,7 +712,7 @@ EventEmitter.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -665,6 +724,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -708,7 +768,7 @@ EventEmitter.rawListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -744,7 +804,7 @@ EventEmitter.removeAllListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -773,6 +833,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -813,6 +875,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -850,13 +913,13 @@ EventEmitter.removeListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
 ### run
 
-▸ `Abstract` **run**(): `Promise`<`void`\>
+▸ **run**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -864,7 +927,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:173](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L173)
+[lib/source-destination/source-destination.ts:173](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L173)
 
 ___
 
@@ -899,13 +962,13 @@ EventEmitter.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -952,7 +1015,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -960,13 +1023,13 @@ EventEmitter.addAbortListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -977,19 +1040,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1014,13 +1077,13 @@ EventEmitter.getEventListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1060,7 +1123,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1068,18 +1131,19 @@ EventEmitter.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1112,34 +1176,33 @@ EventEmitter.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1150,7 +1213,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1198,13 +1263,13 @@ EventEmitter.on
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1215,31 +1280,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1247,13 +1309,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1263,7 +1325,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1308,9 +1370,9 @@ EventEmitter.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1330,19 +1392,16 @@ EventEmitter.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1371,4 +1430,4 @@ EventEmitter.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.XzSource.md
+++ b/doc/classes/sourceDestination.XzSource.md
@@ -84,7 +84,7 @@
 
 ### constructor
 
-• **new XzSource**(`source`)
+• **new XzSource**(`source`): [`XzSource`](sourceDestination.XzSource.md)
 
 #### Parameters
 
@@ -92,13 +92,17 @@
 | :------ | :------ |
 | `source` | [`SourceDestination`](sourceDestination.SourceDestination.md) |
 
+#### Returns
+
+[`XzSource`](sourceDestination.XzSource.md)
+
 #### Inherited from
 
 [CompressedSource](sourceDestination.CompressedSource.md).[constructor](sourceDestination.CompressedSource.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L22)
+[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L22)
 
 ## Properties
 
@@ -112,7 +116,7 @@
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L22)
+[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L22)
 
 ___
 
@@ -120,13 +124,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [CompressedSource](sourceDestination.CompressedSource.md).[captureRejectionSymbol](sourceDestination.CompressedSource.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -134,7 +146,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -142,7 +160,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -150,13 +168,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [CompressedSource](sourceDestination.CompressedSource.md).[defaultMaxListeners](sourceDestination.CompressedSource.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -164,13 +220,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -178,7 +235,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -192,7 +249,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -206,7 +263,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/xz.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/xz.ts#L28)
+[lib/source-destination/xz.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/xz.ts#L28)
 
 ___
 
@@ -220,13 +277,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L20)
+[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L20)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -246,13 +303,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -264,13 +321,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L30)
+[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L30)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -282,13 +339,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L106)
+[lib/source-destination/compressed-source.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L106)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -300,7 +357,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L26)
+[lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L26)
 
 ___
 
@@ -331,7 +388,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -349,7 +406,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L53)
+[lib/source-destination/compressed-source.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L53)
 
 ___
 
@@ -367,7 +424,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -385,7 +442,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -403,7 +460,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -421,7 +478,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L323)
+[lib/source-destination/source-destination.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L321)
 
 ___
 
@@ -439,7 +496,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -457,7 +514,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -481,7 +538,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L57)
+[lib/source-destination/compressed-source.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L57)
 
 ___
 
@@ -505,7 +562,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -530,13 +587,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
 ### createTransform
 
-▸ `Protected` **createTransform**(): `Transform`
+▸ **createTransform**(): `Transform`
 
 #### Returns
 
@@ -548,7 +605,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/xz.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/xz.ts#L30)
+[lib/source-destination/xz.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/xz.ts#L30)
 
 ___
 
@@ -573,7 +630,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -598,7 +655,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
@@ -612,7 +669,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -665,7 +722,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -677,7 +734,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -703,7 +761,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -721,7 +779,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -739,7 +797,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
@@ -757,7 +815,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -782,7 +840,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -800,7 +858,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -818,13 +876,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
 ### getSize
 
-▸ `Protected` **getSize**(): `Promise`<`undefined` \| { `isEstimated`: `boolean` ; `size`: `number`  }\>
+▸ **getSize**(): `Promise`<`undefined` \| { `isEstimated`: `boolean` ; `size`: `number`  }\>
 
 #### Returns
 
@@ -836,13 +894,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/xz.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/xz.ts#L34)
+[lib/source-destination/xz.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/xz.ts#L34)
 
 ___
 
 ### getSizeFromPartitionTable
 
-▸ `Protected` **getSizeFromPartitionTable**(): `Promise`<`undefined` \| `number`\>
+▸ **getSizeFromPartitionTable**(): `Promise`<`undefined` \| `number`\>
 
 #### Returns
 
@@ -854,7 +912,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L87)
+[lib/source-destination/compressed-source.ts:87](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L87)
 
 ___
 
@@ -862,10 +920,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -888,7 +945,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -926,7 +983,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -957,7 +1014,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -982,6 +1039,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1012,7 +1070,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1035,6 +1093,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1065,7 +1124,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1083,7 +1142,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1125,7 +1184,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1165,7 +1224,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1177,6 +1236,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1220,7 +1280,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1247,7 +1307,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L358)
+[lib/source-destination/source-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L356)
 
 ___
 
@@ -1283,7 +1343,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1312,6 +1372,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1352,6 +1414,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1389,7 +1452,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1424,7 +1487,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1451,13 +1514,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1504,7 +1567,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1512,13 +1575,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1529,19 +1592,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1566,13 +1629,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1612,7 +1675,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1620,18 +1683,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1664,34 +1728,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1702,7 +1765,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1750,13 +1815,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1767,31 +1832,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1799,13 +1861,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1815,7 +1877,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1860,9 +1922,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1882,13 +1944,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -1906,19 +1968,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1947,4 +2006,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sourceDestination.ZipSource.md
+++ b/doc/classes/sourceDestination.ZipSource.md
@@ -86,7 +86,7 @@
 
 ### constructor
 
-• **new ZipSource**(`source`, `preferStreamSource?`, `match?`)
+• **new ZipSource**(`source`, `preferStreamSource?`, `match?`): [`ZipSource`](sourceDestination.ZipSource.md)
 
 #### Parameters
 
@@ -96,13 +96,17 @@
 | `preferStreamSource` | `boolean` | `false` |
 | `match` | (`filename`: `string`) => `boolean` | `matchSupportedExtensions` |
 
+#### Returns
+
+[`ZipSource`](sourceDestination.ZipSource.md)
+
 #### Overrides
 
 [SourceSource](sourceDestination.SourceSource.md).[constructor](sourceDestination.SourceSource.md#constructor)
 
 #### Defined in
 
-[lib/source-destination/zip.ts:362](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L362)
+[lib/source-destination/zip.ts:362](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L362)
 
 ## Properties
 
@@ -112,7 +116,7 @@
 
 #### Defined in
 
-[lib/source-destination/zip.ts:360](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L360)
+[lib/source-destination/zip.ts:360](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L360)
 
 ___
 
@@ -136,7 +140,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L365)
+[lib/source-destination/zip.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L365)
 
 ___
 
@@ -146,7 +150,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:364](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L364)
+[lib/source-destination/zip.ts:364](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L364)
 
 ___
 
@@ -156,7 +160,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:359](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L359)
+[lib/source-destination/zip.ts:359](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L359)
 
 ___
 
@@ -170,7 +174,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L22)
+[lib/source-destination/source-source.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L22)
 
 ___
 
@@ -178,13 +182,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 [SourceSource](sourceDestination.SourceSource.md).[captureRejectionSymbol](sourceDestination.SourceSource.md#capturerejectionsymbol)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -192,7 +204,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -200,7 +218,7 @@ Sets or gets the default captureRejection value for all emitters.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -208,13 +226,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 [SourceSource](sourceDestination.SourceSource.md).[defaultMaxListeners](sourceDestination.SourceSource.md#defaultmaxlisteners)
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -222,13 +278,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -236,7 +293,7 @@ regular `'error'` listener is installed.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ___
 
@@ -250,7 +307,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:295](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L295)
+[lib/source-destination/source-destination.ts:293](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L293)
 
 ___
 
@@ -264,7 +321,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L358)
+[lib/source-destination/zip.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L358)
 
 ___
 
@@ -278,13 +335,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L20)
+[lib/source-destination/source-source.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L20)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -304,13 +361,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -322,13 +379,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L30)
+[lib/source-destination/source-source.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L30)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](../interfaces/sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -340,13 +397,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:423](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L423)
+[lib/source-destination/zip.ts:423](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L423)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -358,7 +415,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-source.ts#L26)
+[lib/source-destination/source-source.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-source.ts#L26)
 
 ___
 
@@ -389,7 +446,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -407,7 +464,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:379](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L379)
+[lib/source-destination/zip.ts:379](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L379)
 
 ___
 
@@ -425,7 +482,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:389](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L389)
+[lib/source-destination/zip.ts:389](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L389)
 
 ___
 
@@ -443,7 +500,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -461,7 +518,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -479,7 +536,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L323)
+[lib/source-destination/source-destination.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L321)
 
 ___
 
@@ -497,7 +554,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -515,7 +572,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -539,7 +596,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:394](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L394)
+[lib/source-destination/zip.ts:394](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L394)
 
 ___
 
@@ -563,7 +620,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:410](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L410)
+[lib/source-destination/zip.ts:410](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L410)
 
 ___
 
@@ -588,7 +645,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
@@ -613,7 +670,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -638,7 +695,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
@@ -652,7 +709,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -705,7 +762,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -717,7 +774,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -743,7 +801,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -761,7 +819,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -779,7 +837,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
@@ -797,7 +855,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -822,7 +880,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -840,7 +898,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -858,7 +916,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
@@ -866,10 +924,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -892,7 +949,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -930,7 +987,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -961,7 +1018,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -986,6 +1043,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1016,7 +1074,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -1039,6 +1097,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1069,7 +1128,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -1087,13 +1146,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:384](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L384)
+[lib/source-destination/zip.ts:384](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L384)
 
 ___
 
 ### prepare
 
-▸ `Private` **prepare**(): `Promise`<`void`\>
+▸ **prepare**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -1101,7 +1160,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L371)
+[lib/source-destination/zip.ts:371](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L371)
 
 ___
 
@@ -1143,7 +1202,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1183,7 +1242,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1195,6 +1254,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1238,7 +1298,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1265,7 +1325,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L358)
+[lib/source-destination/source-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L356)
 
 ___
 
@@ -1301,7 +1361,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1330,6 +1390,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1370,6 +1432,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1407,7 +1470,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1442,7 +1505,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1469,13 +1532,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -1522,7 +1585,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -1530,13 +1593,13 @@ v18.18.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -1547,19 +1610,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -1584,13 +1647,13 @@ v15.2.0, v14.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -1630,7 +1693,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -1638,18 +1701,19 @@ v18.17.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -1682,34 +1746,33 @@ Since v3.2.0 - Use `listenerCount` instead.
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -1720,7 +1783,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -1768,13 +1833,13 @@ v13.6.0, v12.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -1785,31 +1850,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -1817,13 +1879,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -1833,7 +1895,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -1878,9 +1940,9 @@ v11.13.0, v10.16.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -1900,13 +1962,13 @@ node_modules/@types/node/events.d.ts:199
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### register
 
-▸ `Static` **register**(`Cls`): `void`
+▸ **register**(`Cls`): `void`
 
 #### Parameters
 
@@ -1924,19 +1986,16 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:313](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L313)
+[lib/source-destination/source-destination.ts:311](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L311)
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -1965,4 +2024,4 @@ v15.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352

--- a/doc/classes/sparseStream.SparseFilterStream.md
+++ b/doc/classes/sparseStream.SparseFilterStream.md
@@ -128,7 +128,7 @@
 
 ### constructor
 
-• **new SparseFilterStream**(`«destructured»`)
+• **new SparseFilterStream**(`«destructured»`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
 #### Parameters
 
@@ -139,13 +139,17 @@
 | › `generateChecksums` | `boolean` |
 | › `verify` | `boolean` |
 
+#### Returns
+
+[`SparseFilterStream`](sparseStream.SparseFilterStream.md)
+
 #### Overrides
 
 Transform.constructor
 
 #### Defined in
 
-[lib/sparse-stream/sparse-filter-stream.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-filter-stream.ts#L32)
+[lib/sparse-stream/sparse-filter-stream.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-filter-stream.ts#L32)
 
 ## Properties
 
@@ -155,7 +159,7 @@ Transform.constructor
 
 If `false` then the stream will automatically end the writable side when the
 readable side ends. Set initially by the `allowHalfOpen` constructor option,
-which defaults to `false`.
+which defaults to `true`.
 
 This can be changed manually to change the half-open behavior of an existing`Duplex` stream instance, but must be changed before the `'end'` event is
 emitted.
@@ -170,7 +174,7 @@ Transform.allowHalfOpen
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1060
+node_modules/@types/node/stream.d.ts:1068
 
 ___
 
@@ -184,7 +188,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-filter-stream.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-filter-stream.ts#L27)
+[lib/sparse-stream/sparse-filter-stream.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-filter-stream.ts#L27)
 
 ___
 
@@ -198,7 +202,7 @@ Transform.closed
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1049
+node_modules/@types/node/stream.d.ts:1057
 
 ___
 
@@ -218,7 +222,7 @@ Transform.destroyed
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:145
+node_modules/@types/node/stream.d.ts:114
 
 ___
 
@@ -232,7 +236,7 @@ Transform.errored
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1050
+node_modules/@types/node/stream.d.ts:1058
 
 ___
 
@@ -242,7 +246,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-filter-stream.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-filter-stream.ts#L30)
+[lib/sparse-stream/sparse-filter-stream.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-filter-stream.ts#L30)
 
 ___
 
@@ -267,7 +271,7 @@ Transform.readable
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:101
+node_modules/@types/node/stream.d.ts:70
 
 ___
 
@@ -287,7 +291,7 @@ Transform.readableAborted
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:95
+node_modules/@types/node/stream.d.ts:64
 
 ___
 
@@ -307,7 +311,7 @@ Transform.readableDidRead
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:107
+node_modules/@types/node/stream.d.ts:76
 
 ___
 
@@ -327,7 +331,7 @@ Transform.readableEncoding
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:112
+node_modules/@types/node/stream.d.ts:81
 
 ___
 
@@ -347,7 +351,7 @@ Transform.readableEnded
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:117
+node_modules/@types/node/stream.d.ts:86
 
 ___
 
@@ -368,7 +372,7 @@ Transform.readableFlowing
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:123
+node_modules/@types/node/stream.d.ts:92
 
 ___
 
@@ -388,7 +392,7 @@ Transform.readableHighWaterMark
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:128
+node_modules/@types/node/stream.d.ts:97
 
 ___
 
@@ -410,7 +414,7 @@ Transform.readableLength
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:135
+node_modules/@types/node/stream.d.ts:104
 
 ___
 
@@ -430,7 +434,7 @@ Transform.readableObjectMode
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:140
+node_modules/@types/node/stream.d.ts:109
 
 ___
 
@@ -440,7 +444,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-filter-stream.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-filter-stream.ts#L29)
+[lib/sparse-stream/sparse-filter-stream.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-filter-stream.ts#L29)
 
 ___
 
@@ -450,7 +454,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-filter-stream.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-filter-stream.ts#L28)
+[lib/sparse-stream/sparse-filter-stream.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-filter-stream.ts#L28)
 
 ___
 
@@ -464,7 +468,7 @@ Transform.writable
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1041
+node_modules/@types/node/stream.d.ts:1049
 
 ___
 
@@ -478,7 +482,7 @@ Transform.writableCorked
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1047
+node_modules/@types/node/stream.d.ts:1055
 
 ___
 
@@ -492,7 +496,7 @@ Transform.writableEnded
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1042
+node_modules/@types/node/stream.d.ts:1050
 
 ___
 
@@ -506,7 +510,7 @@ Transform.writableFinished
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1043
+node_modules/@types/node/stream.d.ts:1051
 
 ___
 
@@ -520,7 +524,7 @@ Transform.writableHighWaterMark
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1044
+node_modules/@types/node/stream.d.ts:1052
 
 ___
 
@@ -534,7 +538,7 @@ Transform.writableLength
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1045
+node_modules/@types/node/stream.d.ts:1053
 
 ___
 
@@ -548,7 +552,7 @@ Transform.writableNeedDrain
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1048
+node_modules/@types/node/stream.d.ts:1056
 
 ___
 
@@ -562,7 +566,7 @@ Transform.writableObjectMode
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1046
+node_modules/@types/node/stream.d.ts:1054
 
 ___
 
@@ -570,13 +574,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 Transform.captureRejectionSymbol
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -584,7 +596,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -592,7 +610,7 @@ Transform.captureRejections
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -600,13 +618,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 Transform.defaultMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -614,13 +670,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -628,7 +685,7 @@ Transform.errorMonitor
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ## Methods
 
@@ -644,7 +701,7 @@ Calls `readable.destroy()` with an `AbortError` and returns a promise that fulfi
 
 **`Since`**
 
-v18.18.0
+v20.4.0
 
 #### Inherited from
 
@@ -652,7 +709,7 @@ Transform.[asyncDispose]
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:682
+node_modules/@types/node/stream.d.ts:651
 
 ___
 
@@ -674,13 +731,13 @@ Transform.[asyncIterator]
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:677
+node_modules/@types/node/stream.d.ts:646
 
 ___
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -704,13 +761,13 @@ Transform.[captureRejectionSymbol]
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_\_transform
 
-▸ `Private` **__transform**(`buffer`): `void`
+▸ **__transform**(`buffer`): `void`
 
 #### Parameters
 
@@ -724,13 +781,13 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-filter-stream.ts:69](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-filter-stream.ts#L69)
+[lib/sparse-stream/sparse-filter-stream.ts:69](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-filter-stream.ts#L69)
 
 ___
 
 ### \_construct
 
-▸ `Optional` **_construct**(`callback`): `void`
+▸ **_construct**(`callback`): `void`
 
 #### Parameters
 
@@ -748,7 +805,7 @@ Transform.\_construct
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:157
+node_modules/@types/node/stream.d.ts:126
 
 ___
 
@@ -761,7 +818,7 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `error` | ``null`` \| `Error` |
-| `callback` | (`error`: ``null`` \| `Error`) => `void` |
+| `callback` | (`error?`: ``null`` \| `Error`) => `void` |
 
 #### Returns
 
@@ -773,7 +830,7 @@ Transform.\_destroy
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1103
+node_modules/@types/node/stream.d.ts:1111
 
 ___
 
@@ -797,7 +854,7 @@ Transform.\_final
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1104
+node_modules/@types/node/stream.d.ts:1112
 
 ___
 
@@ -821,7 +878,7 @@ Transform.\_flush
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1250
+node_modules/@types/node/stream.d.ts:1282
 
 ___
 
@@ -845,7 +902,7 @@ Transform.\_read
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:158
+node_modules/@types/node/stream.d.ts:127
 
 ___
 
@@ -871,7 +928,7 @@ Transform.\_transform
 
 #### Defined in
 
-[lib/sparse-stream/sparse-filter-stream.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-filter-stream.ts#L55)
+[lib/sparse-stream/sparse-filter-stream.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-filter-stream.ts#L55)
 
 ___
 
@@ -897,13 +954,13 @@ Transform.\_write
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1095
+node_modules/@types/node/stream.d.ts:1103
 
 ___
 
 ### \_writev
 
-▸ `Optional` **_writev**(`chunks`, `callback`): `void`
+▸ **_writev**(`chunks`, `callback`): `void`
 
 #### Parameters
 
@@ -922,7 +979,7 @@ Transform.\_writev
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1096
+node_modules/@types/node/stream.d.ts:1104
 
 ___
 
@@ -965,7 +1022,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1128
+node_modules/@types/node/stream.d.ts:1160
 
 ▸ **addListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -990,7 +1047,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1129
+node_modules/@types/node/stream.d.ts:1161
 
 ▸ **addListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -1015,7 +1072,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1130
+node_modules/@types/node/stream.d.ts:1162
 
 ▸ **addListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -1040,7 +1097,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1131
+node_modules/@types/node/stream.d.ts:1163
 
 ▸ **addListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -1065,7 +1122,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1132
+node_modules/@types/node/stream.d.ts:1164
 
 ▸ **addListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -1090,7 +1147,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1133
+node_modules/@types/node/stream.d.ts:1165
 
 ▸ **addListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -1115,7 +1172,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1134
+node_modules/@types/node/stream.d.ts:1166
 
 ▸ **addListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -1140,7 +1197,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1135
+node_modules/@types/node/stream.d.ts:1167
 
 ▸ **addListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -1165,7 +1222,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1136
+node_modules/@types/node/stream.d.ts:1168
 
 ▸ **addListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -1190,7 +1247,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1137
+node_modules/@types/node/stream.d.ts:1169
 
 ▸ **addListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -1215,7 +1272,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1138
+node_modules/@types/node/stream.d.ts:1170
 
 ▸ **addListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -1240,7 +1297,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1139
+node_modules/@types/node/stream.d.ts:1171
 
 ___
 
@@ -1273,7 +1330,7 @@ Transform.asIndexedPairs
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:572
+node_modules/@types/node/stream.d.ts:541
 
 ___
 
@@ -1323,7 +1380,7 @@ Transform.cork
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1111
+node_modules/@types/node/stream.d.ts:1119
 
 ___
 
@@ -1359,7 +1416,7 @@ Transform.destroy
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:609
+node_modules/@types/node/stream.d.ts:578
 
 ___
 
@@ -1392,7 +1449,7 @@ Transform.drop
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:558
+node_modules/@types/node/stream.d.ts:527
 
 ___
 
@@ -1406,7 +1463,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -1462,7 +1519,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1140
+node_modules/@types/node/stream.d.ts:1172
 
 ▸ **emit**(`event`, `chunk`): `boolean`
 
@@ -1487,7 +1544,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1141
+node_modules/@types/node/stream.d.ts:1173
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1511,7 +1568,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1142
+node_modules/@types/node/stream.d.ts:1174
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1535,7 +1592,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1143
+node_modules/@types/node/stream.d.ts:1175
 
 ▸ **emit**(`event`, `err`): `boolean`
 
@@ -1560,7 +1617,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1144
+node_modules/@types/node/stream.d.ts:1176
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1584,7 +1641,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1145
+node_modules/@types/node/stream.d.ts:1177
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1608,7 +1665,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1146
+node_modules/@types/node/stream.d.ts:1178
 
 ▸ **emit**(`event`, `src`): `boolean`
 
@@ -1633,7 +1690,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1147
+node_modules/@types/node/stream.d.ts:1179
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1657,7 +1714,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1148
+node_modules/@types/node/stream.d.ts:1180
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1681,7 +1738,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1149
+node_modules/@types/node/stream.d.ts:1181
 
 ▸ **emit**(`event`, `src`): `boolean`
 
@@ -1706,7 +1763,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1150
+node_modules/@types/node/stream.d.ts:1182
 
 ▸ **emit**(`event`, `...args`): `boolean`
 
@@ -1731,7 +1788,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1151
+node_modules/@types/node/stream.d.ts:1183
 
 ___
 
@@ -1755,7 +1812,7 @@ Transform.end
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1108
+node_modules/@types/node/stream.d.ts:1116
 
 ▸ **end**(`chunk`, `cb?`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -1776,7 +1833,7 @@ Transform.end
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1109
+node_modules/@types/node/stream.d.ts:1117
 
 ▸ **end**(`chunk`, `encoding?`, `cb?`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -1798,7 +1855,7 @@ Transform.end
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1110
+node_modules/@types/node/stream.d.ts:1118
 
 ___
 
@@ -1810,7 +1867,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -1840,7 +1898,7 @@ Transform.eventNames
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -1876,7 +1934,7 @@ Transform.every
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:537
+node_modules/@types/node/stream.d.ts:506
 
 ___
 
@@ -1911,7 +1969,7 @@ Transform.filter
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:465
+node_modules/@types/node/stream.d.ts:434
 
 ___
 
@@ -1954,7 +2012,7 @@ Transform.find
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:520
+node_modules/@types/node/stream.d.ts:489
 
 ▸ **find**(`fn`, `options?`): `Promise`<`any`\>
 
@@ -1975,7 +2033,7 @@ Transform.find
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:524
+node_modules/@types/node/stream.d.ts:493
 
 ___
 
@@ -2012,7 +2070,7 @@ Transform.flatMap
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:551
+node_modules/@types/node/stream.d.ts:520
 
 ___
 
@@ -2054,7 +2112,7 @@ Transform.forEach
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:484
+node_modules/@types/node/stream.d.ts:453
 
 ___
 
@@ -2083,7 +2141,7 @@ Transform.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -2123,7 +2181,7 @@ Transform.isPaused
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:318
+node_modules/@types/node/stream.d.ts:287
 
 ___
 
@@ -2156,7 +2214,7 @@ Transform.iterator
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:448
+node_modules/@types/node/stream.d.ts:417
 
 ___
 
@@ -2164,10 +2222,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -2194,7 +2251,7 @@ Transform.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -2236,7 +2293,7 @@ Transform.listeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -2270,13 +2327,13 @@ Transform.map
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:456
+node_modules/@types/node/stream.d.ts:425
 
 ___
 
 ### nextBlock
 
-▸ `Private` **nextBlock**(): `void`
+▸ **nextBlock**(): `void`
 
 #### Returns
 
@@ -2284,7 +2341,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-filter-stream.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-filter-stream.ts#L51)
+[lib/sparse-stream/sparse-filter-stream.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-filter-stream.ts#L51)
 
 ___
 
@@ -2319,7 +2376,7 @@ Transform.off
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -2344,6 +2401,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -2378,7 +2436,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1152
+node_modules/@types/node/stream.d.ts:1184
 
 ▸ **on**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2403,7 +2461,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1153
+node_modules/@types/node/stream.d.ts:1185
 
 ▸ **on**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2428,7 +2486,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1154
+node_modules/@types/node/stream.d.ts:1186
 
 ▸ **on**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2453,7 +2511,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1155
+node_modules/@types/node/stream.d.ts:1187
 
 ▸ **on**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2478,7 +2536,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1156
+node_modules/@types/node/stream.d.ts:1188
 
 ▸ **on**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2503,7 +2561,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1157
+node_modules/@types/node/stream.d.ts:1189
 
 ▸ **on**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2528,7 +2586,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1158
+node_modules/@types/node/stream.d.ts:1190
 
 ▸ **on**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2553,7 +2611,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1159
+node_modules/@types/node/stream.d.ts:1191
 
 ▸ **on**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2578,7 +2636,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1160
+node_modules/@types/node/stream.d.ts:1192
 
 ▸ **on**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2603,7 +2661,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1161
+node_modules/@types/node/stream.d.ts:1193
 
 ▸ **on**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2628,7 +2686,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1162
+node_modules/@types/node/stream.d.ts:1194
 
 ▸ **on**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2653,7 +2711,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1163
+node_modules/@types/node/stream.d.ts:1195
 
 ___
 
@@ -2676,6 +2734,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -2710,7 +2769,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1164
+node_modules/@types/node/stream.d.ts:1196
 
 ▸ **once**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2735,7 +2794,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1165
+node_modules/@types/node/stream.d.ts:1197
 
 ▸ **once**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2760,7 +2819,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1166
+node_modules/@types/node/stream.d.ts:1198
 
 ▸ **once**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2785,7 +2844,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1167
+node_modules/@types/node/stream.d.ts:1199
 
 ▸ **once**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2810,7 +2869,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1168
+node_modules/@types/node/stream.d.ts:1200
 
 ▸ **once**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2835,7 +2894,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1169
+node_modules/@types/node/stream.d.ts:1201
 
 ▸ **once**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2860,7 +2919,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1170
+node_modules/@types/node/stream.d.ts:1202
 
 ▸ **once**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2885,7 +2944,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1171
+node_modules/@types/node/stream.d.ts:1203
 
 ▸ **once**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2910,7 +2969,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1172
+node_modules/@types/node/stream.d.ts:1204
 
 ▸ **once**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2935,7 +2994,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1173
+node_modules/@types/node/stream.d.ts:1205
 
 ▸ **once**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2960,7 +3019,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1174
+node_modules/@types/node/stream.d.ts:1206
 
 ▸ **once**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -2985,7 +3044,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1175
+node_modules/@types/node/stream.d.ts:1207
 
 ___
 
@@ -3030,7 +3089,7 @@ Transform.pause
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:282
+node_modules/@types/node/stream.d.ts:251
 
 ___
 
@@ -3112,7 +3171,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1176
+node_modules/@types/node/stream.d.ts:1208
 
 ▸ **prependListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3137,7 +3196,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1177
+node_modules/@types/node/stream.d.ts:1209
 
 ▸ **prependListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3162,7 +3221,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1178
+node_modules/@types/node/stream.d.ts:1210
 
 ▸ **prependListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3187,7 +3246,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1179
+node_modules/@types/node/stream.d.ts:1211
 
 ▸ **prependListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3212,7 +3271,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1180
+node_modules/@types/node/stream.d.ts:1212
 
 ▸ **prependListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3237,7 +3296,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1181
+node_modules/@types/node/stream.d.ts:1213
 
 ▸ **prependListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3262,7 +3321,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1182
+node_modules/@types/node/stream.d.ts:1214
 
 ▸ **prependListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3287,7 +3346,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1183
+node_modules/@types/node/stream.d.ts:1215
 
 ▸ **prependListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3312,7 +3371,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1184
+node_modules/@types/node/stream.d.ts:1216
 
 ▸ **prependListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3337,7 +3396,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1185
+node_modules/@types/node/stream.d.ts:1217
 
 ▸ **prependListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3362,7 +3421,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1186
+node_modules/@types/node/stream.d.ts:1218
 
 ▸ **prependListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3387,7 +3446,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1187
+node_modules/@types/node/stream.d.ts:1219
 
 ___
 
@@ -3431,7 +3490,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1188
+node_modules/@types/node/stream.d.ts:1220
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3456,7 +3515,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1189
+node_modules/@types/node/stream.d.ts:1221
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3481,7 +3540,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1190
+node_modules/@types/node/stream.d.ts:1222
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3506,7 +3565,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1191
+node_modules/@types/node/stream.d.ts:1223
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3531,7 +3590,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1192
+node_modules/@types/node/stream.d.ts:1224
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3556,7 +3615,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1193
+node_modules/@types/node/stream.d.ts:1225
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3581,7 +3640,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1194
+node_modules/@types/node/stream.d.ts:1226
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3606,7 +3665,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1195
+node_modules/@types/node/stream.d.ts:1227
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3631,7 +3690,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1196
+node_modules/@types/node/stream.d.ts:1228
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3656,7 +3715,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1197
+node_modules/@types/node/stream.d.ts:1229
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3681,7 +3740,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1198
+node_modules/@types/node/stream.d.ts:1230
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -3706,7 +3765,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1199
+node_modules/@types/node/stream.d.ts:1231
 
 ___
 
@@ -3735,7 +3794,7 @@ Transform.push
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:438
+node_modules/@types/node/stream.d.ts:407
 
 ___
 
@@ -3747,6 +3806,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -3794,7 +3854,7 @@ Transform.rawListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -3899,7 +3959,7 @@ Transform.read
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:235
+node_modules/@types/node/stream.d.ts:204
 
 ___
 
@@ -3946,7 +4006,7 @@ Transform.reduce
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:587
+node_modules/@types/node/stream.d.ts:556
 
 ▸ **reduce**<`T`\>(`fn`, `initial`, `options?`): `Promise`<`T`\>
 
@@ -3974,7 +4034,7 @@ Transform.reduce
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:592
+node_modules/@types/node/stream.d.ts:561
 
 ___
 
@@ -4014,7 +4074,7 @@ Transform.removeAllListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -4043,6 +4103,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -4083,6 +4145,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -4124,7 +4187,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1200
+node_modules/@types/node/stream.d.ts:1232
 
 ▸ **removeListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -4149,7 +4212,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1201
+node_modules/@types/node/stream.d.ts:1233
 
 ▸ **removeListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -4174,7 +4237,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1202
+node_modules/@types/node/stream.d.ts:1234
 
 ▸ **removeListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -4199,7 +4262,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1203
+node_modules/@types/node/stream.d.ts:1235
 
 ▸ **removeListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -4224,7 +4287,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1204
+node_modules/@types/node/stream.d.ts:1236
 
 ▸ **removeListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -4249,7 +4312,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1205
+node_modules/@types/node/stream.d.ts:1237
 
 ▸ **removeListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -4274,7 +4337,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1206
+node_modules/@types/node/stream.d.ts:1238
 
 ▸ **removeListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -4299,7 +4362,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1207
+node_modules/@types/node/stream.d.ts:1239
 
 ▸ **removeListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -4324,7 +4387,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1208
+node_modules/@types/node/stream.d.ts:1240
 
 ▸ **removeListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -4349,7 +4412,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1209
+node_modules/@types/node/stream.d.ts:1241
 
 ▸ **removeListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -4374,7 +4437,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1210
+node_modules/@types/node/stream.d.ts:1242
 
 ▸ **removeListener**(`event`, `listener`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
@@ -4399,7 +4462,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1211
+node_modules/@types/node/stream.d.ts:1243
 
 ___
 
@@ -4441,7 +4504,7 @@ Transform.resume
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:301
+node_modules/@types/node/stream.d.ts:270
 
 ___
 
@@ -4465,7 +4528,7 @@ Transform.setDefaultEncoding
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1107
+node_modules/@types/node/stream.d.ts:1115
 
 ___
 
@@ -4518,7 +4581,7 @@ Transform.setEncoding
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:260
+node_modules/@types/node/stream.d.ts:229
 
 ___
 
@@ -4557,7 +4620,7 @@ Transform.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -4593,7 +4656,7 @@ Transform.some
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:506
+node_modules/@types/node/stream.d.ts:475
 
 ___
 
@@ -4626,7 +4689,7 @@ Transform.take
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:565
+node_modules/@types/node/stream.d.ts:534
 
 ___
 
@@ -4661,7 +4724,7 @@ Transform.toArray
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:496
+node_modules/@types/node/stream.d.ts:465
 
 ___
 
@@ -4679,7 +4742,7 @@ Transform.uncork
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1112
+node_modules/@types/node/stream.d.ts:1120
 
 ___
 
@@ -4696,7 +4759,7 @@ If the `destination` is specified, but no pipe is set up for it, then
 the method does nothing.
 
 ```js
-const fs = require('fs');
+const fs = require('node:fs');
 const readable = getReadableStreamSomehow();
 const writable = fs.createWriteStream('file.txt');
 // All the data from readable goes into 'file.txt',
@@ -4734,7 +4797,7 @@ Transform.unpipe
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:345
+node_modules/@types/node/stream.d.ts:314
 
 ___
 
@@ -4762,7 +4825,7 @@ use of a `Transform` stream instead. See the `API for stream implementers` secti
 // Pull off a header delimited by \n\n.
 // Use unshift() if we get too much.
 // Call the callback with (error, header, stream).
-const { StringDecoder } = require('string_decoder');
+const { StringDecoder } = require('node:string_decoder');
 function parseHeader(stream, callback) {
   stream.on('error', callback);
   stream.on('readable', onReadable);
@@ -4806,7 +4869,7 @@ process of performing a read.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `chunk` | `any` | Chunk of data to unshift onto the read queue. For streams not operating in object mode, `chunk` must be a string, `Buffer`, `Uint8Array` or `null`. For object mode streams, `chunk` may be any JavaScript value. |
+| `chunk` | `any` | Chunk of data to unshift onto the read queue. For streams not operating in object mode, `chunk` must be a string, `Buffer`, `Uint8Array`, or `null`. For object mode streams, `chunk` may be any JavaScript value. |
 | `encoding?` | `BufferEncoding` | Encoding of string chunks. Must be a valid `Buffer` encoding, such as `'utf8'` or `'ascii'`. |
 
 #### Returns
@@ -4827,7 +4890,7 @@ Transform.unshift
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:411
+node_modules/@types/node/stream.d.ts:380
 
 ___
 
@@ -4835,8 +4898,8 @@ ___
 
 ▸ **wrap**(`stream`): [`SparseFilterStream`](sparseStream.SparseFilterStream.md)
 
-Prior to Node.js 0.10, streams did not implement the entire `stream` module API
-as it is currently defined. (See `Compatibility` for more information.)
+Prior to Node.js 0.10, streams did not implement the entire `node:stream`module API as it is currently defined. (See `Compatibility` for more
+information.)
 
 When using an older Node.js library that emits `'data'` events and has a [pause](../interfaces/sourceDestination.SourceTransform.md#pause) method that is advisory only, the`readable.wrap()` method can be used to create a `Readable`
 stream that uses
@@ -4848,7 +4911,7 @@ libraries.
 
 ```js
 const { OldReader } = require('./old-api-module.js');
-const { Readable } = require('stream');
+const { Readable } = require('node:stream');
 const oreader = new OldReader();
 const myReader = new Readable().wrap(oreader);
 
@@ -4881,7 +4944,7 @@ Transform.wrap
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:437
+node_modules/@types/node/stream.d.ts:406
 
 ___
 
@@ -4907,7 +4970,7 @@ Transform.write
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1105
+node_modules/@types/node/stream.d.ts:1113
 
 ▸ **write**(`chunk`, `cb?`): `boolean`
 
@@ -4928,13 +4991,13 @@ Transform.write
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1106
+node_modules/@types/node/stream.d.ts:1114
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -4981,7 +5044,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -4989,13 +5052,13 @@ Transform.addAbortListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### from
 
-▸ `Static` **from**(`src`): `Duplex`
+▸ **from**(`src`): `Duplex`
 
 A utility method for creating duplex streams.
 
@@ -5019,7 +5082,7 @@ A utility method for creating duplex streams.
 
 | Name | Type |
 | :------ | :------ |
-| `src` | `string` \| `Object` \| `ArrayBuffer` \| `Promise`<`any`\> \| `AsyncGeneratorFunction` \| `Blob` \| `Stream` \| `Iterable`<`any`\> \| `AsyncIterable`<`any`\> |
+| `src` | `string` \| `Object` \| `ArrayBuffer` \| `Promise`<`any`\> \| `AsyncGeneratorFunction` \| `Stream` \| `Blob` \| `Iterable`<`any`\> \| `AsyncIterable`<`any`\> |
 
 #### Returns
 
@@ -5035,26 +5098,28 @@ Transform.from
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1083
+node_modules/@types/node/stream.d.ts:1091
 
 ___
 
 ### fromWeb
 
-▸ `Static` **fromWeb**(`readableStream`, `options?`): `Readable`
+▸ **fromWeb**(`duplexStream`, `options?`): `Duplex`
 
-A utility method for creating a `Readable` from a web `ReadableStream`.
+A utility method for creating a `Duplex` from a web `ReadableStream` and `WritableStream`.
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `readableStream` | `ReadableStream`<`any`\> |
-| `options?` | `Pick`<`ReadableOptions`, ``"signal"`` \| ``"encoding"`` \| ``"highWaterMark"`` \| ``"objectMode"``\> |
+| `duplexStream` | `Object` |
+| `duplexStream.readable` | `ReadableStream`<`any`\> |
+| `duplexStream.writable` | `WritableStream`<`any`\> |
+| `options?` | `Pick`<`DuplexOptions`, ``"signal"`` \| ``"encoding"`` \| ``"highWaterMark"`` \| ``"objectMode"`` \| ``"decodeStrings"`` \| ``"allowHalfOpen"``\> |
 
 #### Returns
 
-`Readable`
+`Duplex`
 
 **`Since`**
 
@@ -5066,13 +5131,13 @@ Transform.fromWeb
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:75
+node_modules/@types/node/stream.d.ts:1135
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -5083,19 +5148,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -5120,13 +5185,13 @@ Transform.getEventListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -5166,7 +5231,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -5174,13 +5239,13 @@ Transform.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### isDisturbed
 
-▸ `Static` **isDisturbed**(`stream`): `boolean`
+▸ **isDisturbed**(`stream`): `boolean`
 
 Returns whether the stream has been read from or cancelled.
 
@@ -5188,7 +5253,7 @@ Returns whether the stream has been read from or cancelled.
 
 | Name | Type |
 | :------ | :------ |
-| `stream` | `ReadableStream` \| `Readable` |
+| `stream` | `Readable` \| `ReadableStream` |
 
 #### Returns
 
@@ -5204,18 +5269,19 @@ Transform.isDisturbed
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:83
+node_modules/@types/node/stream.d.ts:58
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -5248,34 +5314,33 @@ Transform.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -5286,7 +5351,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -5334,13 +5401,13 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -5351,31 +5418,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -5383,13 +5447,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -5399,7 +5463,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -5444,9 +5508,9 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -5466,19 +5530,16 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -5507,25 +5568,30 @@ Transform.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352
 
 ___
 
 ### toWeb
 
-▸ `Static` **toWeb**(`streamReadable`): `ReadableStream`<`any`\>
+▸ **toWeb**(`streamDuplex`): `Object`
 
-A utility method for creating a web `ReadableStream` from a `Readable`.
+A utility method for creating a web `ReadableStream` and `WritableStream` from a `Duplex`.
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `streamReadable` | `Readable` |
+| `streamDuplex` | `Duplex` |
 
 #### Returns
 
-`ReadableStream`<`any`\>
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `readable` | `ReadableStream`<`any`\> |
+| `writable` | `WritableStream`<`any`\> |
 
 **`Since`**
 
@@ -5537,4 +5603,4 @@ Transform.toWeb
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:89
+node_modules/@types/node/stream.d.ts:1126

--- a/doc/classes/sparseStream.SparseReadStream.md
+++ b/doc/classes/sparseStream.SparseReadStream.md
@@ -112,7 +112,7 @@
 
 ### constructor
 
-• **new SparseReadStream**(`«destructured»`)
+• **new SparseReadStream**(`«destructured»`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
 #### Parameters
 
@@ -127,13 +127,17 @@
 | › `source` | [`SourceDestination`](sourceDestination.SourceDestination.md) |
 | › `verify` | `boolean` |
 
+#### Returns
+
+[`SparseReadStream`](sparseStream.SparseReadStream.md)
+
 #### Overrides
 
 Readable.constructor
 
 #### Defined in
 
-[lib/sparse-stream/sparse-read-stream.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-read-stream.ts#L41)
+[lib/sparse-stream/sparse-read-stream.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-read-stream.ts#L41)
 
 ## Properties
 
@@ -143,7 +147,7 @@ Readable.constructor
 
 #### Defined in
 
-[lib/sparse-stream/sparse-read-stream.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-read-stream.ts#L39)
+[lib/sparse-stream/sparse-read-stream.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-read-stream.ts#L39)
 
 ___
 
@@ -157,7 +161,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-read-stream.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-read-stream.ts#L34)
+[lib/sparse-stream/sparse-read-stream.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-read-stream.ts#L34)
 
 ___
 
@@ -167,7 +171,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-read-stream.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-read-stream.ts#L35)
+[lib/sparse-stream/sparse-read-stream.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-read-stream.ts#L35)
 
 ___
 
@@ -175,7 +179,7 @@ ___
 
 • `Readonly` **closed**: `boolean`
 
-Is true after 'close' has been emitted.
+Is `true` after `'close'` has been emitted.
 
 **`Since`**
 
@@ -187,7 +191,7 @@ Readable.closed
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:150
+node_modules/@types/node/stream.d.ts:119
 
 ___
 
@@ -207,7 +211,7 @@ Readable.destroyed
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:145
+node_modules/@types/node/stream.d.ts:114
 
 ___
 
@@ -227,7 +231,7 @@ Readable.errored
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:155
+node_modules/@types/node/stream.d.ts:124
 
 ___
 
@@ -237,7 +241,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-read-stream.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-read-stream.ts#L38)
+[lib/sparse-stream/sparse-read-stream.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-read-stream.ts#L38)
 
 ___
 
@@ -262,7 +266,7 @@ Readable.readable
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:101
+node_modules/@types/node/stream.d.ts:70
 
 ___
 
@@ -282,7 +286,7 @@ Readable.readableAborted
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:95
+node_modules/@types/node/stream.d.ts:64
 
 ___
 
@@ -302,7 +306,7 @@ Readable.readableDidRead
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:107
+node_modules/@types/node/stream.d.ts:76
 
 ___
 
@@ -322,7 +326,7 @@ Readable.readableEncoding
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:112
+node_modules/@types/node/stream.d.ts:81
 
 ___
 
@@ -342,7 +346,7 @@ Readable.readableEnded
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:117
+node_modules/@types/node/stream.d.ts:86
 
 ___
 
@@ -363,7 +367,7 @@ Readable.readableFlowing
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:123
+node_modules/@types/node/stream.d.ts:92
 
 ___
 
@@ -383,7 +387,7 @@ Readable.readableHighWaterMark
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:128
+node_modules/@types/node/stream.d.ts:97
 
 ___
 
@@ -405,7 +409,7 @@ Readable.readableLength
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:135
+node_modules/@types/node/stream.d.ts:104
 
 ___
 
@@ -425,7 +429,7 @@ Readable.readableObjectMode
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:140
+node_modules/@types/node/stream.d.ts:109
 
 ___
 
@@ -435,7 +439,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-read-stream.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-read-stream.ts#L33)
+[lib/sparse-stream/sparse-read-stream.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-read-stream.ts#L33)
 
 ___
 
@@ -445,7 +449,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-read-stream.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-read-stream.ts#L37)
+[lib/sparse-stream/sparse-read-stream.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-read-stream.ts#L37)
 
 ___
 
@@ -455,7 +459,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-read-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-read-stream.ts#L36)
+[lib/sparse-stream/sparse-read-stream.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-read-stream.ts#L36)
 
 ___
 
@@ -463,13 +467,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 Readable.captureRejectionSymbol
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -477,7 +489,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -485,7 +503,7 @@ Readable.captureRejections
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -493,13 +511,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 Readable.defaultMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -507,13 +563,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -521,7 +578,7 @@ Readable.errorMonitor
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ## Methods
 
@@ -537,7 +594,7 @@ Calls `readable.destroy()` with an `AbortError` and returns a promise that fulfi
 
 **`Since`**
 
-v18.18.0
+v20.4.0
 
 #### Inherited from
 
@@ -545,7 +602,7 @@ Readable.[asyncDispose]
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:682
+node_modules/@types/node/stream.d.ts:651
 
 ___
 
@@ -567,13 +624,13 @@ Readable.[asyncIterator]
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:677
+node_modules/@types/node/stream.d.ts:646
 
 ___
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -597,13 +654,13 @@ Readable.[captureRejectionSymbol]
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_\_read
 
-▸ `Private` **__read**(): `Promise`<``null`` \| [`SparseStreamChunk`](../interfaces/sparseStream.SparseStreamChunk.md)\>
+▸ **__read**(): `Promise`<``null`` \| [`SparseStreamChunk`](../interfaces/sparseStream.SparseStreamChunk.md)\>
 
 #### Returns
 
@@ -611,13 +668,13 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-read-stream.ts:91](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-read-stream.ts#L91)
+[lib/sparse-stream/sparse-read-stream.ts:91](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-read-stream.ts#L91)
 
 ___
 
 ### \_construct
 
-▸ `Optional` **_construct**(`callback`): `void`
+▸ **_construct**(`callback`): `void`
 
 #### Parameters
 
@@ -635,7 +692,7 @@ Readable.\_construct
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:157
+node_modules/@types/node/stream.d.ts:126
 
 ___
 
@@ -660,7 +717,7 @@ Readable.\_destroy
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:597
+node_modules/@types/node/stream.d.ts:566
 
 ___
 
@@ -678,7 +735,7 @@ Readable.\_read
 
 #### Defined in
 
-[lib/sparse-stream/sparse-read-stream.ts:77](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-read-stream.ts#L77)
+[lib/sparse-stream/sparse-read-stream.ts:77](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-read-stream.ts#L77)
 
 ___
 
@@ -717,7 +774,7 @@ Readable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:621
+node_modules/@types/node/stream.d.ts:590
 
 ▸ **addListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -742,7 +799,7 @@ Readable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:622
+node_modules/@types/node/stream.d.ts:591
 
 ▸ **addListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -767,7 +824,7 @@ Readable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:623
+node_modules/@types/node/stream.d.ts:592
 
 ▸ **addListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -792,7 +849,7 @@ Readable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:624
+node_modules/@types/node/stream.d.ts:593
 
 ▸ **addListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -817,7 +874,7 @@ Readable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:625
+node_modules/@types/node/stream.d.ts:594
 
 ▸ **addListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -842,7 +899,7 @@ Readable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:626
+node_modules/@types/node/stream.d.ts:595
 
 ▸ **addListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -867,7 +924,7 @@ Readable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:627
+node_modules/@types/node/stream.d.ts:596
 
 ▸ **addListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -892,7 +949,7 @@ Readable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:628
+node_modules/@types/node/stream.d.ts:597
 
 ___
 
@@ -925,7 +982,7 @@ Readable.asIndexedPairs
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:572
+node_modules/@types/node/stream.d.ts:541
 
 ___
 
@@ -993,7 +1050,7 @@ Readable.destroy
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:609
+node_modules/@types/node/stream.d.ts:578
 
 ___
 
@@ -1026,7 +1083,7 @@ Readable.drop
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:558
+node_modules/@types/node/stream.d.ts:527
 
 ___
 
@@ -1040,7 +1097,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -1096,7 +1153,7 @@ Readable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:629
+node_modules/@types/node/stream.d.ts:598
 
 ▸ **emit**(`event`, `chunk`): `boolean`
 
@@ -1121,7 +1178,7 @@ Readable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:630
+node_modules/@types/node/stream.d.ts:599
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1145,7 +1202,7 @@ Readable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:631
+node_modules/@types/node/stream.d.ts:600
 
 ▸ **emit**(`event`, `err`): `boolean`
 
@@ -1170,7 +1227,7 @@ Readable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:632
+node_modules/@types/node/stream.d.ts:601
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1194,7 +1251,7 @@ Readable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:633
+node_modules/@types/node/stream.d.ts:602
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1218,7 +1275,7 @@ Readable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:634
+node_modules/@types/node/stream.d.ts:603
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1242,7 +1299,7 @@ Readable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:635
+node_modules/@types/node/stream.d.ts:604
 
 ▸ **emit**(`event`, `...args`): `boolean`
 
@@ -1267,7 +1324,7 @@ Readable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:636
+node_modules/@types/node/stream.d.ts:605
 
 ___
 
@@ -1279,7 +1336,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -1309,7 +1367,7 @@ Readable.eventNames
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -1345,7 +1403,7 @@ Readable.every
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:537
+node_modules/@types/node/stream.d.ts:506
 
 ___
 
@@ -1380,7 +1438,7 @@ Readable.filter
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:465
+node_modules/@types/node/stream.d.ts:434
 
 ___
 
@@ -1423,7 +1481,7 @@ Readable.find
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:520
+node_modules/@types/node/stream.d.ts:489
 
 ▸ **find**(`fn`, `options?`): `Promise`<`any`\>
 
@@ -1444,7 +1502,7 @@ Readable.find
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:524
+node_modules/@types/node/stream.d.ts:493
 
 ___
 
@@ -1481,7 +1539,7 @@ Readable.flatMap
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:551
+node_modules/@types/node/stream.d.ts:520
 
 ___
 
@@ -1523,7 +1581,7 @@ Readable.forEach
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:484
+node_modules/@types/node/stream.d.ts:453
 
 ___
 
@@ -1552,7 +1610,7 @@ Readable.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -1592,7 +1650,7 @@ Readable.isPaused
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:318
+node_modules/@types/node/stream.d.ts:287
 
 ___
 
@@ -1625,7 +1683,7 @@ Readable.iterator
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:448
+node_modules/@types/node/stream.d.ts:417
 
 ___
 
@@ -1633,10 +1691,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -1663,7 +1720,7 @@ Readable.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -1705,7 +1762,7 @@ Readable.listeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -1739,13 +1796,13 @@ Readable.map
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:456
+node_modules/@types/node/stream.d.ts:425
 
 ___
 
 ### nextBlock
 
-▸ `Private` **nextBlock**(): `void`
+▸ **nextBlock**(): `void`
 
 #### Returns
 
@@ -1753,7 +1810,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-read-stream.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-read-stream.ts#L86)
+[lib/sparse-stream/sparse-read-stream.ts:86](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-read-stream.ts#L86)
 
 ___
 
@@ -1788,7 +1845,7 @@ Readable.off
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -1813,6 +1870,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1847,7 +1905,7 @@ Readable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:637
+node_modules/@types/node/stream.d.ts:606
 
 ▸ **on**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -1872,7 +1930,7 @@ Readable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:638
+node_modules/@types/node/stream.d.ts:607
 
 ▸ **on**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -1897,7 +1955,7 @@ Readable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:639
+node_modules/@types/node/stream.d.ts:608
 
 ▸ **on**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -1922,7 +1980,7 @@ Readable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:640
+node_modules/@types/node/stream.d.ts:609
 
 ▸ **on**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -1947,7 +2005,7 @@ Readable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:641
+node_modules/@types/node/stream.d.ts:610
 
 ▸ **on**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -1972,7 +2030,7 @@ Readable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:642
+node_modules/@types/node/stream.d.ts:611
 
 ▸ **on**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -1997,7 +2055,7 @@ Readable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:643
+node_modules/@types/node/stream.d.ts:612
 
 ▸ **on**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2022,7 +2080,7 @@ Readable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:644
+node_modules/@types/node/stream.d.ts:613
 
 ___
 
@@ -2045,6 +2103,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -2079,7 +2138,7 @@ Readable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:645
+node_modules/@types/node/stream.d.ts:614
 
 ▸ **once**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2104,7 +2163,7 @@ Readable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:646
+node_modules/@types/node/stream.d.ts:615
 
 ▸ **once**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2129,7 +2188,7 @@ Readable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:647
+node_modules/@types/node/stream.d.ts:616
 
 ▸ **once**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2154,7 +2213,7 @@ Readable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:648
+node_modules/@types/node/stream.d.ts:617
 
 ▸ **once**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2179,7 +2238,7 @@ Readable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:649
+node_modules/@types/node/stream.d.ts:618
 
 ▸ **once**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2204,7 +2263,7 @@ Readable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:650
+node_modules/@types/node/stream.d.ts:619
 
 ▸ **once**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2229,7 +2288,7 @@ Readable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:651
+node_modules/@types/node/stream.d.ts:620
 
 ▸ **once**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2254,7 +2313,7 @@ Readable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:652
+node_modules/@types/node/stream.d.ts:621
 
 ___
 
@@ -2299,7 +2358,7 @@ Readable.pause
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:282
+node_modules/@types/node/stream.d.ts:251
 
 ___
 
@@ -2381,7 +2440,7 @@ Readable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:653
+node_modules/@types/node/stream.d.ts:622
 
 ▸ **prependListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2406,7 +2465,7 @@ Readable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:654
+node_modules/@types/node/stream.d.ts:623
 
 ▸ **prependListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2431,7 +2490,7 @@ Readable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:655
+node_modules/@types/node/stream.d.ts:624
 
 ▸ **prependListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2456,7 +2515,7 @@ Readable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:656
+node_modules/@types/node/stream.d.ts:625
 
 ▸ **prependListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2481,7 +2540,7 @@ Readable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:657
+node_modules/@types/node/stream.d.ts:626
 
 ▸ **prependListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2506,7 +2565,7 @@ Readable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:658
+node_modules/@types/node/stream.d.ts:627
 
 ▸ **prependListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2531,7 +2590,7 @@ Readable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:659
+node_modules/@types/node/stream.d.ts:628
 
 ▸ **prependListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2556,7 +2615,7 @@ Readable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:660
+node_modules/@types/node/stream.d.ts:629
 
 ___
 
@@ -2600,7 +2659,7 @@ Readable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:661
+node_modules/@types/node/stream.d.ts:630
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2625,7 +2684,7 @@ Readable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:662
+node_modules/@types/node/stream.d.ts:631
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2650,7 +2709,7 @@ Readable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:663
+node_modules/@types/node/stream.d.ts:632
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2675,7 +2734,7 @@ Readable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:664
+node_modules/@types/node/stream.d.ts:633
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2700,7 +2759,7 @@ Readable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:665
+node_modules/@types/node/stream.d.ts:634
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2725,7 +2784,7 @@ Readable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:666
+node_modules/@types/node/stream.d.ts:635
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2750,7 +2809,7 @@ Readable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:667
+node_modules/@types/node/stream.d.ts:636
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -2775,7 +2834,7 @@ Readable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:668
+node_modules/@types/node/stream.d.ts:637
 
 ___
 
@@ -2804,7 +2863,7 @@ Readable.push
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:438
+node_modules/@types/node/stream.d.ts:407
 
 ___
 
@@ -2816,6 +2875,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -2863,7 +2923,7 @@ Readable.rawListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -2968,7 +3028,7 @@ Readable.read
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:235
+node_modules/@types/node/stream.d.ts:204
 
 ___
 
@@ -3015,7 +3075,7 @@ Readable.reduce
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:587
+node_modules/@types/node/stream.d.ts:556
 
 ▸ **reduce**<`T`\>(`fn`, `initial`, `options?`): `Promise`<`T`\>
 
@@ -3043,7 +3103,7 @@ Readable.reduce
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:592
+node_modules/@types/node/stream.d.ts:561
 
 ___
 
@@ -3083,7 +3143,7 @@ Readable.removeAllListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -3112,6 +3172,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -3152,6 +3214,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -3193,7 +3256,7 @@ Readable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:669
+node_modules/@types/node/stream.d.ts:638
 
 ▸ **removeListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -3218,7 +3281,7 @@ Readable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:670
+node_modules/@types/node/stream.d.ts:639
 
 ▸ **removeListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -3243,7 +3306,7 @@ Readable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:671
+node_modules/@types/node/stream.d.ts:640
 
 ▸ **removeListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -3268,7 +3331,7 @@ Readable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:672
+node_modules/@types/node/stream.d.ts:641
 
 ▸ **removeListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -3293,7 +3356,7 @@ Readable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:673
+node_modules/@types/node/stream.d.ts:642
 
 ▸ **removeListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -3318,7 +3381,7 @@ Readable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:674
+node_modules/@types/node/stream.d.ts:643
 
 ▸ **removeListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -3343,7 +3406,7 @@ Readable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:675
+node_modules/@types/node/stream.d.ts:644
 
 ▸ **removeListener**(`event`, `listener`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
@@ -3368,7 +3431,7 @@ Readable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:676
+node_modules/@types/node/stream.d.ts:645
 
 ___
 
@@ -3410,7 +3473,7 @@ Readable.resume
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:301
+node_modules/@types/node/stream.d.ts:270
 
 ___
 
@@ -3463,7 +3526,7 @@ Readable.setEncoding
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:260
+node_modules/@types/node/stream.d.ts:229
 
 ___
 
@@ -3502,7 +3565,7 @@ Readable.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -3538,7 +3601,7 @@ Readable.some
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:506
+node_modules/@types/node/stream.d.ts:475
 
 ___
 
@@ -3571,7 +3634,7 @@ Readable.take
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:565
+node_modules/@types/node/stream.d.ts:534
 
 ___
 
@@ -3606,7 +3669,7 @@ Readable.toArray
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:496
+node_modules/@types/node/stream.d.ts:465
 
 ___
 
@@ -3623,7 +3686,7 @@ If the `destination` is specified, but no pipe is set up for it, then
 the method does nothing.
 
 ```js
-const fs = require('fs');
+const fs = require('node:fs');
 const readable = getReadableStreamSomehow();
 const writable = fs.createWriteStream('file.txt');
 // All the data from readable goes into 'file.txt',
@@ -3661,7 +3724,7 @@ Readable.unpipe
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:345
+node_modules/@types/node/stream.d.ts:314
 
 ___
 
@@ -3689,7 +3752,7 @@ use of a `Transform` stream instead. See the `API for stream implementers` secti
 // Pull off a header delimited by \n\n.
 // Use unshift() if we get too much.
 // Call the callback with (error, header, stream).
-const { StringDecoder } = require('string_decoder');
+const { StringDecoder } = require('node:string_decoder');
 function parseHeader(stream, callback) {
   stream.on('error', callback);
   stream.on('readable', onReadable);
@@ -3733,7 +3796,7 @@ process of performing a read.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `chunk` | `any` | Chunk of data to unshift onto the read queue. For streams not operating in object mode, `chunk` must be a string, `Buffer`, `Uint8Array` or `null`. For object mode streams, `chunk` may be any JavaScript value. |
+| `chunk` | `any` | Chunk of data to unshift onto the read queue. For streams not operating in object mode, `chunk` must be a string, `Buffer`, `Uint8Array`, or `null`. For object mode streams, `chunk` may be any JavaScript value. |
 | `encoding?` | `BufferEncoding` | Encoding of string chunks. Must be a valid `Buffer` encoding, such as `'utf8'` or `'ascii'`. |
 
 #### Returns
@@ -3754,7 +3817,7 @@ Readable.unshift
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:411
+node_modules/@types/node/stream.d.ts:380
 
 ___
 
@@ -3762,8 +3825,8 @@ ___
 
 ▸ **wrap**(`stream`): [`SparseReadStream`](sparseStream.SparseReadStream.md)
 
-Prior to Node.js 0.10, streams did not implement the entire `stream` module API
-as it is currently defined. (See `Compatibility` for more information.)
+Prior to Node.js 0.10, streams did not implement the entire `node:stream`module API as it is currently defined. (See `Compatibility` for more
+information.)
 
 When using an older Node.js library that emits `'data'` events and has a [pause](../interfaces/sourceDestination.SourceTransform.md#pause) method that is advisory only, the`readable.wrap()` method can be used to create a `Readable`
 stream that uses
@@ -3775,7 +3838,7 @@ libraries.
 
 ```js
 const { OldReader } = require('./old-api-module.js');
-const { Readable } = require('stream');
+const { Readable } = require('node:stream');
 const oreader = new OldReader();
 const myReader = new Readable().wrap(oreader);
 
@@ -3808,13 +3871,13 @@ Readable.wrap
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:437
+node_modules/@types/node/stream.d.ts:406
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -3861,7 +3924,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -3869,13 +3932,13 @@ Readable.addAbortListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### from
 
-▸ `Static` **from**(`iterable`, `options?`): `Readable`
+▸ **from**(`iterable`, `options?`): `Readable`
 
 A utility method for creating Readable Streams out of iterators.
 
@@ -3896,13 +3959,13 @@ Readable.from
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:69
+node_modules/@types/node/stream.d.ts:53
 
 ___
 
 ### fromWeb
 
-▸ `Static` **fromWeb**(`readableStream`, `options?`): `Readable`
+▸ **fromWeb**(`readableStream`, `options?`): `Readable`
 
 A utility method for creating a `Readable` from a web `ReadableStream`.
 
@@ -3927,13 +3990,13 @@ Readable.fromWeb
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:75
+node_modules/@types/node/stream.d.ts:967
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -3944,19 +4007,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -3981,13 +4044,13 @@ Readable.getEventListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -4027,7 +4090,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -4035,13 +4098,13 @@ Readable.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### isDisturbed
 
-▸ `Static` **isDisturbed**(`stream`): `boolean`
+▸ **isDisturbed**(`stream`): `boolean`
 
 Returns whether the stream has been read from or cancelled.
 
@@ -4049,7 +4112,7 @@ Returns whether the stream has been read from or cancelled.
 
 | Name | Type |
 | :------ | :------ |
-| `stream` | `ReadableStream` \| `Readable` |
+| `stream` | `Readable` \| `ReadableStream` |
 
 #### Returns
 
@@ -4065,18 +4128,19 @@ Readable.isDisturbed
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:83
+node_modules/@types/node/stream.d.ts:58
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -4109,34 +4173,33 @@ Readable.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -4147,7 +4210,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -4195,13 +4260,13 @@ Readable.on
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -4212,31 +4277,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -4244,13 +4306,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -4260,7 +4322,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -4305,9 +4367,9 @@ Readable.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -4327,19 +4389,16 @@ Readable.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -4368,13 +4427,13 @@ Readable.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352
 
 ___
 
 ### toWeb
 
-▸ `Static` **toWeb**(`streamReadable`): `ReadableStream`<`any`\>
+▸ **toWeb**(`streamReadable`): `ReadableStream`<`any`\>
 
 A utility method for creating a web `ReadableStream` from a `Readable`.
 
@@ -4398,4 +4457,4 @@ Readable.toWeb
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:89
+node_modules/@types/node/stream.d.ts:976

--- a/doc/classes/sparseStream.SparseWriteStream.md
+++ b/doc/classes/sparseStream.SparseWriteStream.md
@@ -93,7 +93,7 @@
 
 ### constructor
 
-• **new SparseWriteStream**(`«destructured»`)
+• **new SparseWriteStream**(`«destructured»`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
 #### Parameters
 
@@ -105,13 +105,17 @@
 | › `highWaterMark?` | `number` |
 | › `maxRetries?` | `number` |
 
+#### Returns
+
+[`SparseWriteStream`](sparseStream.SparseWriteStream.md)
+
 #### Overrides
 
 Writable.constructor
 
 #### Defined in
 
-[lib/sparse-stream/sparse-write-stream.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-write-stream.ts#L20)
+[lib/sparse-stream/sparse-write-stream.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-write-stream.ts#L20)
 
 ## Properties
 
@@ -121,7 +125,7 @@ Writable.constructor
 
 #### Defined in
 
-[lib/sparse-stream/sparse-write-stream.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-write-stream.ts#L18)
+[lib/sparse-stream/sparse-write-stream.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-write-stream.ts#L18)
 
 ___
 
@@ -131,7 +135,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-write-stream.ts:17](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-write-stream.ts#L17)
+[lib/sparse-stream/sparse-write-stream.ts:17](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-write-stream.ts#L17)
 
 ___
 
@@ -139,7 +143,7 @@ ___
 
 • `Readonly` **closed**: `boolean`
 
-Is true after 'close' has been emitted.
+Is `true` after `'close'` has been emitted.
 
 **`Since`**
 
@@ -151,7 +155,7 @@ Writable.closed
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:771
+node_modules/@types/node/stream.d.ts:704
 
 ___
 
@@ -161,7 +165,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-write-stream.ts:13](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-write-stream.ts#L13)
+[lib/sparse-stream/sparse-write-stream.ts:13](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-write-stream.ts#L13)
 
 ___
 
@@ -181,7 +185,7 @@ Writable.destroyed
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:766
+node_modules/@types/node/stream.d.ts:699
 
 ___
 
@@ -201,7 +205,7 @@ Writable.errored
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:776
+node_modules/@types/node/stream.d.ts:709
 
 ___
 
@@ -211,7 +215,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-write-stream.ts:14](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-write-stream.ts#L14)
+[lib/sparse-stream/sparse-write-stream.ts:14](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-write-stream.ts#L14)
 
 ___
 
@@ -221,7 +225,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-write-stream.ts:15](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-write-stream.ts#L15)
+[lib/sparse-stream/sparse-write-stream.ts:15](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-write-stream.ts#L15)
 
 ___
 
@@ -231,7 +235,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-write-stream.ts:16](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-write-stream.ts#L16)
+[lib/sparse-stream/sparse-write-stream.ts:16](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-write-stream.ts#L16)
 
 ___
 
@@ -240,7 +244,7 @@ ___
 • `Readonly` **writable**: `boolean`
 
 Is `true` if it is safe to call `writable.write()`, which means
-the stream has not been destroyed, errored or ended.
+the stream has not been destroyed, errored, or ended.
 
 **`Since`**
 
@@ -256,7 +260,7 @@ Writable.writable
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:727
+node_modules/@types/node/stream.d.ts:660
 
 ___
 
@@ -277,7 +281,7 @@ Writable.writableCorked
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:761
+node_modules/@types/node/stream.d.ts:694
 
 ___
 
@@ -298,7 +302,7 @@ Writable.writableEnded
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:733
+node_modules/@types/node/stream.d.ts:666
 
 ___
 
@@ -318,7 +322,7 @@ Writable.writableFinished
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:738
+node_modules/@types/node/stream.d.ts:671
 
 ___
 
@@ -338,7 +342,7 @@ Writable.writableHighWaterMark
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:743
+node_modules/@types/node/stream.d.ts:676
 
 ___
 
@@ -360,7 +364,7 @@ Writable.writableLength
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:750
+node_modules/@types/node/stream.d.ts:683
 
 ___
 
@@ -368,7 +372,7 @@ ___
 
 • `Readonly` **writableNeedDrain**: `boolean`
 
-Is `true` if the stream's buffer has been full and stream will emit 'drain'.
+Is `true` if the stream's buffer has been full and stream will emit `'drain'`.
 
 **`Since`**
 
@@ -380,7 +384,7 @@ Writable.writableNeedDrain
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:781
+node_modules/@types/node/stream.d.ts:714
 
 ___
 
@@ -400,7 +404,7 @@ Writable.writableObjectMode
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:755
+node_modules/@types/node/stream.d.ts:688
 
 ___
 
@@ -408,13 +412,21 @@ ___
 
 ▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](scanner.adapters.Adapter.md#capturerejectionsymbol)
 
+Value: `Symbol.for('nodejs.rejection')`
+
+See how to write a custom `rejection handler`.
+
+**`Since`**
+
+v13.4.0, v12.16.0
+
 #### Inherited from
 
 Writable.captureRejectionSymbol
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:405
+node_modules/@types/node/events.d.ts:402
 
 ___
 
@@ -422,7 +434,13 @@ ___
 
 ▪ `Static` **captureRejections**: `boolean`
 
-Sets or gets the default captureRejection value for all emitters.
+Value: [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Data_structures#Boolean_type)
+
+Change the default `captureRejections` option on all new `EventEmitter` objects.
+
+**`Since`**
+
+v13.4.0, v12.16.0
 
 #### Inherited from
 
@@ -430,7 +448,7 @@ Writable.captureRejections
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:410
+node_modules/@types/node/events.d.ts:409
 
 ___
 
@@ -438,13 +456,51 @@ ___
 
 ▪ `Static` **defaultMaxListeners**: `number`
 
+By default, a maximum of `10` listeners can be registered for any single
+event. This limit can be changed for individual `EventEmitter` instances
+using the `emitter.setMaxListeners(n)` method. To change the default
+for _all_`EventEmitter` instances, the `events.defaultMaxListeners`property can be used. If this value is not a positive number, a `RangeError`is thrown.
+
+Take caution when setting the `events.defaultMaxListeners` because the
+change affects _all_`EventEmitter` instances, including those created before
+the change is made. However, calling `emitter.setMaxListeners(n)` still has
+precedence over `events.defaultMaxListeners`.
+
+This is not a hard limit. The `EventEmitter` instance will allow
+more listeners to be added but will output a trace warning to stderr indicating
+that a "possible EventEmitter memory leak" has been detected. For any single`EventEmitter`, the `emitter.getMaxListeners()` and `emitter.setMaxListeners()`methods can be used to
+temporarily avoid this warning:
+
+```js
+import { EventEmitter } from 'node:events';
+const emitter = new EventEmitter();
+emitter.setMaxListeners(emitter.getMaxListeners() + 1);
+emitter.once('event', () => {
+  // do stuff
+  emitter.setMaxListeners(Math.max(emitter.getMaxListeners() - 1, 0));
+});
+```
+
+The `--trace-warnings` command-line flag can be used to display the
+stack trace for such warnings.
+
+The emitted warning can be inspected with `process.on('warning')` and will
+have the additional `emitter`, `type`, and `count` properties, referring to
+the event emitter instance, the event's name and the number of attached
+listeners, respectively.
+Its `name` property is set to `'MaxListenersExceededWarning'`.
+
+**`Since`**
+
+v0.11.2
+
 #### Inherited from
 
 Writable.defaultMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:411
+node_modules/@types/node/events.d.ts:446
 
 ___
 
@@ -452,13 +508,14 @@ ___
 
 ▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](scanner.adapters.Adapter.md#errormonitor)
 
-This symbol shall be used to install a listener for only monitoring `'error'`
-events. Listeners installed using this symbol are called before the regular
-`'error'` listeners are called.
+This symbol shall be used to install a listener for only monitoring `'error'`events. Listeners installed using this symbol are called before the regular`'error'` listeners are called.
 
-Installing a listener using this symbol does not change the behavior once an
-`'error'` event is emitted, therefore the process will still crash if no
+Installing a listener using this symbol does not change the behavior once an`'error'` event is emitted. Therefore, the process will still crash if no
 regular `'error'` listener is installed.
+
+**`Since`**
+
+v13.6.0, v12.17.0
 
 #### Inherited from
 
@@ -466,13 +523,13 @@ Writable.errorMonitor
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:404
+node_modules/@types/node/events.d.ts:395
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -496,13 +553,13 @@ Writable.[captureRejectionSymbol]
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_\_final
 
-▸ `Private` **__final**(): `Promise`<`void`\>
+▸ **__final**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -510,13 +567,13 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-write-stream.ts:118](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-write-stream.ts#L118)
+[lib/sparse-stream/sparse-write-stream.ts:118](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-write-stream.ts#L118)
 
 ___
 
 ### \_\_write
 
-▸ `Private` **__write**(`chunk`): `Promise`<`void`\>
+▸ **__write**(`chunk`): `Promise`<`void`\>
 
 #### Parameters
 
@@ -530,13 +587,13 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-write-stream.ts:73](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-write-stream.ts#L73)
+[lib/sparse-stream/sparse-write-stream.ts:73](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-write-stream.ts#L73)
 
 ___
 
 ### \_construct
 
-▸ `Optional` **_construct**(`callback`): `void`
+▸ **_construct**(`callback`): `void`
 
 #### Parameters
 
@@ -554,7 +611,7 @@ Writable.\_construct
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:791
+node_modules/@types/node/stream.d.ts:724
 
 ___
 
@@ -579,7 +636,7 @@ Writable.\_destroy
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:792
+node_modules/@types/node/stream.d.ts:725
 
 ___
 
@@ -607,7 +664,7 @@ Writable.\_final
 
 #### Defined in
 
-[lib/sparse-stream/sparse-write-stream.ts:132](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-write-stream.ts#L132)
+[lib/sparse-stream/sparse-write-stream.ts:132](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-write-stream.ts#L132)
 
 ___
 
@@ -637,13 +694,13 @@ Writable.\_write
 
 #### Defined in
 
-[lib/sparse-stream/sparse-write-stream.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-write-stream.ts#L110)
+[lib/sparse-stream/sparse-write-stream.ts:110](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-write-stream.ts#L110)
 
 ___
 
 ### \_writev
 
-▸ `Optional` **_writev**(`chunks`, `callback`): `void`
+▸ **_writev**(`chunks`, `callback`): `void`
 
 #### Parameters
 
@@ -662,7 +719,7 @@ Writable.\_writev
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:784
+node_modules/@types/node/stream.d.ts:717
 
 ___
 
@@ -700,7 +757,7 @@ Writable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:959
+node_modules/@types/node/stream.d.ts:892
 
 ▸ **addListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -725,7 +782,7 @@ Writable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:960
+node_modules/@types/node/stream.d.ts:893
 
 ▸ **addListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -750,7 +807,7 @@ Writable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:961
+node_modules/@types/node/stream.d.ts:894
 
 ▸ **addListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -775,7 +832,7 @@ Writable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:962
+node_modules/@types/node/stream.d.ts:895
 
 ▸ **addListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -800,7 +857,7 @@ Writable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:963
+node_modules/@types/node/stream.d.ts:896
 
 ▸ **addListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -825,7 +882,7 @@ Writable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:964
+node_modules/@types/node/stream.d.ts:897
 
 ▸ **addListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -850,7 +907,7 @@ Writable.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:965
+node_modules/@types/node/stream.d.ts:898
 
 ___
 
@@ -888,7 +945,7 @@ ___
 
 ### copyChunk
 
-▸ `Private` **copyChunk**(`chunk`): [`SparseStreamChunk`](../interfaces/sparseStream.SparseStreamChunk.md)
+▸ **copyChunk**(`chunk`): [`SparseStreamChunk`](../interfaces/sparseStream.SparseStreamChunk.md)
 
 #### Parameters
 
@@ -902,7 +959,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-write-stream.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-write-stream.ts#L60)
+[lib/sparse-stream/sparse-write-stream.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-write-stream.ts#L60)
 
 ___
 
@@ -936,7 +993,7 @@ Writable.cork
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:897
+node_modules/@types/node/stream.d.ts:830
 
 ___
 
@@ -977,7 +1034,7 @@ Writable.destroy
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:948
+node_modules/@types/node/stream.d.ts:881
 
 ___
 
@@ -991,7 +1048,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -1047,7 +1104,7 @@ Writable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:966
+node_modules/@types/node/stream.d.ts:899
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1071,7 +1128,7 @@ Writable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:967
+node_modules/@types/node/stream.d.ts:900
 
 ▸ **emit**(`event`, `err`): `boolean`
 
@@ -1096,7 +1153,7 @@ Writable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:968
+node_modules/@types/node/stream.d.ts:901
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1120,7 +1177,7 @@ Writable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:969
+node_modules/@types/node/stream.d.ts:902
 
 ▸ **emit**(`event`, `src`): `boolean`
 
@@ -1145,7 +1202,7 @@ Writable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:970
+node_modules/@types/node/stream.d.ts:903
 
 ▸ **emit**(`event`, `src`): `boolean`
 
@@ -1170,7 +1227,7 @@ Writable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:971
+node_modules/@types/node/stream.d.ts:904
 
 ▸ **emit**(`event`, `...args`): `boolean`
 
@@ -1195,7 +1252,7 @@ Writable.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:972
+node_modules/@types/node/stream.d.ts:905
 
 ___
 
@@ -1212,7 +1269,7 @@ Calling the [write](sourceDestination.CountingWritable.md#write) method after ca
 
 ```js
 // Write 'hello, ' and then end with 'world!'.
-const fs = require('fs');
+const fs = require('node:fs');
 const file = fs.createWriteStream('example.txt');
 file.write('hello, ');
 file.end('world!');
@@ -1243,7 +1300,7 @@ Writable.end
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:880
+node_modules/@types/node/stream.d.ts:813
 
 ▸ **end**(`chunk`, `cb?`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -1268,7 +1325,7 @@ Writable.end
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:881
+node_modules/@types/node/stream.d.ts:814
 
 ▸ **end**(`chunk`, `encoding`, `cb?`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -1294,7 +1351,7 @@ Writable.end
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:882
+node_modules/@types/node/stream.d.ts:815
 
 ___
 
@@ -1306,7 +1363,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -1336,7 +1394,7 @@ Writable.eventNames
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -1365,7 +1423,7 @@ Writable.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -1373,10 +1431,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -1403,7 +1460,7 @@ Writable.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -1445,7 +1502,7 @@ Writable.listeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -1480,7 +1537,7 @@ Writable.off
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -1505,6 +1562,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -1539,7 +1597,7 @@ Writable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:973
+node_modules/@types/node/stream.d.ts:906
 
 ▸ **on**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -1564,7 +1622,7 @@ Writable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:974
+node_modules/@types/node/stream.d.ts:907
 
 ▸ **on**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -1589,7 +1647,7 @@ Writable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:975
+node_modules/@types/node/stream.d.ts:908
 
 ▸ **on**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -1614,7 +1672,7 @@ Writable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:976
+node_modules/@types/node/stream.d.ts:909
 
 ▸ **on**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -1639,7 +1697,7 @@ Writable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:977
+node_modules/@types/node/stream.d.ts:910
 
 ▸ **on**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -1664,7 +1722,7 @@ Writable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:978
+node_modules/@types/node/stream.d.ts:911
 
 ▸ **on**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -1689,7 +1747,7 @@ Writable.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:979
+node_modules/@types/node/stream.d.ts:912
 
 ___
 
@@ -1712,6 +1770,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -1746,7 +1805,7 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:980
+node_modules/@types/node/stream.d.ts:913
 
 ▸ **once**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -1771,7 +1830,7 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:981
+node_modules/@types/node/stream.d.ts:914
 
 ▸ **once**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -1796,7 +1855,7 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:982
+node_modules/@types/node/stream.d.ts:915
 
 ▸ **once**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -1821,7 +1880,7 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:983
+node_modules/@types/node/stream.d.ts:916
 
 ▸ **once**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -1846,7 +1905,7 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:984
+node_modules/@types/node/stream.d.ts:917
 
 ▸ **once**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -1871,7 +1930,7 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:985
+node_modules/@types/node/stream.d.ts:918
 
 ▸ **once**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -1896,7 +1955,7 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:986
+node_modules/@types/node/stream.d.ts:919
 
 ___
 
@@ -1974,7 +2033,7 @@ Writable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:987
+node_modules/@types/node/stream.d.ts:920
 
 ▸ **prependListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -1999,7 +2058,7 @@ Writable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:988
+node_modules/@types/node/stream.d.ts:921
 
 ▸ **prependListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -2024,7 +2083,7 @@ Writable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:989
+node_modules/@types/node/stream.d.ts:922
 
 ▸ **prependListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -2049,7 +2108,7 @@ Writable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:990
+node_modules/@types/node/stream.d.ts:923
 
 ▸ **prependListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -2074,7 +2133,7 @@ Writable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:991
+node_modules/@types/node/stream.d.ts:924
 
 ▸ **prependListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -2099,7 +2158,7 @@ Writable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:992
+node_modules/@types/node/stream.d.ts:925
 
 ▸ **prependListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -2124,7 +2183,7 @@ Writable.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:993
+node_modules/@types/node/stream.d.ts:926
 
 ___
 
@@ -2168,7 +2227,7 @@ Writable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:994
+node_modules/@types/node/stream.d.ts:927
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -2193,7 +2252,7 @@ Writable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:995
+node_modules/@types/node/stream.d.ts:928
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -2218,7 +2277,7 @@ Writable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:996
+node_modules/@types/node/stream.d.ts:929
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -2243,7 +2302,7 @@ Writable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:997
+node_modules/@types/node/stream.d.ts:930
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -2268,7 +2327,7 @@ Writable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:998
+node_modules/@types/node/stream.d.ts:931
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -2293,7 +2352,7 @@ Writable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:999
+node_modules/@types/node/stream.d.ts:932
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -2318,7 +2377,7 @@ Writable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1000
+node_modules/@types/node/stream.d.ts:933
 
 ___
 
@@ -2330,6 +2389,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -2377,7 +2437,7 @@ Writable.rawListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -2417,7 +2477,7 @@ Writable.removeAllListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -2446,6 +2506,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -2486,6 +2548,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -2527,7 +2590,7 @@ Writable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1001
+node_modules/@types/node/stream.d.ts:934
 
 ▸ **removeListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -2552,7 +2615,7 @@ Writable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1002
+node_modules/@types/node/stream.d.ts:935
 
 ▸ **removeListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -2577,7 +2640,7 @@ Writable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1003
+node_modules/@types/node/stream.d.ts:936
 
 ▸ **removeListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -2602,7 +2665,7 @@ Writable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1004
+node_modules/@types/node/stream.d.ts:937
 
 ▸ **removeListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -2627,7 +2690,7 @@ Writable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1005
+node_modules/@types/node/stream.d.ts:938
 
 ▸ **removeListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -2652,7 +2715,7 @@ Writable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1006
+node_modules/@types/node/stream.d.ts:939
 
 ▸ **removeListener**(`event`, `listener`): [`SparseWriteStream`](sparseStream.SparseWriteStream.md)
 
@@ -2677,7 +2740,7 @@ Writable.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1007
+node_modules/@types/node/stream.d.ts:940
 
 ___
 
@@ -2707,7 +2770,7 @@ Writable.setDefaultEncoding
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:857
+node_modules/@types/node/stream.d.ts:790
 
 ___
 
@@ -2746,7 +2809,7 @@ Writable.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -2799,7 +2862,7 @@ Writable.uncork
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:931
+node_modules/@types/node/stream.d.ts:864
 
 ___
 
@@ -2883,7 +2946,7 @@ Writable.write
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:850
+node_modules/@types/node/stream.d.ts:783
 
 ▸ **write**(`chunk`, `encoding`, `callback?`): `boolean`
 
@@ -2909,13 +2972,13 @@ Writable.write
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:851
+node_modules/@types/node/stream.d.ts:784
 
 ___
 
 ### writeChunk
 
-▸ `Private` **writeChunk**(`chunk`, `flushing?`): `Promise`<`void`\>
+▸ **writeChunk**(`chunk`, `flushing?`): `Promise`<`void`\>
 
 #### Parameters
 
@@ -2930,13 +2993,13 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/sparse-write-stream.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-write-stream.ts#L37)
+[lib/sparse-stream/sparse-write-stream.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-write-stream.ts#L37)
 
 ___
 
 ### addAbortListener
 
-▸ `Static` **addAbortListener**(`signal`, `resource`): `Disposable`
+▸ **addAbortListener**(`signal`, `resource`): `Disposable`
 
 Listens once to the `abort` event on the provided `signal`.
 
@@ -2983,7 +3046,7 @@ Disposable that removes the `abort` listener.
 
 **`Since`**
 
-v18.18.0
+v20.5.0
 
 #### Inherited from
 
@@ -2991,13 +3054,13 @@ Writable.addAbortListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:394
+node_modules/@types/node/events.d.ts:387
 
 ___
 
 ### fromWeb
 
-▸ `Static` **fromWeb**(`writableStream`, `options?`): `Writable`
+▸ **fromWeb**(`writableStream`, `options?`): `Writable`
 
 A utility method for creating a `Writable` from a web `WritableStream`.
 
@@ -3022,13 +3085,13 @@ Writable.fromWeb
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:712
+node_modules/@types/node/stream.d.ts:1006
 
 ___
 
 ### getEventListeners
 
-▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+▸ **getEventListeners**(`emitter`, `name`): `Function`[]
 
 Returns a copy of the array of listeners for the event named `eventName`.
 
@@ -3039,19 +3102,19 @@ For `EventTarget`s this is the only way to get the event listeners for the
 event target. This is useful for debugging and diagnostic purposes.
 
 ```js
-const { getEventListeners, EventEmitter } = require('events');
+import { getEventListeners, EventEmitter } from 'node:events';
 
 {
   const ee = new EventEmitter();
   const listener = () => console.log('Events are fun');
   ee.on('foo', listener);
-  getEventListeners(ee, 'foo'); // [listener]
+  console.log(getEventListeners(ee, 'foo')); // [ [Function: listener] ]
 }
 {
   const et = new EventTarget();
   const listener = () => console.log('Events are fun');
   et.addEventListener('foo', listener);
-  getEventListeners(et, 'foo'); // [listener]
+  console.log(getEventListeners(et, 'foo')); // [ [Function: listener] ]
 }
 ```
 
@@ -3076,13 +3139,13 @@ Writable.getEventListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:312
+node_modules/@types/node/events.d.ts:308
 
 ___
 
 ### getMaxListeners
 
-▸ `Static` **getMaxListeners**(`emitter`): `number`
+▸ **getMaxListeners**(`emitter`): `number`
 
 Returns the currently set max amount of listeners.
 
@@ -3122,7 +3185,7 @@ import { getMaxListeners, setMaxListeners, EventEmitter } from 'node:events';
 
 **`Since`**
 
-v18.17.0
+v19.9.0
 
 #### Inherited from
 
@@ -3130,18 +3193,19 @@ Writable.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:341
+node_modules/@types/node/events.d.ts:337
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
+▸ **listenerCount**(`emitter`, `eventName`): `number`
 
 A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
 
 ```js
-const { EventEmitter, listenerCount } = require('events');
+import { EventEmitter, listenerCount } from 'node:events';
+
 const myEmitter = new EventEmitter();
 myEmitter.on('event', () => {});
 myEmitter.on('event', () => {});
@@ -3174,34 +3238,33 @@ Writable.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:284
+node_modules/@types/node/events.d.ts:280
 
 ___
 
 ### on
 
-▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+▸ **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-(async () => {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  // Emit later on
-  process.nextTick(() => {
-    ee.emit('foo', 'bar');
-    ee.emit('foo', 42);
-  });
+// Emit later on
+process.nextTick(() => {
+  ee.emit('foo', 'bar');
+  ee.emit('foo', 42);
+});
 
-  for await (const event of on(ee, 'foo')) {
-    // The execution of this inner block is synchronous and it
-    // processes one event at a time (even with await). Do not use
-    // if concurrent execution is required.
-    console.log(event); // prints ['bar'] [42]
-  }
-  // Unreachable here
-})();
+for await (const event of on(ee, 'foo')) {
+  // The execution of this inner block is synchronous and it
+  // processes one event at a time (even with await). Do not use
+  // if concurrent execution is required.
+  console.log(event); // prints ['bar'] [42]
+}
+// Unreachable here
 ```
 
 Returns an `AsyncIterator` that iterates `eventName` events. It will throw
@@ -3212,7 +3275,9 @@ composed of the emitted event arguments.
 An `AbortSignal` can be used to cancel waiting on events:
 
 ```js
-const { on, EventEmitter } = require('events');
+import { on, EventEmitter } from 'node:events';
+import process from 'node:process';
+
 const ac = new AbortController();
 
 (async () => {
@@ -3260,13 +3325,13 @@ Writable.on
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:263
+node_modules/@types/node/events.d.ts:258
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
 event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
@@ -3277,31 +3342,28 @@ This method is intentionally generic and works with the web platform [EventTarge
 semantics and does not listen to the `'error'` event.
 
 ```js
-const { once, EventEmitter } = require('events');
+import { once, EventEmitter } from 'node:events';
+import process from 'node:process';
 
-async function run() {
-  const ee = new EventEmitter();
+const ee = new EventEmitter();
 
-  process.nextTick(() => {
-    ee.emit('myevent', 42);
-  });
+process.nextTick(() => {
+  ee.emit('myevent', 42);
+});
 
-  const [value] = await once(ee, 'myevent');
-  console.log(value);
+const [value] = await once(ee, 'myevent');
+console.log(value);
 
-  const err = new Error('kaboom');
-  process.nextTick(() => {
-    ee.emit('error', err);
-  });
+const err = new Error('kaboom');
+process.nextTick(() => {
+  ee.emit('error', err);
+});
 
-  try {
-    await once(ee, 'myevent');
-  } catch (err) {
-    console.log('error happened', err);
-  }
+try {
+  await once(ee, 'myevent');
+} catch (err) {
+  console.error('error happened', err);
 }
-
-run();
 ```
 
 The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
@@ -3309,13 +3371,13 @@ The special handling of the `'error'` event is only used when `events.once()`is 
 special handling:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 
 once(ee, 'error')
   .then(([err]) => console.log('ok', err.message))
-  .catch((err) => console.log('error', err.message));
+  .catch((err) => console.error('error', err.message));
 
 ee.emit('error', new Error('boom'));
 
@@ -3325,7 +3387,7 @@ ee.emit('error', new Error('boom'));
 An `AbortSignal` can be used to cancel waiting for the event:
 
 ```js
-const { EventEmitter, once } = require('events');
+import { EventEmitter, once } from 'node:events';
 
 const ee = new EventEmitter();
 const ac = new AbortController();
@@ -3370,9 +3432,9 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:199
+node_modules/@types/node/events.d.ts:193
 
-▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+▸ **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
@@ -3392,19 +3454,16 @@ Writable.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:204
+node_modules/@types/node/events.d.ts:198
 
 ___
 
 ### setMaxListeners
 
-▸ `Static` **setMaxListeners**(`n?`, `...eventTargets`): `void`
+▸ **setMaxListeners**(`n?`, `...eventTargets`): `void`
 
 ```js
-const {
-  setMaxListeners,
-  EventEmitter
-} = require('events');
+import { setMaxListeners, EventEmitter } from 'node:events';
 
 const target = new EventTarget();
 const emitter = new EventEmitter();
@@ -3433,13 +3492,13 @@ Writable.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:359
+node_modules/@types/node/events.d.ts:352
 
 ___
 
 ### toWeb
 
-▸ `Static` **toWeb**(`streamWritable`): `WritableStream`<`any`\>
+▸ **toWeb**(`streamWritable`): `WritableStream`<`any`\>
 
 A utility method for creating a web `WritableStream` from a `Writable`.
 
@@ -3463,4 +3522,4 @@ Writable.toWeb
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:721
+node_modules/@types/node/stream.d.ts:1015

--- a/doc/enums/migrator.MigrateResult.md
+++ b/doc/enums/migrator.MigrateResult.md
@@ -21,7 +21,7 @@ Describes the result of running migrate() function.
 
 #### Defined in
 
-[lib/migrator/index.ts:112](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/migrator/index.ts#L112)
+[lib/migrator/index.ts:112](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/migrator/index.ts#L112)
 
 ___
 
@@ -31,4 +31,4 @@ ___
 
 #### Defined in
 
-[lib/migrator/index.ts:111](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/migrator/index.ts#L111)
+[lib/migrator/index.ts:111](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/migrator/index.ts#L111)

--- a/doc/enums/migrator.WifiAuthType.md
+++ b/doc/enums/migrator.WifiAuthType.md
@@ -23,7 +23,7 @@ NONE means no authentication.
 
 #### Defined in
 
-[lib/migrator/helpers.ts:226](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/migrator/helpers.ts#L226)
+[lib/migrator/helpers.ts:226](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/migrator/helpers.ts#L226)
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 #### Defined in
 
-[lib/migrator/helpers.ts:227](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/migrator/helpers.ts#L227)
+[lib/migrator/helpers.ts:227](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/migrator/helpers.ts#L227)
 
 ___
 
@@ -43,4 +43,4 @@ ___
 
 #### Defined in
 
-[lib/migrator/helpers.ts:228](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/migrator/helpers.ts#L228)
+[lib/migrator/helpers.ts:228](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/migrator/helpers.ts#L228)

--- a/doc/interfaces/migrator.ConnectionProfile.md
+++ b/doc/interfaces/migrator.ConnectionProfile.md
@@ -23,7 +23,7 @@ Configuration values for a single WiFi network profile.
 
 #### Defined in
 
-[lib/migrator/helpers.ts:233](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/migrator/helpers.ts#L233)
+[lib/migrator/helpers.ts:233](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/migrator/helpers.ts#L233)
 
 ___
 
@@ -33,7 +33,7 @@ ___
 
 #### Defined in
 
-[lib/migrator/helpers.ts:235](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/migrator/helpers.ts#L235)
+[lib/migrator/helpers.ts:235](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/migrator/helpers.ts#L235)
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 #### Defined in
 
-[lib/migrator/helpers.ts:236](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/migrator/helpers.ts#L236)
+[lib/migrator/helpers.ts:236](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/migrator/helpers.ts#L236)
 
 ___
 
@@ -53,4 +53,4 @@ ___
 
 #### Defined in
 
-[lib/migrator/helpers.ts:234](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/migrator/helpers.ts#L234)
+[lib/migrator/helpers.ts:234](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/migrator/helpers.ts#L234)

--- a/doc/interfaces/migrator.MigrateOptions.md
+++ b/doc/interfaces/migrator.MigrateOptions.md
@@ -21,7 +21,7 @@ Options for migrate():
 
 #### Defined in
 
-[lib/migrator/index.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/migrator/index.ts#L106)
+[lib/migrator/index.ts:106](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/migrator/index.ts#L106)
 
 ___
 
@@ -31,4 +31,4 @@ ___
 
 #### Defined in
 
-[lib/migrator/index.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/migrator/index.ts#L104)
+[lib/migrator/index.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/migrator/index.ts#L104)

--- a/doc/interfaces/multiWrite.MultiDestinationProgress.md
+++ b/doc/interfaces/multiWrite.MultiDestinationProgress.md
@@ -44,7 +44,7 @@ MultiDestinationState.active
 
 #### Defined in
 
-[lib/multi-write.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L48)
+[lib/multi-write.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L48)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[lib/multi-write.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L65)
+[lib/multi-write.ts:65](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L65)
 
 ___
 
@@ -68,7 +68,7 @@ MultiDestinationState.blockmappedSize
 
 #### Defined in
 
-[lib/multi-write.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L53)
+[lib/multi-write.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L53)
 
 ___
 
@@ -78,7 +78,7 @@ ___
 
 #### Defined in
 
-[lib/multi-write.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L62)
+[lib/multi-write.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L62)
 
 ___
 
@@ -92,7 +92,7 @@ MultiDestinationState.bytesWritten
 
 #### Defined in
 
-[lib/multi-write.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L58)
+[lib/multi-write.ts:58](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L58)
 
 ___
 
@@ -106,7 +106,7 @@ MultiDestinationState.compressedSize
 
 #### Defined in
 
-[lib/multi-write.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L52)
+[lib/multi-write.ts:52](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L52)
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 #### Defined in
 
-[lib/multi-write.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L67)
+[lib/multi-write.ts:67](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L67)
 
 ___
 
@@ -130,7 +130,7 @@ MultiDestinationState.failed
 
 #### Defined in
 
-[lib/multi-write.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L49)
+[lib/multi-write.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L49)
 
 ___
 
@@ -140,7 +140,7 @@ ___
 
 #### Defined in
 
-[lib/multi-write.ts:66](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L66)
+[lib/multi-write.ts:66](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L66)
 
 ___
 
@@ -150,7 +150,7 @@ ___
 
 #### Defined in
 
-[lib/multi-write.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L63)
+[lib/multi-write.ts:63](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L63)
 
 ___
 
@@ -164,7 +164,7 @@ MultiDestinationState.rootStreamAverageSpeed
 
 #### Defined in
 
-[lib/multi-write.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L57)
+[lib/multi-write.ts:57](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L57)
 
 ___
 
@@ -178,7 +178,7 @@ MultiDestinationState.rootStreamPosition
 
 #### Defined in
 
-[lib/multi-write.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L55)
+[lib/multi-write.ts:55](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L55)
 
 ___
 
@@ -192,7 +192,7 @@ MultiDestinationState.rootStreamSpeed
 
 #### Defined in
 
-[lib/multi-write.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L56)
+[lib/multi-write.ts:56](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L56)
 
 ___
 
@@ -206,7 +206,7 @@ MultiDestinationState.size
 
 #### Defined in
 
-[lib/multi-write.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L51)
+[lib/multi-write.ts:51](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L51)
 
 ___
 
@@ -220,7 +220,7 @@ MultiDestinationState.sparse
 
 #### Defined in
 
-[lib/multi-write.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L54)
+[lib/multi-write.ts:54](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L54)
 
 ___
 
@@ -230,7 +230,7 @@ ___
 
 #### Defined in
 
-[lib/multi-write.ts:64](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L64)
+[lib/multi-write.ts:64](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L64)
 
 ___
 
@@ -244,4 +244,4 @@ MultiDestinationState.type
 
 #### Defined in
 
-[lib/multi-write.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L50)
+[lib/multi-write.ts:50](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L50)

--- a/doc/interfaces/multiWrite.PipeSourceToDestinationsResult.md
+++ b/doc/interfaces/multiWrite.PipeSourceToDestinationsResult.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[lib/multi-write.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L79)
+[lib/multi-write.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L79)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[lib/multi-write.ts:78](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L78)
+[lib/multi-write.ts:78](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L78)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[lib/multi-write.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L80)
+[lib/multi-write.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L80)

--- a/doc/interfaces/scanner.adapters.AdapterSourceDestination.md
+++ b/doc/interfaces/scanner.adapters.AdapterSourceDestination.md
@@ -80,7 +80,7 @@
 
 #### Defined in
 
-[lib/scanner/adapters/adapter.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/adapter.ts#L27)
+[lib/scanner/adapters/adapter.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/adapter.ts#L27)
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/adapter.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/adapter.ts#L24)
+[lib/scanner/adapters/adapter.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/adapter.ts#L24)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/adapter.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/adapter.ts#L25)
+[lib/scanner/adapters/adapter.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/adapter.ts#L25)
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/adapter.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/adapter.ts#L30)
+[lib/scanner/adapters/adapter.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/adapter.ts#L30)
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/adapter.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/adapter.ts#L26)
+[lib/scanner/adapters/adapter.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/adapter.ts#L26)
 
 ___
 
@@ -130,7 +130,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/adapter.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/adapter.ts#L28)
+[lib/scanner/adapters/adapter.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/adapter.ts#L28)
 
 ___
 
@@ -140,7 +140,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/adapter.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/adapter.ts#L23)
+[lib/scanner/adapters/adapter.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/adapter.ts#L23)
 
 ___
 
@@ -150,13 +150,13 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/adapter.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/adapter.ts#L29)
+[lib/scanner/adapters/adapter.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/adapter.ts#L29)
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -176,13 +176,13 @@ ___
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_close
 
-▸ `Protected` **_close**(): `Promise`<`void`\>
+▸ **_close**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -194,13 +194,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:422](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L422)
+[lib/source-destination/source-destination.ts:420](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L420)
 
 ___
 
 ### \_getMetadata
 
-▸ `Protected` **_getMetadata**(): `Promise`<[`Metadata`](sourceDestination.Metadata.md)\>
+▸ **_getMetadata**(): `Promise`<[`Metadata`](sourceDestination.Metadata.md)\>
 
 #### Returns
 
@@ -212,13 +212,13 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:354](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L354)
+[lib/source-destination/source-destination.ts:352](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L352)
 
 ___
 
 ### \_open
 
-▸ `Protected` **_open**(): `Promise`<`void`\>
+▸ **_open**(): `Promise`<`void`\>
 
 #### Returns
 
@@ -230,7 +230,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:418](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L418)
+[lib/source-destination/source-destination.ts:416](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L416)
 
 ___
 
@@ -261,7 +261,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -279,7 +279,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:331](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L331)
+[lib/source-destination/source-destination.ts:329](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L329)
 
 ___
 
@@ -297,7 +297,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:335](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L335)
+[lib/source-destination/source-destination.ts:333](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L333)
 
 ___
 
@@ -315,7 +315,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:343](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L343)
+[lib/source-destination/source-destination.ts:341](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L341)
 
 ___
 
@@ -333,7 +333,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:339](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L339)
+[lib/source-destination/source-destination.ts:337](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L337)
 
 ___
 
@@ -351,7 +351,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:323](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L323)
+[lib/source-destination/source-destination.ts:321](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L321)
 
 ___
 
@@ -369,7 +369,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:327](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L327)
+[lib/source-destination/source-destination.ts:325](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L325)
 
 ___
 
@@ -387,7 +387,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:411](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L411)
+[lib/source-destination/source-destination.ts:409](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L409)
 
 ___
 
@@ -411,7 +411,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:376](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L376)
+[lib/source-destination/source-destination.ts:374](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L374)
 
 ___
 
@@ -435,7 +435,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:382](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L382)
+[lib/source-destination/source-destination.ts:380](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L380)
 
 ___
 
@@ -460,7 +460,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:398](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L398)
+[lib/source-destination/source-destination.ts:396](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L396)
 
 ___
 
@@ -485,7 +485,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:426](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L426)
+[lib/source-destination/source-destination.ts:424](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L424)
 
 ___
 
@@ -510,7 +510,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:392](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L392)
+[lib/source-destination/source-destination.ts:390](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L390)
 
 ___
 
@@ -524,7 +524,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -577,7 +577,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -589,7 +589,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -615,7 +616,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -633,7 +634,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:319](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L319)
+[lib/source-destination/source-destination.ts:317](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L317)
 
 ___
 
@@ -651,7 +652,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:388](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L388)
+[lib/source-destination/source-destination.ts:386](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L386)
 
 ___
 
@@ -669,7 +670,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:501](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L501)
+[lib/source-destination/source-destination.ts:499](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L499)
 
 ___
 
@@ -694,7 +695,7 @@ v1.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -712,7 +713,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:347](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L347)
+[lib/source-destination/source-destination.ts:345](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L345)
 
 ___
 
@@ -730,7 +731,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:531](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L531)
+[lib/source-destination/source-destination.ts:529](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L529)
 
 ___
 
@@ -738,10 +739,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -764,7 +764,7 @@ v3.2.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -802,7 +802,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -833,7 +833,7 @@ v10.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -858,6 +858,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -888,7 +889,7 @@ v0.1.101
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -911,6 +912,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -941,7 +943,7 @@ v0.3.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -959,7 +961,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:404](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L404)
+[lib/source-destination/source-destination.ts:402](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L402)
 
 ___
 
@@ -1001,7 +1003,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -1041,7 +1043,7 @@ v6.0.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -1053,6 +1055,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -1096,7 +1099,7 @@ v9.4.0
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -1123,7 +1126,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:358](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L358)
+[lib/source-destination/source-destination.ts:356](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L356)
 
 ___
 
@@ -1159,7 +1162,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -1188,6 +1191,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -1228,6 +1233,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -1265,7 +1271,7 @@ v0.1.26
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -1300,7 +1306,7 @@ v0.3.5
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -1327,4 +1333,4 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:367](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L367)
+[lib/source-destination/source-destination.ts:365](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L365)

--- a/doc/interfaces/scanner.adapters.DrivelistDrive.md
+++ b/doc/interfaces/scanner.adapters.DrivelistDrive.md
@@ -130,7 +130,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/block-device.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/block-device.ts#L59)
+[lib/scanner/adapters/block-device.ts:59](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/block-device.ts#L59)
 
 ___
 
@@ -168,7 +168,7 @@ ___
 
 #### Defined in
 
-[lib/scanner/adapters/block-device.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/block-device.ts#L60)
+[lib/scanner/adapters/block-device.ts:60](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/block-device.ts#L60)
 
 ___
 

--- a/doc/interfaces/sourceDestination.AwsCredentials.md
+++ b/doc/interfaces/sourceDestination.AwsCredentials.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L36)
+[lib/source-destination/balena-s3-source.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L36)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L37)
+[lib/source-destination/balena-s3-source.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L37)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L38)
+[lib/source-destination/balena-s3-source.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L38)

--- a/doc/interfaces/sourceDestination.BalenaS3CompressedSourceOptions.md
+++ b/doc/interfaces/sourceDestination.BalenaS3CompressedSourceOptions.md
@@ -38,7 +38,7 @@
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L49)
+[lib/source-destination/balena-s3-source.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L49)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L43)
+[lib/source-destination/balena-s3-source.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L43)
 
 ___
 
@@ -66,7 +66,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L46)
+[lib/source-destination/balena-s3-source.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L46)
 
 ___
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L41)
+[lib/source-destination/balena-s3-compressed-source.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L41)
 
 ___
 
@@ -90,7 +90,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L45)
+[lib/source-destination/balena-s3-source.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L45)
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L40)
+[lib/source-destination/balena-s3-compressed-source.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L40)
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L39)
+[lib/source-destination/balena-s3-compressed-source.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L39)
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L42)
+[lib/source-destination/balena-s3-source.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L42)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L48)
+[lib/source-destination/balena-s3-source.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L48)
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L44)
+[lib/source-destination/balena-s3-source.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L44)
 
 ___
 
@@ -166,4 +166,4 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L47)
+[lib/source-destination/balena-s3-source.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L47)

--- a/doc/interfaces/sourceDestination.BalenaS3SourceOptions.md
+++ b/doc/interfaces/sourceDestination.BalenaS3SourceOptions.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L49)
+[lib/source-destination/balena-s3-source.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L49)
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L43)
+[lib/source-destination/balena-s3-source.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L43)
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L46)
+[lib/source-destination/balena-s3-source.ts:46](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L46)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L45)
+[lib/source-destination/balena-s3-source.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L45)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L42)
+[lib/source-destination/balena-s3-source.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L42)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L48)
+[lib/source-destination/balena-s3-source.ts:48](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L48)
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L44)
+[lib/source-destination/balena-s3-source.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L44)
 
 ___
 
@@ -101,4 +101,4 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-source.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-source.ts#L47)
+[lib/source-destination/balena-s3-source.ts:47](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-source.ts#L47)

--- a/doc/interfaces/sourceDestination.CreateReadStreamOptions.md
+++ b/doc/interfaces/sourceDestination.CreateReadStreamOptions.md
@@ -22,7 +22,7 @@
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:284](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L284)
+[lib/source-destination/source-destination.ts:282](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L282)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:281](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L281)
+[lib/source-destination/source-destination.ts:279](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L279)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:283](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L283)
+[lib/source-destination/source-destination.ts:281](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L281)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:285](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L285)
+[lib/source-destination/source-destination.ts:283](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L283)
 
 ___
 
@@ -62,4 +62,4 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:282](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L282)
+[lib/source-destination/source-destination.ts:280](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L280)

--- a/doc/interfaces/sourceDestination.CreateSparseReadStreamOptions.md
+++ b/doc/interfaces/sourceDestination.CreateSparseReadStreamOptions.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:290](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L290)
+[lib/source-destination/source-destination.ts:288](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L288)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:289](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L289)
+[lib/source-destination/source-destination.ts:287](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L287)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:291](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L291)
+[lib/source-destination/source-destination.ts:289](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L289)

--- a/doc/interfaces/sourceDestination.Metadata.md
+++ b/doc/interfaces/sourceDestination.Metadata.md
@@ -41,7 +41,7 @@
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L45)
+[lib/source-destination/metadata.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L45)
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L28)
+[lib/source-destination/metadata.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L28)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L26)
+[lib/source-destination/metadata.ts:26](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L26)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L29)
+[lib/source-destination/metadata.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L29)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L32)
+[lib/source-destination/metadata.ts:32](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L32)
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L33)
+[lib/source-destination/metadata.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L33)
 
 ___
 
@@ -101,7 +101,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L34)
+[lib/source-destination/metadata.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L34)
 
 ___
 
@@ -111,7 +111,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L25)
+[lib/source-destination/metadata.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L25)
 
 ___
 
@@ -121,7 +121,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L44)
+[lib/source-destination/metadata.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L44)
 
 ___
 
@@ -131,7 +131,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L30)
+[lib/source-destination/metadata.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L30)
 
 ___
 
@@ -141,7 +141,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L24)
+[lib/source-destination/metadata.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L24)
 
 ___
 
@@ -151,7 +151,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L40)
+[lib/source-destination/metadata.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L40)
 
 ___
 
@@ -161,7 +161,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L23)
+[lib/source-destination/metadata.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L23)
 
 ___
 
@@ -171,7 +171,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L43)
+[lib/source-destination/metadata.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L43)
 
 ___
 
@@ -181,7 +181,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L31)
+[lib/source-destination/metadata.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L31)
 
 ___
 
@@ -191,7 +191,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L27)
+[lib/source-destination/metadata.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L27)
 
 ___
 
@@ -201,7 +201,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L42)
+[lib/source-destination/metadata.ts:42](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L42)
 
 ___
 
@@ -211,7 +211,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L35)
+[lib/source-destination/metadata.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L35)
 
 ___
 
@@ -221,7 +221,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L36)
+[lib/source-destination/metadata.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L36)
 
 ___
 
@@ -231,7 +231,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L22)
+[lib/source-destination/metadata.ts:22](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L22)
 
 ___
 
@@ -241,7 +241,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L41)
+[lib/source-destination/metadata.ts:41](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L41)
 
 ___
 
@@ -251,7 +251,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L37)
+[lib/source-destination/metadata.ts:37](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L37)
 
 ___
 
@@ -261,7 +261,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L38)
+[lib/source-destination/metadata.ts:38](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L38)
 
 ___
 
@@ -271,4 +271,4 @@ ___
 
 #### Defined in
 
-[lib/source-destination/metadata.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/metadata.ts#L39)
+[lib/source-destination/metadata.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/metadata.ts#L39)

--- a/doc/interfaces/sourceDestination.ProgressEvent.md
+++ b/doc/interfaces/sourceDestination.ProgressEvent.md
@@ -21,7 +21,7 @@
 
 #### Defined in
 
-[lib/source-destination/progress.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/progress.ts#L30)
+[lib/source-destination/progress.ts:30](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/progress.ts#L30)
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/progress.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/progress.ts#L28)
+[lib/source-destination/progress.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/progress.ts#L28)
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/progress.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/progress.ts#L27)
+[lib/source-destination/progress.ts:27](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/progress.ts#L27)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[lib/source-destination/progress.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/progress.ts#L29)
+[lib/source-destination/progress.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/progress.ts#L29)

--- a/doc/interfaces/sourceDestination.SourceTransform.md
+++ b/doc/interfaces/sourceDestination.SourceTransform.md
@@ -104,7 +104,7 @@
 
 If `false` then the stream will automatically end the writable side when the
 readable side ends. Set initially by the `allowHalfOpen` constructor option,
-which defaults to `false`.
+which defaults to `true`.
 
 This can be changed manually to change the half-open behavior of an existing`Duplex` stream instance, but must be changed before the `'end'` event is
 emitted.
@@ -119,7 +119,7 @@ Transform.allowHalfOpen
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1060
+node_modules/@types/node/stream.d.ts:1068
 
 ___
 
@@ -133,7 +133,7 @@ Transform.closed
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1049
+node_modules/@types/node/stream.d.ts:1057
 
 ___
 
@@ -153,7 +153,7 @@ Transform.destroyed
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:145
+node_modules/@types/node/stream.d.ts:114
 
 ___
 
@@ -167,7 +167,7 @@ Transform.errored
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1050
+node_modules/@types/node/stream.d.ts:1058
 
 ___
 
@@ -188,7 +188,7 @@ Transform.readable
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:101
+node_modules/@types/node/stream.d.ts:70
 
 ___
 
@@ -208,7 +208,7 @@ Transform.readableAborted
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:95
+node_modules/@types/node/stream.d.ts:64
 
 ___
 
@@ -228,7 +228,7 @@ Transform.readableDidRead
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:107
+node_modules/@types/node/stream.d.ts:76
 
 ___
 
@@ -248,7 +248,7 @@ Transform.readableEncoding
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:112
+node_modules/@types/node/stream.d.ts:81
 
 ___
 
@@ -268,7 +268,7 @@ Transform.readableEnded
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:117
+node_modules/@types/node/stream.d.ts:86
 
 ___
 
@@ -289,7 +289,7 @@ Transform.readableFlowing
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:123
+node_modules/@types/node/stream.d.ts:92
 
 ___
 
@@ -309,7 +309,7 @@ Transform.readableHighWaterMark
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:128
+node_modules/@types/node/stream.d.ts:97
 
 ___
 
@@ -331,7 +331,7 @@ Transform.readableLength
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:135
+node_modules/@types/node/stream.d.ts:104
 
 ___
 
@@ -351,7 +351,7 @@ Transform.readableObjectMode
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:140
+node_modules/@types/node/stream.d.ts:109
 
 ___
 
@@ -361,7 +361,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L28)
+[lib/source-destination/compressed-source.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L28)
 
 ___
 
@@ -375,7 +375,7 @@ Transform.writable
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1041
+node_modules/@types/node/stream.d.ts:1049
 
 ___
 
@@ -389,7 +389,7 @@ Transform.writableCorked
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1047
+node_modules/@types/node/stream.d.ts:1055
 
 ___
 
@@ -403,7 +403,7 @@ Transform.writableEnded
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1042
+node_modules/@types/node/stream.d.ts:1050
 
 ___
 
@@ -417,7 +417,7 @@ Transform.writableFinished
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1043
+node_modules/@types/node/stream.d.ts:1051
 
 ___
 
@@ -431,7 +431,7 @@ Transform.writableHighWaterMark
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1044
+node_modules/@types/node/stream.d.ts:1052
 
 ___
 
@@ -445,7 +445,7 @@ Transform.writableLength
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1045
+node_modules/@types/node/stream.d.ts:1053
 
 ___
 
@@ -459,7 +459,7 @@ Transform.writableNeedDrain
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1048
+node_modules/@types/node/stream.d.ts:1056
 
 ___
 
@@ -473,7 +473,7 @@ Transform.writableObjectMode
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1046
+node_modules/@types/node/stream.d.ts:1054
 
 ## Methods
 
@@ -489,7 +489,7 @@ Calls `readable.destroy()` with an `AbortError` and returns a promise that fulfi
 
 **`Since`**
 
-v18.18.0
+v20.4.0
 
 #### Inherited from
 
@@ -497,7 +497,7 @@ Transform.[asyncDispose]
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:682
+node_modules/@types/node/stream.d.ts:651
 
 ___
 
@@ -515,13 +515,13 @@ Transform.[asyncIterator]
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:677
+node_modules/@types/node/stream.d.ts:646
 
 ___
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -541,13 +541,13 @@ Transform.[captureRejectionSymbol]
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:115
+node_modules/@types/node/events.d.ts:112
 
 ___
 
 ### \_construct
 
-▸ `Optional` **_construct**(`callback`): `void`
+▸ **_construct**(`callback`): `void`
 
 #### Parameters
 
@@ -565,7 +565,7 @@ Transform.\_construct
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:157
+node_modules/@types/node/stream.d.ts:126
 
 ___
 
@@ -578,7 +578,7 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `error` | ``null`` \| `Error` |
-| `callback` | (`error`: ``null`` \| `Error`) => `void` |
+| `callback` | (`error?`: ``null`` \| `Error`) => `void` |
 
 #### Returns
 
@@ -590,7 +590,7 @@ Transform.\_destroy
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1103
+node_modules/@types/node/stream.d.ts:1111
 
 ___
 
@@ -614,7 +614,7 @@ Transform.\_final
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1104
+node_modules/@types/node/stream.d.ts:1112
 
 ___
 
@@ -638,7 +638,7 @@ Transform.\_flush
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1250
+node_modules/@types/node/stream.d.ts:1282
 
 ___
 
@@ -662,7 +662,7 @@ Transform.\_read
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:158
+node_modules/@types/node/stream.d.ts:127
 
 ___
 
@@ -688,7 +688,7 @@ Transform.\_transform
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1249
+node_modules/@types/node/stream.d.ts:1281
 
 ___
 
@@ -714,13 +714,13 @@ Transform.\_write
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1095
+node_modules/@types/node/stream.d.ts:1103
 
 ___
 
 ### \_writev
 
-▸ `Optional` **_writev**(`chunks`, `callback`): `void`
+▸ **_writev**(`chunks`, `callback`): `void`
 
 #### Parameters
 
@@ -739,7 +739,7 @@ Transform.\_writev
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1096
+node_modules/@types/node/stream.d.ts:1104
 
 ___
 
@@ -778,7 +778,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1128
+node_modules/@types/node/stream.d.ts:1160
 
 ▸ **addListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -799,7 +799,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1129
+node_modules/@types/node/stream.d.ts:1161
 
 ▸ **addListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -820,7 +820,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1130
+node_modules/@types/node/stream.d.ts:1162
 
 ▸ **addListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -841,7 +841,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1131
+node_modules/@types/node/stream.d.ts:1163
 
 ▸ **addListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -862,7 +862,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1132
+node_modules/@types/node/stream.d.ts:1164
 
 ▸ **addListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -883,7 +883,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1133
+node_modules/@types/node/stream.d.ts:1165
 
 ▸ **addListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -904,7 +904,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1134
+node_modules/@types/node/stream.d.ts:1166
 
 ▸ **addListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -925,7 +925,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1135
+node_modules/@types/node/stream.d.ts:1167
 
 ▸ **addListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -946,7 +946,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1136
+node_modules/@types/node/stream.d.ts:1168
 
 ▸ **addListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -967,7 +967,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1137
+node_modules/@types/node/stream.d.ts:1169
 
 ▸ **addListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -988,7 +988,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1138
+node_modules/@types/node/stream.d.ts:1170
 
 ▸ **addListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -1009,7 +1009,7 @@ Transform.addListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1139
+node_modules/@types/node/stream.d.ts:1171
 
 ___
 
@@ -1042,7 +1042,7 @@ Transform.asIndexedPairs
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:572
+node_modules/@types/node/stream.d.ts:541
 
 ___
 
@@ -1092,7 +1092,7 @@ Transform.cork
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1111
+node_modules/@types/node/stream.d.ts:1119
 
 ___
 
@@ -1128,7 +1128,7 @@ Transform.destroy
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:609
+node_modules/@types/node/stream.d.ts:578
 
 ___
 
@@ -1161,7 +1161,7 @@ Transform.drop
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:558
+node_modules/@types/node/stream.d.ts:527
 
 ___
 
@@ -1185,7 +1185,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1140
+node_modules/@types/node/stream.d.ts:1172
 
 ▸ **emit**(`event`, `chunk`): `boolean`
 
@@ -1206,7 +1206,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1141
+node_modules/@types/node/stream.d.ts:1173
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1226,7 +1226,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1142
+node_modules/@types/node/stream.d.ts:1174
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1246,7 +1246,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1143
+node_modules/@types/node/stream.d.ts:1175
 
 ▸ **emit**(`event`, `err`): `boolean`
 
@@ -1267,7 +1267,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1144
+node_modules/@types/node/stream.d.ts:1176
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1287,7 +1287,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1145
+node_modules/@types/node/stream.d.ts:1177
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1307,7 +1307,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1146
+node_modules/@types/node/stream.d.ts:1178
 
 ▸ **emit**(`event`, `src`): `boolean`
 
@@ -1328,7 +1328,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1147
+node_modules/@types/node/stream.d.ts:1179
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1348,7 +1348,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1148
+node_modules/@types/node/stream.d.ts:1180
 
 ▸ **emit**(`event`): `boolean`
 
@@ -1368,7 +1368,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1149
+node_modules/@types/node/stream.d.ts:1181
 
 ▸ **emit**(`event`, `src`): `boolean`
 
@@ -1389,7 +1389,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1150
+node_modules/@types/node/stream.d.ts:1182
 
 ▸ **emit**(`event`, `...args`): `boolean`
 
@@ -1410,7 +1410,7 @@ Transform.emit
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1151
+node_modules/@types/node/stream.d.ts:1183
 
 ___
 
@@ -1434,7 +1434,7 @@ Transform.end
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1108
+node_modules/@types/node/stream.d.ts:1116
 
 ▸ **end**(`chunk`, `cb?`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -1455,7 +1455,7 @@ Transform.end
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1109
+node_modules/@types/node/stream.d.ts:1117
 
 ▸ **end**(`chunk`, `encoding?`, `cb?`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -1477,7 +1477,7 @@ Transform.end
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1110
+node_modules/@types/node/stream.d.ts:1118
 
 ___
 
@@ -1489,7 +1489,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -1515,7 +1516,7 @@ Transform.eventNames
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -1551,7 +1552,7 @@ Transform.every
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:537
+node_modules/@types/node/stream.d.ts:506
 
 ___
 
@@ -1586,7 +1587,7 @@ Transform.filter
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:465
+node_modules/@types/node/stream.d.ts:434
 
 ___
 
@@ -1629,7 +1630,7 @@ Transform.find
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:520
+node_modules/@types/node/stream.d.ts:489
 
 ▸ **find**(`fn`, `options?`): `Promise`<`any`\>
 
@@ -1650,7 +1651,7 @@ Transform.find
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:524
+node_modules/@types/node/stream.d.ts:493
 
 ___
 
@@ -1687,7 +1688,7 @@ Transform.flatMap
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:551
+node_modules/@types/node/stream.d.ts:520
 
 ___
 
@@ -1729,7 +1730,7 @@ Transform.forEach
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:484
+node_modules/@types/node/stream.d.ts:453
 
 ___
 
@@ -1754,7 +1755,7 @@ Transform.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -1790,7 +1791,7 @@ Transform.isPaused
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:318
+node_modules/@types/node/stream.d.ts:287
 
 ___
 
@@ -1823,7 +1824,7 @@ Transform.iterator
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:448
+node_modules/@types/node/stream.d.ts:417
 
 ___
 
@@ -1831,10 +1832,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -1857,7 +1857,7 @@ Transform.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -1895,7 +1895,7 @@ Transform.listeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -1929,7 +1929,7 @@ Transform.map
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:456
+node_modules/@types/node/stream.d.ts:425
 
 ___
 
@@ -1960,7 +1960,7 @@ Transform.off
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -1985,7 +1985,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1152
+node_modules/@types/node/stream.d.ts:1184
 
 ▸ **on**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2006,7 +2006,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1153
+node_modules/@types/node/stream.d.ts:1185
 
 ▸ **on**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2027,7 +2027,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1154
+node_modules/@types/node/stream.d.ts:1186
 
 ▸ **on**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2048,7 +2048,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1155
+node_modules/@types/node/stream.d.ts:1187
 
 ▸ **on**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2069,7 +2069,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1156
+node_modules/@types/node/stream.d.ts:1188
 
 ▸ **on**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2090,7 +2090,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1157
+node_modules/@types/node/stream.d.ts:1189
 
 ▸ **on**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2111,7 +2111,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1158
+node_modules/@types/node/stream.d.ts:1190
 
 ▸ **on**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2132,7 +2132,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1159
+node_modules/@types/node/stream.d.ts:1191
 
 ▸ **on**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2153,7 +2153,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1160
+node_modules/@types/node/stream.d.ts:1192
 
 ▸ **on**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2174,7 +2174,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1161
+node_modules/@types/node/stream.d.ts:1193
 
 ▸ **on**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2195,7 +2195,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1162
+node_modules/@types/node/stream.d.ts:1194
 
 ▸ **on**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2216,7 +2216,7 @@ Transform.on
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1163
+node_modules/@types/node/stream.d.ts:1195
 
 ___
 
@@ -2241,7 +2241,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1164
+node_modules/@types/node/stream.d.ts:1196
 
 ▸ **once**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2262,7 +2262,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1165
+node_modules/@types/node/stream.d.ts:1197
 
 ▸ **once**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2283,7 +2283,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1166
+node_modules/@types/node/stream.d.ts:1198
 
 ▸ **once**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2304,7 +2304,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1167
+node_modules/@types/node/stream.d.ts:1199
 
 ▸ **once**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2325,7 +2325,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1168
+node_modules/@types/node/stream.d.ts:1200
 
 ▸ **once**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2346,7 +2346,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1169
+node_modules/@types/node/stream.d.ts:1201
 
 ▸ **once**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2367,7 +2367,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1170
+node_modules/@types/node/stream.d.ts:1202
 
 ▸ **once**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2388,7 +2388,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1171
+node_modules/@types/node/stream.d.ts:1203
 
 ▸ **once**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2409,7 +2409,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1172
+node_modules/@types/node/stream.d.ts:1204
 
 ▸ **once**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2430,7 +2430,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1173
+node_modules/@types/node/stream.d.ts:1205
 
 ▸ **once**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2451,7 +2451,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1174
+node_modules/@types/node/stream.d.ts:1206
 
 ▸ **once**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2472,7 +2472,7 @@ Transform.once
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1175
+node_modules/@types/node/stream.d.ts:1207
 
 ___
 
@@ -2513,7 +2513,7 @@ Transform.pause
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:282
+node_modules/@types/node/stream.d.ts:251
 
 ___
 
@@ -2570,7 +2570,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1176
+node_modules/@types/node/stream.d.ts:1208
 
 ▸ **prependListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2591,7 +2591,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1177
+node_modules/@types/node/stream.d.ts:1209
 
 ▸ **prependListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2612,7 +2612,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1178
+node_modules/@types/node/stream.d.ts:1210
 
 ▸ **prependListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2633,7 +2633,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1179
+node_modules/@types/node/stream.d.ts:1211
 
 ▸ **prependListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2654,7 +2654,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1180
+node_modules/@types/node/stream.d.ts:1212
 
 ▸ **prependListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2675,7 +2675,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1181
+node_modules/@types/node/stream.d.ts:1213
 
 ▸ **prependListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2696,7 +2696,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1182
+node_modules/@types/node/stream.d.ts:1214
 
 ▸ **prependListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2717,7 +2717,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1183
+node_modules/@types/node/stream.d.ts:1215
 
 ▸ **prependListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2738,7 +2738,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1184
+node_modules/@types/node/stream.d.ts:1216
 
 ▸ **prependListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2759,7 +2759,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1185
+node_modules/@types/node/stream.d.ts:1217
 
 ▸ **prependListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2780,7 +2780,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1186
+node_modules/@types/node/stream.d.ts:1218
 
 ▸ **prependListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2801,7 +2801,7 @@ Transform.prependListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1187
+node_modules/@types/node/stream.d.ts:1219
 
 ___
 
@@ -2826,7 +2826,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1188
+node_modules/@types/node/stream.d.ts:1220
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2847,7 +2847,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1189
+node_modules/@types/node/stream.d.ts:1221
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2868,7 +2868,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1190
+node_modules/@types/node/stream.d.ts:1222
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2889,7 +2889,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1191
+node_modules/@types/node/stream.d.ts:1223
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2910,7 +2910,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1192
+node_modules/@types/node/stream.d.ts:1224
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2931,7 +2931,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1193
+node_modules/@types/node/stream.d.ts:1225
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2952,7 +2952,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1194
+node_modules/@types/node/stream.d.ts:1226
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2973,7 +2973,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1195
+node_modules/@types/node/stream.d.ts:1227
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -2994,7 +2994,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1196
+node_modules/@types/node/stream.d.ts:1228
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -3015,7 +3015,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1197
+node_modules/@types/node/stream.d.ts:1229
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -3036,7 +3036,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1198
+node_modules/@types/node/stream.d.ts:1230
 
 ▸ **prependOnceListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -3057,7 +3057,7 @@ Transform.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1199
+node_modules/@types/node/stream.d.ts:1231
 
 ___
 
@@ -3082,7 +3082,7 @@ Transform.push
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:438
+node_modules/@types/node/stream.d.ts:407
 
 ___
 
@@ -3094,6 +3094,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -3137,7 +3138,7 @@ Transform.rawListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -3238,7 +3239,7 @@ Transform.read
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:235
+node_modules/@types/node/stream.d.ts:204
 
 ___
 
@@ -3285,7 +3286,7 @@ Transform.reduce
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:587
+node_modules/@types/node/stream.d.ts:556
 
 ▸ **reduce**<`T`\>(`fn`, `initial`, `options?`): `Promise`<`T`\>
 
@@ -3313,7 +3314,7 @@ Transform.reduce
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:592
+node_modules/@types/node/stream.d.ts:561
 
 ___
 
@@ -3349,7 +3350,7 @@ Transform.removeAllListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -3374,7 +3375,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1200
+node_modules/@types/node/stream.d.ts:1232
 
 ▸ **removeListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -3395,7 +3396,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1201
+node_modules/@types/node/stream.d.ts:1233
 
 ▸ **removeListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -3416,7 +3417,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1202
+node_modules/@types/node/stream.d.ts:1234
 
 ▸ **removeListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -3437,7 +3438,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1203
+node_modules/@types/node/stream.d.ts:1235
 
 ▸ **removeListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -3458,7 +3459,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1204
+node_modules/@types/node/stream.d.ts:1236
 
 ▸ **removeListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -3479,7 +3480,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1205
+node_modules/@types/node/stream.d.ts:1237
 
 ▸ **removeListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -3500,7 +3501,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1206
+node_modules/@types/node/stream.d.ts:1238
 
 ▸ **removeListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -3521,7 +3522,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1207
+node_modules/@types/node/stream.d.ts:1239
 
 ▸ **removeListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -3542,7 +3543,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1208
+node_modules/@types/node/stream.d.ts:1240
 
 ▸ **removeListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -3563,7 +3564,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1209
+node_modules/@types/node/stream.d.ts:1241
 
 ▸ **removeListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -3584,7 +3585,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1210
+node_modules/@types/node/stream.d.ts:1242
 
 ▸ **removeListener**(`event`, `listener`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
@@ -3605,7 +3606,7 @@ Transform.removeListener
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1211
+node_modules/@types/node/stream.d.ts:1243
 
 ___
 
@@ -3643,7 +3644,7 @@ Transform.resume
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:301
+node_modules/@types/node/stream.d.ts:270
 
 ___
 
@@ -3667,7 +3668,7 @@ Transform.setDefaultEncoding
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1107
+node_modules/@types/node/stream.d.ts:1115
 
 ___
 
@@ -3716,7 +3717,7 @@ Transform.setEncoding
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:260
+node_modules/@types/node/stream.d.ts:229
 
 ___
 
@@ -3751,7 +3752,7 @@ Transform.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -3787,7 +3788,7 @@ Transform.some
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:506
+node_modules/@types/node/stream.d.ts:475
 
 ___
 
@@ -3820,7 +3821,7 @@ Transform.take
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:565
+node_modules/@types/node/stream.d.ts:534
 
 ___
 
@@ -3855,7 +3856,7 @@ Transform.toArray
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:496
+node_modules/@types/node/stream.d.ts:465
 
 ___
 
@@ -3873,7 +3874,7 @@ Transform.uncork
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1112
+node_modules/@types/node/stream.d.ts:1120
 
 ___
 
@@ -3890,7 +3891,7 @@ If the `destination` is specified, but no pipe is set up for it, then
 the method does nothing.
 
 ```js
-const fs = require('fs');
+const fs = require('node:fs');
 const readable = getReadableStreamSomehow();
 const writable = fs.createWriteStream('file.txt');
 // All the data from readable goes into 'file.txt',
@@ -3924,7 +3925,7 @@ Transform.unpipe
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:345
+node_modules/@types/node/stream.d.ts:314
 
 ___
 
@@ -3952,7 +3953,7 @@ use of a `Transform` stream instead. See the `API for stream implementers` secti
 // Pull off a header delimited by \n\n.
 // Use unshift() if we get too much.
 // Call the callback with (error, header, stream).
-const { StringDecoder } = require('string_decoder');
+const { StringDecoder } = require('node:string_decoder');
 function parseHeader(stream, callback) {
   stream.on('error', callback);
   stream.on('readable', onReadable);
@@ -3996,7 +3997,7 @@ process of performing a read.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `chunk` | `any` | Chunk of data to unshift onto the read queue. For streams not operating in object mode, `chunk` must be a string, `Buffer`, `Uint8Array` or `null`. For object mode streams, `chunk` may be any JavaScript value. |
+| `chunk` | `any` | Chunk of data to unshift onto the read queue. For streams not operating in object mode, `chunk` must be a string, `Buffer`, `Uint8Array`, or `null`. For object mode streams, `chunk` may be any JavaScript value. |
 | `encoding?` | `BufferEncoding` | Encoding of string chunks. Must be a valid `Buffer` encoding, such as `'utf8'` or `'ascii'`. |
 
 #### Returns
@@ -4013,7 +4014,7 @@ Transform.unshift
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:411
+node_modules/@types/node/stream.d.ts:380
 
 ___
 
@@ -4021,8 +4022,8 @@ ___
 
 ▸ **wrap**(`stream`): [`SourceTransform`](sourceDestination.SourceTransform.md)
 
-Prior to Node.js 0.10, streams did not implement the entire `stream` module API
-as it is currently defined. (See `Compatibility` for more information.)
+Prior to Node.js 0.10, streams did not implement the entire `node:stream`module API as it is currently defined. (See `Compatibility` for more
+information.)
 
 When using an older Node.js library that emits `'data'` events and has a [pause](sourceDestination.SourceTransform.md#pause) method that is advisory only, the`readable.wrap()` method can be used to create a `Readable`
 stream that uses
@@ -4034,7 +4035,7 @@ libraries.
 
 ```js
 const { OldReader } = require('./old-api-module.js');
-const { Readable } = require('stream');
+const { Readable } = require('node:stream');
 const oreader = new OldReader();
 const myReader = new Readable().wrap(oreader);
 
@@ -4063,7 +4064,7 @@ Transform.wrap
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:437
+node_modules/@types/node/stream.d.ts:406
 
 ___
 
@@ -4089,7 +4090,7 @@ Transform.write
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1105
+node_modules/@types/node/stream.d.ts:1113
 
 ▸ **write**(`chunk`, `cb?`): `boolean`
 
@@ -4110,4 +4111,4 @@ Transform.write
 
 #### Defined in
 
-node_modules/@types/node/stream.d.ts:1106
+node_modules/@types/node/stream.d.ts:1114

--- a/doc/interfaces/sparseStream.Block.md
+++ b/doc/interfaces/sparseStream.Block.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[lib/sparse-stream/shared.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/shared.ts#L29)
+[lib/sparse-stream/shared.ts:29](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/shared.ts#L29)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/shared.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/shared.ts#L28)
+[lib/sparse-stream/shared.ts:28](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/shared.ts#L28)

--- a/doc/interfaces/sparseStream.BlocksWithChecksum.md
+++ b/doc/interfaces/sparseStream.BlocksWithChecksum.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[lib/sparse-stream/shared.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/shared.ts#L35)
+[lib/sparse-stream/shared.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/shared.ts#L35)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/shared.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/shared.ts#L34)
+[lib/sparse-stream/shared.ts:34](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/shared.ts#L34)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/shared.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/shared.ts#L33)
+[lib/sparse-stream/shared.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/shared.ts#L33)

--- a/doc/interfaces/sparseStream.SparseReadable.md
+++ b/doc/interfaces/sparseStream.SparseReadable.md
@@ -60,7 +60,7 @@
 
 #### Defined in
 
-[lib/sparse-stream/shared.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/shared.ts#L44)
+[lib/sparse-stream/shared.ts:44](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/shared.ts#L44)
 
 ___
 
@@ -74,7 +74,7 @@ NodeJS.ReadableStream.readable
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:230
+node_modules/@types/node/globals.d.ts:273
 
 ## Methods
 
@@ -92,13 +92,13 @@ NodeJS.ReadableStream.[asyncIterator]
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:240
+node_modules/@types/node/globals.d.ts:283
 
 ___
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -118,7 +118,7 @@ NodeJS.ReadableStream.[captureRejectionSymbol]
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:470
+node_modules/@types/node/events.d.ts:540
 
 ___
 
@@ -149,7 +149,7 @@ NodeJS.ReadableStream.addListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -163,7 +163,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -216,7 +216,7 @@ NodeJS.ReadableStream.emit
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -228,7 +228,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -254,7 +255,7 @@ NodeJS.ReadableStream.eventNames
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -279,7 +280,7 @@ NodeJS.ReadableStream.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -297,7 +298,7 @@ NodeJS.ReadableStream.isPaused
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:235
+node_modules/@types/node/globals.d.ts:278
 
 ___
 
@@ -305,10 +306,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -331,7 +331,7 @@ NodeJS.ReadableStream.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -369,7 +369,7 @@ NodeJS.ReadableStream.listeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -400,7 +400,7 @@ NodeJS.ReadableStream.off
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -425,6 +425,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -455,7 +456,7 @@ NodeJS.ReadableStream.on
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -478,6 +479,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -508,7 +510,7 @@ NodeJS.ReadableStream.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -526,7 +528,7 @@ NodeJS.ReadableStream.pause
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:233
+node_modules/@types/node/globals.d.ts:276
 
 ___
 
@@ -558,7 +560,7 @@ NodeJS.ReadableStream.pipe
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:236
+node_modules/@types/node/globals.d.ts:279
 
 ___
 
@@ -600,7 +602,7 @@ NodeJS.ReadableStream.prependListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -640,7 +642,7 @@ NodeJS.ReadableStream.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -660,7 +662,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/shared.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/shared.ts#L45)
+[lib/sparse-stream/shared.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/shared.ts#L45)
 
 ___
 
@@ -672,6 +674,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -715,7 +718,7 @@ NodeJS.ReadableStream.rawListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -739,7 +742,7 @@ NodeJS.ReadableStream.read
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:231
+node_modules/@types/node/globals.d.ts:274
 
 ___
 
@@ -775,7 +778,7 @@ NodeJS.ReadableStream.removeAllListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -804,6 +807,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -844,6 +849,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -881,7 +887,7 @@ NodeJS.ReadableStream.removeListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -899,7 +905,7 @@ NodeJS.ReadableStream.resume
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:234
+node_modules/@types/node/globals.d.ts:277
 
 ___
 
@@ -923,7 +929,7 @@ NodeJS.ReadableStream.setEncoding
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:232
+node_modules/@types/node/globals.d.ts:275
 
 ___
 
@@ -958,7 +964,7 @@ NodeJS.ReadableStream.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -982,7 +988,7 @@ NodeJS.ReadableStream.unpipe
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:237
+node_modules/@types/node/globals.d.ts:280
 
 ___
 
@@ -1007,7 +1013,7 @@ NodeJS.ReadableStream.unshift
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:238
+node_modules/@types/node/globals.d.ts:281
 
 ___
 
@@ -1031,4 +1037,4 @@ NodeJS.ReadableStream.wrap
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:239
+node_modules/@types/node/globals.d.ts:282

--- a/doc/interfaces/sparseStream.SparseReaderState.md
+++ b/doc/interfaces/sparseStream.SparseReaderState.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[lib/sparse-stream/shared.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/shared.ts#L70)
+[lib/sparse-stream/shared.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/shared.ts#L70)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/shared.ts:72](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/shared.ts#L72)
+[lib/sparse-stream/shared.ts:72](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/shared.ts#L72)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/shared.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/shared.ts#L71)
+[lib/sparse-stream/shared.ts:71](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/shared.ts#L71)

--- a/doc/interfaces/sparseStream.SparseStreamChunk.md
+++ b/doc/interfaces/sparseStream.SparseStreamChunk.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[lib/sparse-stream/shared.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/shared.ts#L39)
+[lib/sparse-stream/shared.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/shared.ts#L39)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/shared.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/shared.ts#L40)
+[lib/sparse-stream/shared.ts:40](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/shared.ts#L40)

--- a/doc/interfaces/sparseStream.SparseWritable.md
+++ b/doc/interfaces/sparseStream.SparseWritable.md
@@ -54,13 +54,13 @@ NodeJS.WritableStream.writable
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:244
+node_modules/@types/node/globals.d.ts:287
 
 ## Methods
 
 ### [captureRejectionSymbol]
 
-▸ `Optional` **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
+▸ **[captureRejectionSymbol]**(`error`, `event`, `...args`): `void`
 
 #### Parameters
 
@@ -80,7 +80,7 @@ NodeJS.WritableStream.[captureRejectionSymbol]
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:470
+node_modules/@types/node/events.d.ts:540
 
 ___
 
@@ -102,7 +102,7 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/shared.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/shared.ts#L49)
+[lib/sparse-stream/shared.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/shared.ts#L49)
 
 ___
 
@@ -133,7 +133,7 @@ NodeJS.WritableStream.addListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:475
+node_modules/@types/node/events.d.ts:545
 
 ___
 
@@ -147,7 +147,7 @@ to each.
 Returns `true` if the event had listeners, `false` otherwise.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
 const myEmitter = new EventEmitter();
 
 // First listener
@@ -200,7 +200,7 @@ NodeJS.WritableStream.emit
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:731
+node_modules/@types/node/events.d.ts:807
 
 ___
 
@@ -224,7 +224,7 @@ NodeJS.WritableStream.end
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:247
+node_modules/@types/node/globals.d.ts:290
 
 ▸ **end**(`data`, `cb?`): [`SparseWritable`](sparseStream.SparseWritable.md)
 
@@ -245,7 +245,7 @@ NodeJS.WritableStream.end
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:248
+node_modules/@types/node/globals.d.ts:291
 
 ▸ **end**(`str`, `encoding?`, `cb?`): [`SparseWritable`](sparseStream.SparseWritable.md)
 
@@ -267,7 +267,7 @@ NodeJS.WritableStream.end
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:249
+node_modules/@types/node/globals.d.ts:292
 
 ___
 
@@ -279,7 +279,8 @@ Returns an array listing the events for which the emitter has registered
 listeners. The values in the array are strings or `Symbol`s.
 
 ```js
-const EventEmitter = require('events');
+import { EventEmitter } from 'node:events';
+
 const myEE = new EventEmitter();
 myEE.on('foo', () => {});
 myEE.on('bar', () => {});
@@ -305,7 +306,7 @@ NodeJS.WritableStream.eventNames
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:794
+node_modules/@types/node/events.d.ts:870
 
 ___
 
@@ -330,7 +331,7 @@ NodeJS.WritableStream.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:647
+node_modules/@types/node/events.d.ts:722
 
 ___
 
@@ -338,10 +339,9 @@ ___
 
 ▸ **listenerCount**(`eventName`, `listener?`): `number`
 
-Returns the number of listeners listening to the event named `eventName`.
-
-If `listener` is provided, it will return how many times the listener
-is found in the list of the listeners of the event.
+Returns the number of listeners listening for the event named `eventName`.
+If `listener` is provided, it will return how many times the listener is found
+in the list of the listeners of the event.
 
 #### Parameters
 
@@ -364,7 +364,7 @@ NodeJS.WritableStream.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:741
+node_modules/@types/node/events.d.ts:816
 
 ___
 
@@ -402,7 +402,7 @@ NodeJS.WritableStream.listeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:660
+node_modules/@types/node/events.d.ts:735
 
 ___
 
@@ -433,7 +433,7 @@ NodeJS.WritableStream.off
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:620
+node_modules/@types/node/events.d.ts:695
 
 ___
 
@@ -458,6 +458,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.on('foo', () => console.log('a'));
 myEE.prependListener('foo', () => console.log('b'));
@@ -488,7 +489,7 @@ NodeJS.WritableStream.on
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:506
+node_modules/@types/node/events.d.ts:577
 
 ___
 
@@ -511,6 +512,7 @@ By default, event listeners are invoked in the order they are added. The`emitter
 event listener to the beginning of the listeners array.
 
 ```js
+import { EventEmitter } from 'node:events';
 const myEE = new EventEmitter();
 myEE.once('foo', () => console.log('a'));
 myEE.prependOnceListener('foo', () => console.log('b'));
@@ -541,7 +543,7 @@ NodeJS.WritableStream.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:535
+node_modules/@types/node/events.d.ts:607
 
 ___
 
@@ -583,7 +585,7 @@ NodeJS.WritableStream.prependListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:759
+node_modules/@types/node/events.d.ts:834
 
 ___
 
@@ -623,7 +625,7 @@ NodeJS.WritableStream.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:775
+node_modules/@types/node/events.d.ts:850
 
 ___
 
@@ -635,6 +637,7 @@ Returns a copy of the array of listeners for the event named `eventName`,
 including any wrappers (such as those created by `.once()`).
 
 ```js
+import { EventEmitter } from 'node:events';
 const emitter = new EventEmitter();
 emitter.once('log', () => console.log('log once'));
 
@@ -678,7 +681,7 @@ NodeJS.WritableStream.rawListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:690
+node_modules/@types/node/events.d.ts:766
 
 ___
 
@@ -714,7 +717,7 @@ NodeJS.WritableStream.removeAllListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:631
+node_modules/@types/node/events.d.ts:706
 
 ___
 
@@ -743,6 +746,8 @@ time of emitting are called in order. This implies that any`removeListener()` or
 will not remove them from`emit()` in progress. Subsequent events behave as expected.
 
 ```js
+import { EventEmitter } from 'node:events';
+class MyEmitter extends EventEmitter {}
 const myEmitter = new MyEmitter();
 
 const callbackA = () => {
@@ -783,6 +788,7 @@ event (as in the example below), `removeListener()` will remove the most
 recently added instance. In the example the `once('ping')`listener is removed:
 
 ```js
+import { EventEmitter } from 'node:events';
 const ee = new EventEmitter();
 
 function pong() {
@@ -820,7 +826,7 @@ NodeJS.WritableStream.removeListener
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:615
+node_modules/@types/node/events.d.ts:690
 
 ___
 
@@ -855,7 +861,7 @@ NodeJS.WritableStream.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:641
+node_modules/@types/node/events.d.ts:716
 
 ___
 
@@ -880,7 +886,7 @@ NodeJS.WritableStream.write
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:245
+node_modules/@types/node/globals.d.ts:288
 
 ▸ **write**(`str`, `encoding?`, `cb?`): `boolean`
 
@@ -902,4 +908,4 @@ NodeJS.WritableStream.write
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:246
+node_modules/@types/node/globals.d.ts:289

--- a/doc/interfaces/tmp.TmpFileOptions.md
+++ b/doc/interfaces/tmp.TmpFileOptions.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[lib/tmp.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/tmp.ts#L79)
+[lib/tmp.ts:79](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/tmp.ts#L79)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[lib/tmp.ts:81](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/tmp.ts#L81)
+[lib/tmp.ts:81](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/tmp.ts#L81)
 
 ___
 
@@ -40,4 +40,4 @@ ___
 
 #### Defined in
 
-[lib/tmp.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/tmp.ts#L80)
+[lib/tmp.ts:80](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/tmp.ts#L80)

--- a/doc/interfaces/tmp.TmpFileResult.md
+++ b/doc/interfaces/tmp.TmpFileResult.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[lib/tmp.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/tmp.ts#L36)
+[lib/tmp.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/tmp.ts#L36)
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 #### Defined in
 
-[lib/tmp.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/tmp.ts#L35)
+[lib/tmp.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/tmp.ts#L35)

--- a/doc/modules/constants.md
+++ b/doc/modules/constants.md
@@ -22,7 +22,7 @@
 
 #### Defined in
 
-[lib/constants.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/constants.ts#L20)
+[lib/constants.ts:20](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/constants.ts#L20)
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 #### Defined in
 
-[lib/constants.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/constants.ts#L24)
+[lib/constants.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/constants.ts#L24)
 
 ___
 
@@ -42,7 +42,7 @@ ___
 
 #### Defined in
 
-[lib/constants.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/constants.ts#L21)
+[lib/constants.ts:21](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/constants.ts#L21)
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 #### Defined in
 
-[lib/constants.ts:17](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/constants.ts#L17)
+[lib/constants.ts:17](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/constants.ts#L17)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[lib/constants.ts:19](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/constants.ts#L19)
+[lib/constants.ts:19](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/constants.ts#L19)
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 #### Defined in
 
-[lib/constants.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/constants.ts#L18)
+[lib/constants.ts:18](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/constants.ts#L18)
 
 ___
 
@@ -82,4 +82,4 @@ ___
 
 #### Defined in
 
-[lib/constants.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/constants.ts#L23)
+[lib/constants.ts:23](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/constants.ts#L23)

--- a/doc/modules/errors.md
+++ b/doc/modules/errors.md
@@ -41,4 +41,4 @@
 
 #### Defined in
 
-[lib/errors.ts:77](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/errors.ts#L77)
+[lib/errors.ts:81](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/errors.ts#L81)

--- a/doc/modules/migrator.md
+++ b/doc/modules/migrator.md
@@ -67,4 +67,4 @@ original run. A task may be omitted by listing it in the options.omitTasks param
 
 #### Defined in
 
-[lib/migrator/index.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/migrator/index.ts#L147)
+[lib/migrator/index.ts:147](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/migrator/index.ts#L147)

--- a/doc/modules/multiWrite.md
+++ b/doc/modules/multiWrite.md
@@ -47,7 +47,7 @@
 
 #### Defined in
 
-[lib/multi-write.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L70)
+[lib/multi-write.ts:70](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L70)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 #### Defined in
 
-[lib/multi-write.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L75)
+[lib/multi-write.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L75)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[lib/multi-write.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L43)
+[lib/multi-write.ts:43](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L43)
 
 ## Variables
 
@@ -91,7 +91,7 @@ ___
 
 #### Defined in
 
-[lib/multi-write.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L45)
+[lib/multi-write.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L45)
 
 ## Functions
 
@@ -122,7 +122,7 @@ ___
 
 #### Defined in
 
-[lib/multi-write.ts:109](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L109)
+[lib/multi-write.ts:109](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L109)
 
 ___
 
@@ -148,4 +148,4 @@ ___
 
 #### Defined in
 
-[lib/multi-write.ts:276](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/multi-write.ts#L276)
+[lib/multi-write.ts:286](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/multi-write.ts#L286)

--- a/doc/modules/scanner.adapters.md
+++ b/doc/modules/scanner.adapters.md
@@ -30,4 +30,4 @@
 
 #### Defined in
 
-[lib/scanner/adapters/driverless.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/scanner/adapters/driverless.ts#L104)
+[lib/scanner/adapters/driverless.ts:104](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/scanner/adapters/driverless.ts#L104)

--- a/doc/modules/sourceDestination.md
+++ b/doc/modules/sourceDestination.md
@@ -91,7 +91,7 @@
 
 #### Defined in
 
-[lib/source-destination/configured-source/configured-source.ts:45](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/configured-source/configured-source.ts#L45)
+[lib/source-destination/configured-source/configured-source.ts:49](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/configured-source/configured-source.ts#L49)
 
 ___
 
@@ -107,7 +107,7 @@ ___
 
 #### Type declaration
 
-• (`...args`)
+• (`...args`): `T`
 
 ##### Parameters
 
@@ -115,9 +115,13 @@ ___
 | :------ | :------ |
 | `...args` | `any`[] |
 
+##### Returns
+
+`T`
+
 #### Defined in
 
-[lib/source-destination/progress.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/progress.ts#L24)
+[lib/source-destination/progress.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/progress.ts#L24)
 
 ___
 
@@ -127,7 +131,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/balena-s3-compressed-source.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/balena-s3-compressed-source.ts#L36)
+[lib/source-destination/balena-s3-compressed-source.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/balena-s3-compressed-source.ts#L36)
 
 ## Variables
 
@@ -137,7 +141,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:95](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L95)
+[lib/source-destination/source-destination.ts:95](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L95)
 
 ___
 
@@ -147,7 +151,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/progress.ts:113](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/progress.ts#L113)
+[lib/source-destination/progress.ts:119](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/progress.ts#L119)
 
 ___
 
@@ -157,7 +161,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/file.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/file.ts#L36)
+[lib/source-destination/file.ts:36](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/file.ts#L36)
 
 ## Functions
 
@@ -171,7 +175,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/source-destination.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/source-destination.ts#L101)
+[lib/source-destination/source-destination.ts:101](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/source-destination.ts#L101)
 
 ___
 
@@ -191,7 +195,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L35)
+[lib/source-destination/compressed-source.ts:35](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L35)
 
 ___
 
@@ -211,7 +215,7 @@ stream is SourceTransform
 
 #### Defined in
 
-[lib/source-destination/compressed-source.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/compressed-source.ts#L31)
+[lib/source-destination/compressed-source.ts:31](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/compressed-source.ts#L31)
 
 ___
 
@@ -240,7 +244,7 @@ ___
 
 #### Defined in
 
-[lib/source-destination/progress.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/progress.ts#L33)
+[lib/source-destination/progress.ts:33](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/progress.ts#L33)
 
 ___
 
@@ -260,4 +264,4 @@ ___
 
 #### Defined in
 
-[lib/source-destination/zip.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/source-destination/zip.ts#L62)
+[lib/source-destination/zip.ts:62](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/source-destination/zip.ts#L62)

--- a/doc/modules/sparseStream.md
+++ b/doc/modules/sparseStream.md
@@ -40,7 +40,7 @@
 
 #### Defined in
 
-[lib/sparse-stream/shared.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/shared.ts#L25)
+[lib/sparse-stream/shared.ts:25](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/shared.ts#L25)
 
 ## Variables
 
@@ -50,7 +50,7 @@
 
 #### Defined in
 
-[lib/sparse-stream/sparse-write-stream.ts:137](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/sparse-write-stream.ts#L137)
+[lib/sparse-stream/sparse-write-stream.ts:137](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/sparse-write-stream.ts#L137)
 
 ## Functions
 
@@ -70,7 +70,7 @@
 
 #### Defined in
 
-[lib/sparse-stream/shared.ts:117](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/shared.ts#L117)
+[lib/sparse-stream/shared.ts:117](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/shared.ts#L117)
 
 ___
 
@@ -92,4 +92,4 @@ ___
 
 #### Defined in
 
-[lib/sparse-stream/shared.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/sparse-stream/shared.ts#L75)
+[lib/sparse-stream/shared.ts:75](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/sparse-stream/shared.ts#L75)

--- a/doc/modules/tmp.md
+++ b/doc/modules/tmp.md
@@ -35,7 +35,7 @@
 
 #### Defined in
 
-[lib/tmp.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/tmp.ts#L39)
+[lib/tmp.ts:39](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/tmp.ts#L39)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[lib/tmp.ts:139](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/tmp.ts#L139)
+[lib/tmp.ts:139](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/tmp.ts#L139)
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 #### Defined in
 
-[lib/tmp.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/tmp.ts#L84)
+[lib/tmp.ts:84](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/tmp.ts#L84)
 
 ___
 
@@ -96,4 +96,4 @@ ___
 
 #### Defined in
 
-[lib/tmp.ts:117](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/tmp.ts#L117)
+[lib/tmp.ts:117](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/tmp.ts#L117)

--- a/doc/modules/utils.md
+++ b/doc/modules/utils.md
@@ -47,7 +47,7 @@
 
 #### Defined in
 
-[lib/utils.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/utils.ts#L102)
+[lib/utils.ts:102](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/utils.ts#L102)
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 #### Defined in
 
-[lib/utils.ts:128](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/utils.ts#L128)
+[lib/utils.ts:128](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/utils.ts#L128)
 
 ___
 
@@ -94,7 +94,7 @@ ___
 
 #### Defined in
 
-[lib/utils.ts:94](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/utils.ts#L94)
+[lib/utils.ts:94](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/utils.ts#L94)
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 #### Defined in
 
-[lib/utils.ts:168](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/utils.ts#L168)
+[lib/utils.ts:168](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/utils.ts#L168)
 
 ___
 
@@ -146,7 +146,7 @@ ___
 
 #### Defined in
 
-[lib/utils.ts:114](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/utils.ts#L114)
+[lib/utils.ts:114](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/utils.ts#L114)
 
 ___
 
@@ -173,7 +173,7 @@ ___
 
 #### Defined in
 
-[lib/utils.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/utils.ts#L150)
+[lib/utils.ts:150](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/utils.ts#L150)
 
 ___
 
@@ -200,7 +200,7 @@ ___
 
 #### Defined in
 
-[lib/utils.ts:134](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/utils.ts#L134)
+[lib/utils.ts:134](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/utils.ts#L134)
 
 ___
 
@@ -232,7 +232,7 @@ ___
 
 #### Defined in
 
-[lib/utils.ts:177](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/utils.ts#L177)
+[lib/utils.ts:177](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/utils.ts#L177)
 
 ___
 
@@ -252,7 +252,7 @@ ___
 
 #### Defined in
 
-[lib/utils.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/utils.ts#L53)
+[lib/utils.ts:53](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/utils.ts#L53)
 
 ___
 
@@ -272,7 +272,7 @@ ___
 
 #### Defined in
 
-[lib/utils.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/utils.ts#L24)
+[lib/utils.ts:24](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/utils.ts#L24)
 
 ___
 
@@ -299,4 +299,4 @@ ___
 
 #### Defined in
 
-[lib/utils.ts:157](https://github.com/balena-io-modules/etcher-sdk/blob/a70e73b/lib/utils.ts#L157)
+[lib/utils.ts:157](https://github.com/balena-io-modules/etcher-sdk/blob/2636458/lib/utils.ts#L157)

--- a/lib/source-destination/configured-source/operations/configure.ts
+++ b/lib/source-destination/configured-source/operations/configure.ts
@@ -122,8 +122,12 @@ export async function configure(
 
 	await interact(disk, partition, async (fs) => {
 		const writeFileAsync = promisify(fs.writeFile);
+		const utimesAsync = promisify(fs.utimes);
 		const mkdirAsync = promisify(fs.mkdir);
-		await writeFileAsync('/config.json', JSON.stringify(configJSON));
+		const path = '/config.json';
+		await writeFileAsync(path, JSON.stringify(configJSON));
+		// Set the mtime and atime to 0 so that the checksum for two images with the same config.json will match, rather than varying based on generation time
+		await utimesAsync(path, 0, 0);
 		try {
 			await mkdirAsync('/system-connections');
 		} catch {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "@types/cli-spinner": "^0.2.0",
         "@types/crc": "^3.4.0",
         "@types/debug": "4.1.12",
-        "@types/file-type": "^10.9.1",
         "@types/lodash": "^4.14.108",
         "@types/mocha": "^10.0.3",
         "@types/node": "^20.0.0",
@@ -1900,16 +1899,6 @@
       "dev": true,
       "dependencies": {
         "@types/ms": "*"
-      }
-    },
-    "node_modules/@types/file-type": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/@types/file-type/-/file-type-10.9.1.tgz",
-      "integrity": "sha512-oq0fy8Jqj19HofanFsZ56o5anMDUQtFO9B3wfLqM9o42RyCe1WT+wRbSvRbL2l8ARZXNaJturHk0b442+0yi+g==",
-      "deprecated": "This is a stub types definition. file-type provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "file-type": "*"
       }
     },
     "node_modules/@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,8 @@
   "scripts": {
     "flowzone-preinstall": "sudo apt-get update && sudo apt-get install -y libudev-dev",
     "test": "npm run lint && mocha -r ts-node/register tests/**/*.spec.ts",
-    "prettier": "balena-lint --fix lib typings examples tests",
     "lint": "balena-lint lib typings examples",
-    "lint:fix": "balena-lint --fix lib typings examples",
+    "lint-fix": "balena-lint --fix lib typings examples tests",
     "build": "tsc",
     "doc": "typedoc --readme none --plugin typedoc-plugin-markdown --out doc lib && npm run sed",
     "sed": "sed -i'.bak' 's|'$(pwd)'||g' $(find doc -type f) && rimraf doc/*.bak doc/**/*.bak",
@@ -85,7 +84,6 @@
     "@types/cli-spinner": "^0.2.0",
     "@types/crc": "^3.4.0",
     "@types/debug": "4.1.12",
-    "@types/file-type": "^10.9.1",
     "@types/lodash": "^4.14.108",
     "@types/mocha": "^10.0.3",
     "@types/node": "^20.0.0",


### PR DESCRIPTION
Previously the timestamp was changing each time which meant the checksum would be different every time even if the rest of the contents were identical. Changing this to a fixed timestamp avoids that change such that only the contents matter.

Change-type: patch