### PR TITLE
url-compressed-source: Cleanup all streams

### DIFF
--- a/lib/source-destination/balena-s3-compressed-source.ts
+++ b/lib/source-destination/balena-s3-compressed-source.ts
@@ -1,8 +1,11 @@
 import * as CombinedStream from 'combined-stream';
 import { BufferDisk } from 'file-disk';
 import { createDeflatePart, DEFLATE_END } from 'gzip-stream';
-import { createGzipStreamFromParts } from './compressed-source-utils';
-import { Readable, pipeline } from 'node:stream';
+import {
+	cleanupParts,
+	createGzipStreamFromParts,
+} from './compressed-source-utils';
+import { Readable, finished, pipeline } from 'node:stream';
 import {
 	createZipStreamFromParts,
 	getZipSizeFromParts,
@@ -310,6 +313,12 @@ export class BalenaS3CompressedSource extends BalenaS3SourceBase {
 			this.format === 'zip'
 				? createZipStreamFromParts(parts)
 				: createGzipStreamFromParts(parts);
+		const cleanupFinishedListeners = finished(stream, (err) => {
+			if (err != null) {
+				cleanupParts(parts);
+			}
+			cleanupFinishedListeners();
+		});
 		return stream;
 	}
 

--- a/lib/source-destination/compressed-source-utils.ts
+++ b/lib/source-destination/compressed-source-utils.ts
@@ -1,5 +1,6 @@
 import { createGzipFromParts } from 'gzip-stream';
 import { RawDeflatePart } from './raw-deflate-zip-stream';
+import { Stream } from 'node:stream';
 
 export const createGzipStreamFromParts = (parts: RawDeflatePart[]) => {
 	if (parts.length !== 1) {
@@ -8,4 +9,14 @@ export const createGzipStreamFromParts = (parts: RawDeflatePart[]) => {
 		);
 	}
 	return createGzipFromParts(parts[0].parts);
+};
+
+export const cleanupParts = function (partsByImage: RawDeflatePart[]) {
+	for (const part of partsByImage) {
+		for (const { stream } of part.parts) {
+			if (stream instanceof Stream && !stream.destroyed) {
+				stream.destroy();
+			}
+		}
+	}
 };

--- a/lib/source-destination/raw-deflate-zip-stream.ts
+++ b/lib/source-destination/raw-deflate-zip-stream.ts
@@ -130,6 +130,9 @@ async function addRawDeflatePartEntry(
 	await new Promise<void>((resolve, reject) => {
 		archive.entry(entry, source, (err) => {
 			if (err != null) {
+				if (!source.destroyed) {
+					source.destroy();
+				}
 				reject(err);
 				return;
 			}
@@ -150,7 +153,7 @@ export function createZipStreamFromParts(partsByImage: RawDeflatePart[]) {
 			// If the error was emitted by the archive stream,
 			// we then don't need to emit back to the stream again.
 			if (!archive.destroyed) {
-				archive.emit('error', error);
+				archive.destroy(error);
 			}
 		}
 	})();

--- a/lib/source-destination/url-compressed-source.ts
+++ b/lib/source-destination/url-compressed-source.ts
@@ -1,8 +1,11 @@
 import * as CombinedStream from 'combined-stream';
 import { BufferDisk } from 'file-disk';
 import { createDeflatePart, DEFLATE_END } from 'gzip-stream';
-import { createGzipStreamFromParts } from './compressed-source-utils';
-import { Readable, pipeline } from 'node:stream';
+import {
+	cleanupParts,
+	createGzipStreamFromParts,
+} from './compressed-source-utils';
+import { Readable, finished, pipeline } from 'node:stream';
 import {
 	createZipStreamFromParts,
 	getZipSizeFromParts,
@@ -361,6 +364,12 @@ export class URLCompressedSource extends SourceDestination {
 			this.format === 'zip'
 				? createZipStreamFromParts(parts)
 				: createGzipStreamFromParts(parts);
+		const cleanupFinishedListeners = finished(stream, (err) => {
+			if (err != null) {
+				cleanupParts(parts);
+			}
+			cleanupFinishedListeners();
+		});
 		return stream;
 	}
 


### PR DESCRIPTION
Depends-on: https://github.com/balena-io-modules/etcher-sdk/pull/359
Change-type: patch
See: https://balena.fibery.io/Work/Project/2628