### PR TITLE
url-compressed-source: Avoid creating gz streams while estimating size

### DIFF
--- a/lib/source-destination/balena-s3-compressed-source.ts
+++ b/lib/source-destination/balena-s3-compressed-source.ts
@@ -4,6 +4,7 @@ import { createDeflatePart, DEFLATE_END } from 'gzip-stream';
 import {
 	cleanupParts,
 	createGzipStreamFromParts,
+	getGzipSizeFromParts,
 } from './compressed-source-utils';
 import { Readable, finished, pipeline } from 'node:stream';
 import {
@@ -306,7 +307,7 @@ export class BalenaS3CompressedSource extends BalenaS3SourceBase {
 		if (this.format === 'zip') {
 			return getZipSizeFromParts(parts);
 		}
-		return createGzipStreamFromParts(parts).zLen;
+		return getGzipSizeFromParts(parts);
 	}
 
 	private async createStream() {

--- a/lib/source-destination/compressed-source-utils.ts
+++ b/lib/source-destination/compressed-source-utils.ts
@@ -1,4 +1,7 @@
-import { createGzipFromParts } from 'gzip-stream';
+import {
+	createGzipFromParts,
+	getGzipSizeFromParts as $getGzipSizeFromParts,
+} from 'gzip-stream';
 import { RawDeflatePart } from './raw-deflate-zip-stream';
 import { Stream } from 'node:stream';
 
@@ -9,6 +12,15 @@ export const createGzipStreamFromParts = (parts: RawDeflatePart[]) => {
 		);
 	}
 	return createGzipFromParts(parts[0].parts);
+};
+
+export const getGzipSizeFromParts = (parts: RawDeflatePart[]) => {
+	if (parts.length !== 1) {
+		throw new Error(
+			'Using gzip is only supported for sources with a single part',
+		);
+	}
+	return $getGzipSizeFromParts(parts[0].parts);
 };
 
 export const cleanupParts = function (partsByImage: RawDeflatePart[]) {

--- a/lib/source-destination/url-compressed-source.ts
+++ b/lib/source-destination/url-compressed-source.ts
@@ -4,6 +4,7 @@ import { createDeflatePart, DEFLATE_END } from 'gzip-stream';
 import {
 	cleanupParts,
 	createGzipStreamFromParts,
+	getGzipSizeFromParts,
 } from './compressed-source-utils';
 import { Readable, finished, pipeline } from 'node:stream';
 import {
@@ -355,7 +356,7 @@ export class URLCompressedSource extends SourceDestination {
 		if (this.format === 'zip') {
 			return getZipSizeFromParts(parts);
 		}
-		return createGzipStreamFromParts(parts).zLen;
+		return getGzipSizeFromParts(parts);
 	}
 
 	private async createStream() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "file-disk": "^8.0.1",
         "file-type": "^16.0.0",
         "glob": "^10.3.10",
-        "gzip-stream": "^2.0.3",
+        "gzip-stream": "^2.1.0",
         "lzma-native": "^8.0.6",
         "minimatch": "^9.0.3",
         "mountutils": "^2.0.0",
@@ -4745,9 +4745,9 @@
       "dev": true
     },
     "node_modules/gzip-stream": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/gzip-stream/-/gzip-stream-2.0.3.tgz",
-      "integrity": "sha512-O+OudOsoZV4eH2RGvnOt/nvZqstAC33fOlaeMTJrwUycVNSnlF0YOZcAMYDYkrjCuBkegjxpiNPWoIL2fl+MBg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/gzip-stream/-/gzip-stream-2.1.0.tgz",
+      "integrity": "sha512-O58o44OQz5IdyuXzoS4b1/pNvfe4FaOubHFumtTXGLR2KgNnInNCRyAfi5LQtFYH8+VHXerHh49SUE+XOsrKVw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@balena/node-crc-utils": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "file-disk": "^8.0.1",
     "file-type": "^16.0.0",
     "glob": "^10.3.10",
-    "gzip-stream": "^2.0.3",
+    "gzip-stream": "^2.1.0",
     "lzma-native": "^8.0.6",
     "minimatch": "^9.0.3",
     "mountutils": "^2.0.0",

--- a/tests/balena-s3-compressed-source.spec.ts
+++ b/tests/balena-s3-compressed-source.spec.ts
@@ -209,6 +209,15 @@ for (const opts of [
 			await source.open();
 			// @ts-expect-error access private property for test
 			const expectedTotal = sumImageJSONLenFields(source.imageJSON);
+			const metadata = await source.getMetadata();
+			expect(metadata).to.include({
+				format: 'gzip',
+				osVersion: opts.buildId,
+				version: opts.buildId,
+				supervisorVersion: opts.supervisorVersion,
+				arch: opts.arch,
+				name: `${opts.deviceType}-${opts.buildId}-${opts.supervisorVersion}.img`,
+			});
 			const stream = await source.createReadStream();
 			let total = 0;
 			await pipeline(

--- a/tests/url-compressed-source.spec.ts
+++ b/tests/url-compressed-source.spec.ts
@@ -249,6 +249,15 @@ for (const opts of [
 			await source.open();
 			// @ts-expect-error access private property for test
 			const expectedTotal = sumImageJSONLenFields(source.imageJSON);
+			const metadata = await source.getMetadata();
+			expect(metadata).to.include({
+				format: 'gzip',
+				osVersion: opts.buildId,
+				version: opts.buildId,
+				supervisorVersion: opts.supervisorVersion,
+				arch: opts.arch,
+				name: `${opts.deviceType}-${opts.buildId}-${opts.supervisorVersion}.img`,
+			});
 			const stream = await source.createReadStream();
 			let total = 0;
 			await pipeline(

--- a/typings/gzip-stream/index.d.ts
+++ b/typings/gzip-stream/index.d.ts
@@ -18,6 +18,12 @@ declare module 'gzip-stream' {
 
 	export function createDeflatePart(): DeflatePartStream;
 
+	export function getGzipSizeFromParts(
+		parts: Array<{
+			zLen: number;
+		}>,
+	): number;
+
 	export function createGzipFromParts(
 		parts: Array<{
 			stream: NodeJS.ReadableStream | Buffer;


### PR DESCRIPTION


Change-type: patch
See: https://balena.fibery.io/Work/Project/2628
See: https://github.com/balena-io-modules/gzip-stream/pull/14