### PR TITLE
url-compressed-source: Use an empty Buffer instead of a dummy Stream while estimating the download size

### DIFF
--- a/lib/source-destination/balena-s3-compressed-source.ts
+++ b/lib/source-destination/balena-s3-compressed-source.ts
@@ -285,7 +285,10 @@ export class BalenaS3CompressedSource extends BalenaS3SourceBase {
 						if (configuredPart !== undefined) {
 							({ buffer: stream, crc, zLen } = configuredPart);
 						} else if (fake) {
-							stream = new Readable();
+							// We use an empty buffer when getting the parts to estimate
+							// the resulting size, since we do not use it in the size calculations anyway
+							// and it's lighter than a dummy stream.
+							stream = Buffer.alloc(0);
 						} else {
 							stream = await this.getPartStream(p.filename);
 						}

--- a/lib/source-destination/url-compressed-source.ts
+++ b/lib/source-destination/url-compressed-source.ts
@@ -338,7 +338,10 @@ export class URLCompressedSource extends SourceDestination {
 						if (configuredPart !== undefined) {
 							({ buffer: stream, crc, zLen } = configuredPart);
 						} else if (fake) {
-							stream = new Readable();
+							// We use an empty buffer when getting the parts to estimate
+							// the resulting size, since we do not use it in the size calculations anyway
+							// and it's lighter than a dummy stream.
+							stream = Buffer.alloc(0);
 						} else {
 							stream = await this.getPartStream(p.filename);
 						}


### PR DESCRIPTION

Change-type: patch
See: https://balena.fibery.io/Work/Project/2628