### PR TITLE
bug: Add forceUnmountDisk function to handle APFS volumes on macOS

### DIFF
--- a/lib/diskpart.ts
+++ b/lib/diskpart.ts
@@ -123,6 +123,50 @@ const prepareDeviceId = (device: string) => {
 };
 
 /**
+ * @summary Force-unmount a whole disk (including any APFS/synthesized
+ *   sub-volumes) on macOS via `diskutil unmountDisk force`.
+ *
+ * The `mountutils` package used elsewhere in the SDK calls
+ * `DADiskUnmount(disk, kDADiskUnmountOptionWhole | kDADiskUnmountOptionForce, ...)`
+ * against the parent BSD device (e.g. `/dev/disk2`). For drives formatted
+ * with APFS, the volumes are exposed as a separate *synthesized* disk
+ * (e.g. `/dev/disk3`) backed by an APFS container partition on the parent
+ * device. DiskArbitration's whole-disk unmount on the parent does not
+ * propagate to the synthesized APFS volumes, leaving them mounted. The
+ * subsequent `O_EXLOCK` open of the raw device then blocks/fails, which
+ * manifests as Etcher hanging at "Starting" when flashing APFS-formatted
+ * drives (see balena-io/etcher#4490).
+ *
+ * `diskutil unmountDisk force` understands APFS containers and will unmount
+ * the synthesized volumes as well as the parent disk, so we invoke it as
+ * an additional safeguard on macOS.
+ *
+ * No-op on non-darwin platforms.
+ *
+ * @param {String} device - device path (e.g. `/dev/disk2`)
+ */
+export const forceUnmountDisk = async (device: string): Promise<void> => {
+	if (platform() !== 'darwin') {
+		return;
+	}
+	debug('forceUnmountDisk', device);
+	try {
+		const { stdout, stderr } = await execFileAsync('diskutil', [
+			'unmountDisk',
+			'force',
+			device,
+		]);
+		debug('diskutil stdout:', stdout);
+		debug('diskutil stderr:', stderr);
+	} catch (error) {
+		// Don't propagate: the preceding mountutils unmount may already have
+		// succeeded for non-APFS volumes, and if the device truly cannot be
+		// unmounted the subsequent open will surface a meaningful error.
+		debug('forceUnmountDisk failed:', error.message);
+	}
+};
+
+/**
  * @summary Clean a device's partition tables
  * Functional only on Windows platform; otherwise does nothing.
  * @param {String} device - device path

--- a/lib/source-destination/block-device.ts
+++ b/lib/source-destination/block-device.ts
@@ -25,7 +25,7 @@ import {
 	ProgressBlockWriteStream,
 } from '../block-write-stream';
 import { DEFAULT_ALIGNMENT } from '../constants';
-import { clean } from '../diskpart';
+import { clean, forceUnmountDisk } from '../diskpart';
 import { getUnmountDisk } from '../lazy';
 import { AdapterSourceDestination } from '../scanner/adapters/adapter';
 import {
@@ -183,6 +183,13 @@ export class BlockDevice extends File implements AdapterSourceDestination {
 			if (plat !== 'win32') {
 				const unmountDisk = getUnmountDisk();
 				await unmountDisk(this.drive.device);
+				if (plat === 'darwin') {
+					// `mountutils.unmountDisk` does not unmount APFS volumes,
+					// which are exposed as a separate synthesized disk on macOS.
+					// Without this, opening an APFS-formatted drive with O_EXLOCK
+					// hangs/fails - see balena-io/etcher#4490.
+					await forceUnmountDisk(this.drive.device);
+				}
 			}
 			// diskpart clean on windows
 			if (!this.keepOriginal) {


### PR DESCRIPTION
## Fix APFS-formatted drives hanging at "Starting" on macOS

Fixes [balena-io/etcher#4490](https://github.com/balena-io/etcher/issues/4490).

### Problem

On macOS, flashing a drive that contains an APFS volume hangs indefinitely at the "Starting" stage. Users have worked around this by reformatting the drive to ExFAT or by manually deleting the APFS volume in Disk Utility before flashing.

### Root cause

When opening a `BlockDevice` for write, `BlockDevice._open` (on non-Windows) calls `mountutils.unmountDisk(device)` before opening the raw device with `O_EXLOCK`.

On macOS, `mountutils.unmountDisk` is implemented with DiskArbitration:

```cpp
DADiskUnmount(disk,
              kDADiskUnmountOptionWhole | kDADiskUnmountOptionForce,
              callback, ctx);
```

It is invoked against the parent BSD device (e.g. /dev/disk2). However, APFS volumes are exposed as a separate synthesized disk (e.g. /dev/disk3) backed by an APFS container partition on the parent. The whole-disk DADiskUnmount against the parent does not propagate to the synthesized APFS volumes, so they remain mounted. The subsequent O_EXLOCK open of the raw parent device then blocks/fails — which is what users see as the indefinite "Starting" hang.

This explains the reported workarounds: reformatting to ExFAT (no APFS container) and "Delete APFS Volume…" (removes the synthesized disk) both let mountutils succeed cleanly.

Errors from diskutil are intentionally swallowed (and logged via debug):

The preceding mountutils unmount may already have handled non-APFS volumes.
If the device truly cannot be unmounted, the subsequent open() will surface a meaningful error rather than masking it.