### PR TITLE
Update zip-part-steam to add support for zip64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "file-disk": "^8.0.1",
         "file-type": "^16.0.0",
         "glob": "^10.3.10",
-        "gzip-stream": "^2.0.0",
+        "gzip-stream": "2.0.2-build-large-file-support-3b05fe923bd50846612f0954a840b06d7b07234a-1",
         "lzma-native": "^8.0.6",
         "minimatch": "^9.0.3",
         "mountutils": "^2.0.0",
@@ -37,7 +37,7 @@
         "unzip-stream": "^0.3.1",
         "xxhash-addon": "^2.0.1",
         "yauzl": "^2.9.2",
-        "zip-part-stream": "2.1.0-build-zip64-8c325703d28db3bf584aef1a1e280d5e56e7c6bf-1"
+        "zip-part-stream": "2.1.0-build-zip64-ba87af745a0d553bc611a835573c68edc3bd3fbf-1"
       },
       "devDependencies": {
         "@balena/lint": "^7.2.1",
@@ -4645,9 +4645,10 @@
       "dev": true
     },
     "node_modules/gzip-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/gzip-stream/-/gzip-stream-2.0.0.tgz",
-      "integrity": "sha512-Vf5SFUMy6NMJ0zyBHSdBnN8XfNvNBfW+0mnNdsnB65KhCxDY7G8BTTdKqgxuET/bxzHPa0us25I2z6Lqw/YsTg==",
+      "version": "2.0.2-build-large-file-support-3b05fe923bd50846612f0954a840b06d7b07234a-1",
+      "resolved": "https://registry.npmjs.org/gzip-stream/-/gzip-stream-2.0.2-build-large-file-support-3b05fe923bd50846612f0954a840b06d7b07234a-1.tgz",
+      "integrity": "sha512-ORU/Mz1vfubOmAleXpbAcOPEEOtry1wUaGGcNx5CjwUTMh+l7fA+ehZ4sbf+UuE1VnbMcfZtok+bRnbfYVrdLA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@balena/node-crc-utils": "^3.0.0",
         "combined-stream": "^1.0.8",
@@ -8290,9 +8291,9 @@
       }
     },
     "node_modules/zip-part-stream": {
-      "version": "2.1.0-build-zip64-8c325703d28db3bf584aef1a1e280d5e56e7c6bf-1",
-      "resolved": "https://registry.npmjs.org/zip-part-stream/-/zip-part-stream-2.1.0-build-zip64-8c325703d28db3bf584aef1a1e280d5e56e7c6bf-1.tgz",
-      "integrity": "sha512-05BuTB51xcdupT7HyLmPsrJqd26h5CFhWDZ4HfY2nceRr9T+qUhO9cZyZZdbMuB76JhQcANY5KM8/7UWgrqBtg==",
+      "version": "2.1.0-build-zip64-ba87af745a0d553bc611a835573c68edc3bd3fbf-1",
+      "resolved": "https://registry.npmjs.org/zip-part-stream/-/zip-part-stream-2.1.0-build-zip64-ba87af745a0d553bc611a835573c68edc3bd3fbf-1.tgz",
+      "integrity": "sha512-wYa9CMA7zo3kg9LGweHdWKI+fmtqk7ArMu+nO84/+TmBiTyE3Che25+zPAjAcw1V8sJ/tq/3Zt2vlZHN2XNQTg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@balena/node-crc-utils": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "unzip-stream": "^0.3.1",
         "xxhash-addon": "^2.0.1",
         "yauzl": "^2.9.2",
-        "zip-part-stream": "^2.0.0"
+        "zip-part-stream": "2.1.0-build-zip64-8c325703d28db3bf584aef1a1e280d5e56e7c6bf-1"
       },
       "devDependencies": {
         "@balena/lint": "^7.2.1",
@@ -8290,9 +8290,10 @@
       }
     },
     "node_modules/zip-part-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/zip-part-stream/-/zip-part-stream-2.0.0.tgz",
-      "integrity": "sha512-d2ZgYcCHH7q5aaZ6m/UKJQWsUT6FY7+IuOv0eIuVRUdyh5i6bxTo+aLB4dhGpdYsYx475XBsUvyOO4dBbqZGNw==",
+      "version": "2.1.0-build-zip64-8c325703d28db3bf584aef1a1e280d5e56e7c6bf-1",
+      "resolved": "https://registry.npmjs.org/zip-part-stream/-/zip-part-stream-2.1.0-build-zip64-8c325703d28db3bf584aef1a1e280d5e56e7c6bf-1.tgz",
+      "integrity": "sha512-05BuTB51xcdupT7HyLmPsrJqd26h5CFhWDZ4HfY2nceRr9T+qUhO9cZyZZdbMuB76JhQcANY5KM8/7UWgrqBtg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@balena/node-crc-utils": "^3.0.0",
         "combined-stream": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "unzip-stream": "^0.3.1",
     "xxhash-addon": "^2.0.1",
     "yauzl": "^2.9.2",
-    "zip-part-stream": "^2.0.0"
+    "zip-part-stream": "2.1.0-build-zip64-ba87af745a0d553bc611a835573c68edc3bd3fbf-1"
   },
   "optionalDependencies": {
     "winusb-driver-generator": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "file-disk": "^8.0.1",
     "file-type": "^16.0.0",
     "glob": "^10.3.10",
-    "gzip-stream": "^2.0.0",
+    "gzip-stream": "2.0.2-build-large-file-support-3b05fe923bd50846612f0954a840b06d7b07234a-1",
     "lzma-native": "^8.0.6",
     "minimatch": "^9.0.3",
     "mountutils": "^2.0.0",

--- a/tests/balena-s3-compressed-source.spec.ts
+++ b/tests/balena-s3-compressed-source.spec.ts
@@ -1,0 +1,283 @@
+import { execFile as execFileCb } from 'child_process';
+import { promisify } from 'util';
+const execFile = promisify(execFileCb);
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Readable, Writable } from 'stream';
+import { pipeline } from 'stream/promises';
+import { createGunzip } from 'zlib';
+import * as sinon from 'sinon';
+import * as unzip from 'unzip-stream';
+
+import { BalenaS3CompressedSource } from '../lib/source-destination/balena-s3-compressed-source';
+import { streamToBuffer } from '../lib/utils';
+import { countBytes, makeDeflatePart, sumImageJSONLenFields } from './utils';
+
+// ─── unit test fixtures ───────────────────────────────────────────────────────
+
+const BASE_OPTIONS = {
+	host: 'https://s3.example.com',
+	bucket: 'test-bucket',
+	deviceType: 'raspberrypi3',
+	buildId: '2.9.6+rev1.prod',
+};
+
+const DEVICE_TYPE_JSON = {
+	slug: 'raspberrypi3',
+	version: 1,
+	aliases: ['raspberrypi3'],
+	name: 'Raspberry Pi 3',
+	arch: 'armv7hf',
+	configuration: { config: { partition: 1 } },
+	yocto: {},
+};
+
+/**
+ * Stubs the private `download` method (for VERSION / VERSION_HOSTOS /
+ * image.json / device-type.json) and the private `getPartStream` method (for
+ * compressed part data) on a URLCompressedSource instance.
+ */
+function stubDownload(
+	source: BalenaS3CompressedSource,
+	imageJSON: object,
+	partFiles: Map<string, Buffer>,
+): sinon.SinonStub {
+	return sinon
+		.stub(source as any, 'download')
+		.callsFake(async (path: string) => {
+			switch (path) {
+				case 'VERSION':
+					return {
+						headers: { 'last-modified': 'Wed, 01 Jan 2025 00:00:00 GMT' },
+						data: '2.0.0',
+					};
+				case 'VERSION_HOSTOS':
+					return { headers: {}, data: '2.9.0' };
+				case 'image.json':
+					return { headers: {}, data: imageJSON };
+				case 'device-type.json':
+					return { headers: {}, data: DEVICE_TYPE_JSON };
+				default:
+					for (const [filename, buf] of partFiles) {
+						if (path === `compressed/${filename}`) {
+							return { data: Readable.from([buf]) };
+						}
+					}
+					throw new Error(`Unexpected download call: ${path}`);
+			}
+		});
+}
+
+// ─── unit tests ───────────────────────────────────────────────────────────────
+
+describe('BalenaS3CompressedSource', function () {
+	this.timeout(10000);
+
+	const PART_DATA = Buffer.alloc(512, 0xab);
+	let deflatePartMeta: { buf: Buffer; crc: number; len: number; zLen: number };
+
+	before(async () => {
+		deflatePartMeta = await makeDeflatePart(PART_DATA);
+	});
+
+	afterEach(() => sinon.restore());
+
+	// ── gzip ──────────────────────────────────────────────────────────────────
+
+	describe('createReadStream() — gzip format', () => {
+		it('concatenates multiple deflate parts into a single gzip stream', async () => {
+			const PART_DATA2 = Buffer.alloc(512, 0xcd);
+			const deflatePart2Meta = await makeDeflatePart(PART_DATA2);
+
+			const source = new BalenaS3CompressedSource({
+				...BASE_OPTIONS,
+				format: 'gzip',
+			});
+			const imageJSON = {
+				'resin.img': {
+					parts: [
+						{
+							filename: 'part1.gz',
+							crc: deflatePartMeta.crc,
+							len: deflatePartMeta.len,
+							zLen: deflatePartMeta.zLen,
+						},
+						{
+							filename: 'part2.gz',
+							crc: deflatePart2Meta.crc,
+							len: deflatePart2Meta.len,
+							zLen: deflatePart2Meta.zLen,
+						},
+					],
+				},
+			};
+			stubDownload(
+				source,
+				imageJSON,
+				new Map([
+					['part1.gz', deflatePartMeta.buf],
+					['part2.gz', deflatePart2Meta.buf],
+				]),
+			);
+
+			await source.open();
+			const stream = await source.createReadStream();
+			const gz = createGunzip();
+			const bufPromise = streamToBuffer(gz);
+			await pipeline(stream, gz);
+			const decompressed = await bufPromise;
+
+			expect(decompressed).to.deep.equal(
+				Buffer.concat([PART_DATA, PART_DATA2]),
+			);
+			await source.close();
+		});
+	});
+
+	// ── zip ───────────────────────────────────────────────────────────────────
+
+	describe('createReadStream() — zip format', () => {
+		it('creates a valid zip with the correct entry name and data', async () => {
+			const source = new BalenaS3CompressedSource({
+				...BASE_OPTIONS,
+				format: 'zip',
+			});
+			const imageJSON = {
+				'resin.img': {
+					parts: [
+						{
+							filename: 'part.gz',
+							crc: deflatePartMeta.crc,
+							len: deflatePartMeta.len,
+							zLen: deflatePartMeta.zLen,
+						},
+					],
+				},
+			};
+			stubDownload(
+				source,
+				imageJSON,
+				new Map([['part.gz', deflatePartMeta.buf]]),
+			);
+
+			await source.open();
+			const expectedName = (source as any).filename as string;
+
+			const stream = await source.createReadStream();
+			const unzipper = unzip.Parse();
+			const entryPromises: Array<Promise<{ name: string; data: Buffer }>> = [];
+			unzipper.on('entry', (entry: unzip.ZipStreamEntry) => {
+				entryPromises.push(
+					streamToBuffer(entry).then((data) => ({ name: entry.path, data })),
+				);
+			});
+			await pipeline(stream, unzipper);
+			const [result] = await Promise.all(entryPromises);
+
+			expect(result.name).to.equal(expectedName);
+			expect(result.data).to.deep.equal(PART_DATA);
+			await source.close();
+		});
+	});
+});
+
+// ─── integration tests (real S3 data) ──────────────────────────────────────
+
+const BUCKET_BASE_OPTIONS = {
+	host: 'https://s3.amazonaws.com',
+	bucket: 'resin-production-img-cloudformation',
+};
+
+for (const opts of [
+	{
+		deviceType: 'raspberrypi3',
+		buildId: '2.115.7',
+	},
+	{
+		// tests zip64 support with an image part that's >4GB uncompressed
+		deviceType: 'jetson-orin-nx-xavier-nx-devkit',
+		buildId: '2.113.32',
+	},
+]) {
+	describe(`BalenaS3CompressedSource (integration — ${opts.deviceType} ${opts.buildId})`, function () {
+		this.timeout(600_000);
+
+		const sourceBaseOptions = {
+			...BUCKET_BASE_OPTIONS,
+			...opts,
+			configuration: {
+				applicationId: 12345,
+				deviceType: opts.deviceType,
+				apiKey: 'dummy',
+			}
+		};
+
+		it('gzip: decompressed size matches sum of len fields in image.json', async function () {
+			const source = new BalenaS3CompressedSource({
+				...sourceBaseOptions,
+				format: 'gzip',
+			});
+			await source.open();
+			const expectedTotal = sumImageJSONLenFields((source as any).imageJSON);
+			const stream = await source.createReadStream();
+			let total = 0;
+			await pipeline(
+				stream,
+				createGunzip(),
+				new Writable({
+					write(chunk: Buffer, _enc, cb) {
+						total += chunk.length;
+						cb();
+					},
+				}),
+			);
+			await source.close();
+			expect(total).to.equal(expectedTotal);
+		});
+
+		it('zip: single entry with correct filename and decompressed size', async () => {
+			const source = new BalenaS3CompressedSource({
+				...sourceBaseOptions,
+				format: 'zip',
+			});
+			await source.open();
+			const expectedName = (source as any).filename as string;
+			const expectedTotal = sumImageJSONLenFields((source as any).imageJSON);
+			const stream = await source.createReadStream();
+
+			const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'etcher-sdk-tests-'));
+			const tmpPath = `${tmpDir}/${expectedName}.zip`;
+			try {
+				await pipeline(stream, fs.createWriteStream(tmpPath));
+
+				// Confirms that the crc is correct
+				// Note: I wasn't able to find an npm package that checks with crc verification
+				await execFile('unzip', ['-t', tmpPath]);
+
+				const unzipper = unzip.Parse();
+				const entryPromises: Array<
+					Promise<{ entryName: string; totalBytes: number }>
+				> = [];
+				unzipper.on('entry', (entry: unzip.ZipStreamEntry) => {
+					entryPromises.push(
+						countBytes(entry).then((n) => ({
+							entryName: entry.path,
+							totalBytes: n,
+						})),
+					);
+				}).on('error', (err) => {
+					entryPromises.push(Promise.reject(err));
+				});
+				await pipeline(fs.createReadStream(tmpPath), unzipper);
+				const entryInfo = await Promise.all(entryPromises);
+
+				await source.close();
+				expect(entryInfo).to.deep.equal([{ entryName: expectedName, totalBytes: expectedTotal }]);
+			} finally {
+				await fs.promises.rm(tmpDir, { recursive: true });
+			}
+		});
+	});
+}

--- a/tests/url-compressed-source.spec.ts
+++ b/tests/url-compressed-source.spec.ts
@@ -1,0 +1,343 @@
+import { execFile as execFileCb } from 'child_process';
+import { promisify } from 'util';
+const execFile = promisify(execFileCb);
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { Readable, Writable } from 'stream';
+import { pipeline } from 'stream/promises';
+import { createGunzip } from 'zlib';
+import * as sinon from 'sinon';
+import * as unzip from 'unzip-stream';
+
+import { URLCompressedSource, URLSourceConfig } from '../lib/source-destination/url-compressed-source';
+import { streamToBuffer } from '../lib/utils';
+import { countBytes, makeDeflatePart, sumImageJSONLenFields } from './utils';
+
+/**
+ * Build a URLSourceConfig from standard S3 bucket parameters.
+ * Part URLs are resolved dynamically via a Proxy so we don't need to know
+ * the part filenames ahead of time.
+ */
+function buildS3URLConfig(
+	host: string,
+	bucket: string,
+	prefix: string,
+	deviceType: string,
+	buildId: string,
+): URLSourceConfig {
+	const base = [
+		host,
+		bucket,
+		prefix,
+		deviceType,
+		encodeURIComponent(buildId),
+	].join('/');
+
+	const parts = new Proxy({} as Record<string, string>, {
+		get(_target, filename: string) {
+			return `${base}/compressed/${filename}`;
+		},
+		has() {
+			return true;
+		},
+	});
+
+	return {
+		VERSION: `${base}/VERSION`,
+		VERSION_HOSTOS: `${base}/VERSION_HOSTOS`,
+		'device-type.json': `${base}/device-type.json`,
+		'image.json': `${base}/image.json`,
+		parts,
+	};
+}
+
+// ─── unit test fixtures ───────────────────────────────────────────────────────
+
+/**
+ * A Proxy that returns a truthy stub URL for any part filename.
+ * This satisfies the URLCompressedSource._open() validation that checks
+ * `this.urls.parts[part.filename]` without needing to know filenames upfront.
+ */
+const stubPartsProxy = new Proxy({} as Record<string, string>, {
+	get: () => 'https://example.com/stub',
+	has: () => true,
+});
+
+const BASE_OPTIONS = {
+	urls: {
+		VERSION: 'https://example.com/VERSION',
+		VERSION_HOSTOS: 'https://example.com/VERSION_HOSTOS',
+		'device-type.json': 'https://example.com/device-type.json',
+		'image.json': 'https://example.com/image.json',
+		parts: stubPartsProxy,
+	} as URLSourceConfig,
+	deviceType: 'raspberrypi3',
+	buildId: '2.9.6+rev1.prod',
+};
+
+const DEVICE_TYPE_JSON = {
+	slug: 'raspberrypi3',
+	version: 1,
+	aliases: ['raspberrypi3'],
+	name: 'Raspberry Pi 3',
+	arch: 'armv7hf',
+	configuration: { config: { partition: 1 } },
+	yocto: {},
+};
+
+/**
+ * Stubs the private `download` method (for VERSION / VERSION_HOSTOS /
+ * image.json / device-type.json) and the private `getPartStream` method (for
+ * compressed part data) on a URLCompressedSource instance.
+ */
+function stubDownload(
+	source: URLCompressedSource,
+	imageJSON: object,
+	partFiles: Map<string, Buffer>,
+): void {
+	sinon.stub(source as any, 'download').callsFake(async (key: string) => {
+		switch (key) {
+			case 'VERSION':
+				return {
+					headers: { 'last-modified': 'Wed, 01 Jan 2025 00:00:00 GMT' },
+					data: '2.0.0',
+				};
+			case 'VERSION_HOSTOS':
+				return { headers: {}, data: '2.9.0' };
+			case 'image.json':
+				return { headers: {}, data: imageJSON };
+			case 'device-type.json':
+				return { headers: {}, data: DEVICE_TYPE_JSON };
+			default:
+				throw new Error(`Unexpected download call: ${key}`);
+		}
+	});
+
+	sinon
+		.stub(source as any, 'getPartStream')
+		.callsFake(async (filename: string) => {
+			const buf = partFiles.get(filename);
+			if (buf === undefined) {
+				throw new Error(`No part data for: ${filename}`);
+			}
+			return Readable.from([buf]);
+		});
+}
+
+// ─── unit tests ───────────────────────────────────────────────────────────────
+
+describe('URLCompressedSource', function () {
+	this.timeout(10000);
+
+	const PART_DATA = Buffer.alloc(512, 0xab);
+	let deflatePartMeta: { buf: Buffer; crc: number; len: number; zLen: number };
+
+	before(async () => {
+		deflatePartMeta = await makeDeflatePart(PART_DATA);
+	});
+
+	afterEach(() => sinon.restore());
+
+	// ── gzip ──────────────────────────────────────────────────────────────────
+
+	describe('createReadStream() — gzip format', () => {
+		it('concatenates multiple deflate parts into a single gzip stream', async () => {
+			const PART_DATA2 = Buffer.alloc(512, 0xcd);
+			const deflatePart2Meta = await makeDeflatePart(PART_DATA2);
+
+			const source = new URLCompressedSource({
+				...BASE_OPTIONS,
+				format: 'gzip',
+			});
+			const imageJSON = {
+				'resin.img': {
+					parts: [
+						{
+							filename: 'part1.gz',
+							crc: deflatePartMeta.crc,
+							len: deflatePartMeta.len,
+							zLen: deflatePartMeta.zLen,
+						},
+						{
+							filename: 'part2.gz',
+							crc: deflatePart2Meta.crc,
+							len: deflatePart2Meta.len,
+							zLen: deflatePart2Meta.zLen,
+						},
+					],
+				},
+			};
+			stubDownload(
+				source,
+				imageJSON,
+				new Map([
+					['part1.gz', deflatePartMeta.buf],
+					['part2.gz', deflatePart2Meta.buf],
+				]),
+			);
+
+			await source.open();
+			const stream = await source.createReadStream();
+			const gz = createGunzip();
+			const bufPromise = streamToBuffer(gz);
+			await pipeline(stream, gz);
+			const decompressed = await bufPromise;
+
+			expect(decompressed).to.deep.equal(
+				Buffer.concat([PART_DATA, PART_DATA2]),
+			);
+			await source.close();
+		});
+	});
+
+	// ── zip ───────────────────────────────────────────────────────────────────
+
+	describe('createReadStream() — zip format', () => {
+		it('creates a valid zip with the correct entry name and data', async () => {
+			const source = new URLCompressedSource({
+				...BASE_OPTIONS,
+				format: 'zip',
+			});
+			const imageJSON = {
+				'resin.img': {
+					parts: [
+						{
+							filename: 'part.gz',
+							crc: deflatePartMeta.crc,
+							len: deflatePartMeta.len,
+							zLen: deflatePartMeta.zLen,
+						},
+					],
+				},
+			};
+			stubDownload(
+				source,
+				imageJSON,
+				new Map([['part.gz', deflatePartMeta.buf]]),
+			);
+
+			await source.open();
+			const expectedName = (source as any).filename as string;
+
+			const stream = await source.createReadStream();
+			const unzipper = unzip.Parse();
+			const entryPromises: Array<Promise<{ name: string; data: Buffer }>> = [];
+			unzipper.on('entry', (entry: unzip.ZipStreamEntry) => {
+				entryPromises.push(
+					streamToBuffer(entry).then((data) => ({ name: entry.path, data })),
+				);
+			});
+			await pipeline(stream, unzipper);
+			const [result] = await Promise.all(entryPromises);
+
+			expect(result.name).to.equal(expectedName);
+			expect(result.data).to.deep.equal(PART_DATA);
+			await source.close();
+		});
+	});
+});
+
+// ─── integration tests (real S3 data) ──────────────────────────────────────
+
+const BUCKET_BASE_OPTIONS = {
+	host: 'https://s3.amazonaws.com',
+	bucket: 'resin-production-img-cloudformation',
+	prefix: 'images',
+};
+
+for (const opts of [
+	{
+		deviceType: 'raspberrypi3',
+		buildId: '2.115.7',
+	},
+	{
+		// tests zip64 support with an image part that's >4GB uncompressed
+		deviceType: 'jetson-orin-nx-xavier-nx-devkit',
+		buildId: '2.113.32',
+	},
+]) {
+	describe(`URLCompressedSource (integration — ${opts.deviceType} ${opts.buildId})`, function () {
+		this.timeout(600_000);
+		const sourceBaseOptions = {
+			urls: buildS3URLConfig(
+				BUCKET_BASE_OPTIONS.host,
+				BUCKET_BASE_OPTIONS.bucket,
+				BUCKET_BASE_OPTIONS.prefix,
+				opts.deviceType,
+				opts.buildId,
+			),
+			...opts,
+			configuration: {
+				applicationId: 12345,
+				deviceType: opts.deviceType,
+				apiKey: 'dummy',
+			}
+		};
+
+		it('gzip: decompressed size matches sum of len fields in image.json', async function () {
+			const source = new URLCompressedSource({
+				...sourceBaseOptions,
+				format: 'gzip',
+			});
+			await source.open();
+			const expectedTotal = sumImageJSONLenFields((source as any).imageJSON);
+			const stream = await source.createReadStream();
+			let total = 0;
+			await pipeline(
+				stream,
+				createGunzip(),
+				new Writable({
+					write(chunk: Buffer, _enc, cb) {
+						total += chunk.length;
+						cb();
+					},
+				}),
+			);
+			await source.close();
+			expect(total).to.equal(expectedTotal);
+		});
+
+		it('zip: single entry with correct filename and decompressed size', async () => {
+			const source = new URLCompressedSource({
+				...sourceBaseOptions,
+				format: 'zip',
+			});
+			await source.open();
+			const expectedName = (source as any).filename as string;
+			const expectedTotal = sumImageJSONLenFields((source as any).imageJSON);
+			const stream = await source.createReadStream();
+
+			const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'etcher-sdk-tests-'));
+			const tmpPath = `${tmpDir}/${expectedName}.zip`;
+			try {
+				await pipeline(stream, fs.createWriteStream(tmpPath));
+				
+				// Confirms that the crc is correct
+				// Note: I wasn't able to find an npm package that checks with crc verification
+				await execFile('unzip', ['-t', tmpPath]);
+
+				const unzipper = unzip.Parse();
+				const entryPromises: Array<
+					Promise<{ entryName: string; totalBytes: number }>
+				> = [];
+				unzipper.on('entry', (entry: unzip.ZipStreamEntry) => {
+					entryPromises.push(
+						countBytes(entry).then((n) => ({
+							entryName: entry.path,
+							totalBytes: n,
+						})),
+					);
+				});
+				await pipeline(fs.createReadStream(tmpPath), unzipper);
+				const entryInfo = await Promise.all(entryPromises);
+
+				await source.close();
+				expect(entryInfo).to.deep.equal([{ entryName: expectedName, totalBytes: expectedTotal }]);
+			} finally {
+				await fs.promises.rm(tmpDir, { recursive: true });
+			}
+		});
+	});
+}

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,44 @@
+import { createDeflatePart } from 'gzip-stream';
+import { Readable, Writable } from 'stream';
+import { pipeline } from 'stream/promises';
+
+/** Compress data with DeflatePartStream and return the buffer + metadata. */
+export async function makeDeflatePart(
+	data: Buffer,
+): Promise<{ buf: Buffer; crc: number; len: number; zLen: number }> {
+	const deflate = createDeflatePart();
+	const chunks: Buffer[] = [];
+	await pipeline(
+		Readable.from([data]),
+		deflate,
+		new Writable({
+			write(chunk: Buffer, _enc, cb) {
+				chunks.push(chunk);
+				cb();
+			},
+		}),
+	);
+	return { buf: Buffer.concat(chunks), ...deflate.metadata() };
+}
+
+export function sumImageJSONLenFields(
+    imageJSON: Record<string, { parts: Array<{ len: number }> }>,
+): number {
+    return Object.values(imageJSON)
+        .flatMap((img) => img.parts)
+        .reduce((sum, part) => sum + part.len, 0);
+}
+
+export async function countBytes(readable: NodeJS.ReadableStream): Promise<number> {
+	let n = 0;
+	await pipeline(
+		readable,
+		new Writable({
+			write(chunk: Buffer, _enc, cb) {
+				n += chunk.length;
+				cb();
+			},
+		}),
+	);
+	return n;
+}


### PR DESCRIPTION
Update zip-part-steam from 2.0.0 to 2.1.0

Change-type: minor
See: https://balena.fibery.io/Work/Project/2525
See: https://balena.fibery.io/Work/Project/2628
Depends-on: https://github.com/balena-io-modules/zip-part-stream/pull/15
Depends-on: https://github.com/balena-io-modules/gzip-stream/pull/12