### PR TITLE
url-compressed-source: Fix zipped img permissions to be 644 like in v10.1.6

### DIFF
--- a/lib/source-destination/raw-deflate-zip-stream.ts
+++ b/lib/source-destination/raw-deflate-zip-stream.ts
@@ -121,6 +121,15 @@ async function addRawDeflatePartEntry(
 		compressedSize:
 			parts.reduce((sum, p) => sum + p.zLen, 0) + DEFLATE_END.length,
 	});
+
+	// Set the entry permissions to 644, just like zip-part-stream was using 0x81a4 (which equals 0o100644)
+	// See: https://github.com/balena-io-modules/zip-part-stream/blob/v2.0.1/index.coffee#L16
+	// using `setUnixMode()` in the same way zip-stream's entry() sets the permissions
+	// See: https://github.com/archiverjs/node-zip-stream/blob/6.0.1/index.js#L157
+	// which is also the default that node-archiver uses
+	// See: https://github.com/archiverjs/node-archiver/blob/7.0.1/lib/core.js#L339
+	entry.setUnixMode(0o644); // rw-r--r--
+
 	const source = CombinedStream.create();
 	for (const { stream } of parts) {
 		source.append(stream);

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -11,6 +11,13 @@ import { Readable, Writable } from 'stream';
 import { pipeline } from 'stream/promises';
 import { Metadata } from '../lib/source-destination';
 
+export function assertExists(
+	v: unknown,
+	message?: string,
+): asserts v is NonNullable<typeof v> {
+	expect(v, message).to.exist;
+}
+
 /** Compress data with DeflatePartStream and return the buffer + metadata. */
 export async function makeDeflatePart(
 	data: Buffer,
@@ -59,16 +66,13 @@ export async function testZipArchive(
 	metadata: Metadata,
 	uncompressedSize: number,
 ) {
+	assertExists(metadata.name);
 	const tmpDir = await fs.promises.mkdtemp(
 		path.join(os.tmpdir(), 'etcher-sdk-tests-'),
 	);
-	const tmpPath = `${tmpDir}/${metadata.name}.zip`;
+	const tmpPath = path.join(tmpDir, `${metadata.name}.zip`);
 	try {
 		await pipeline(stream, fs.createWriteStream(tmpPath));
-
-		// Confirms that the crc is correct.
-		// Note: Wasn't able to find an npm package that does crc verification of zip files.
-		await execFile('unzip', ['-t', tmpPath]);
 
 		const unzipper = unzip.Parse();
 		const entryPromises: Array<
@@ -93,10 +97,20 @@ export async function testZipArchive(
 			{ entryName: metadata.name, totalBytes: uncompressedSize },
 		]);
 
-		const { size: zipFileSize } = await fs.promises.stat(tmpPath);
+		const archiveStats = await fs.promises.stat(tmpPath);
 		expect(metadata).to.include({
-			size: zipFileSize,
+			size: archiveStats.size,
 		});
+
+		// Also confirms that the crc is correct.
+		// Note: Wasn't able to find an npm package that does crc verification of zip files.
+		await execFile('unzip', ['-o', tmpPath, '-d', tmpDir]);
+		const imgStats = await fs.promises.stat(path.join(tmpDir, metadata.name));
+		expect(imgStats).to.include({
+			mode: 0o100644, // S_IFREG (regular file: 0o100), rw-r--r--
+		});
+		const imgPermissions = (imgStats.mode & 0o777).toString(8);
+		expect(imgPermissions).to.equal('644');
 	} finally {
 		await fs.promises.rm(tmpDir, { recursive: true });
 	}

--- a/typings/compress-commons/index.d.ts
+++ b/typings/compress-commons/index.d.ts
@@ -7,6 +7,7 @@ declare module 'compress-commons' {
 		setSize(size: number): void;
 		setCompressedSize(size: number): void;
 		getMethod(): number;
+		setUnixMode(mode: number): void;
 	}
 
 	export class ZipArchiveOutputStream extends Transform {


### PR DESCRIPTION
Change-type: patch
See: https://balena.fibery.io/Work/Project/2628