### PR TITLE
url-compressed-source: Separate the size estimation parts from the part streaming

### DIFF
--- a/lib/source-destination/balena-s3-compressed-source.ts
+++ b/lib/source-destination/balena-s3-compressed-source.ts
@@ -273,10 +273,29 @@ export class BalenaS3CompressedSource extends BalenaS3SourceBase {
 		}
 		await this.configure();
 		// The order is important, getSize() expects imageJSON and filename to be set and the image to be configured
-		this.size = await this.getSize();
+		this.size = this.getSize();
 	}
 
-	private async getParts(fake: boolean) {
+	private getSize(): number {
+		const partInfos = Object.entries(this.imageJSON).map(
+			([filename, { parts }]) => ({
+				filename,
+				parts: parts.map((p) => {
+					const configuredPart = this.configuredParts.get(p.filename);
+					return {
+						len: p.len,
+						zLen: (configuredPart ?? p).zLen,
+					};
+				}),
+			}),
+		);
+		if (this.format === 'zip') {
+			return getZipSizeFromParts(partInfos);
+		}
+		return getGzipSizeFromParts(partInfos);
+	}
+
+	private async getParts() {
 		return Promise.all(
 			Object.entries(this.imageJSON).map(async ([filename, { parts }]) => ({
 				filename,
@@ -287,11 +306,6 @@ export class BalenaS3CompressedSource extends BalenaS3SourceBase {
 						const configuredPart = this.configuredParts.get(p.filename);
 						if (configuredPart !== undefined) {
 							({ buffer: stream, crc, zLen } = configuredPart);
-						} else if (fake) {
-							// We use an empty buffer when getting the parts to estimate
-							// the resulting size, since we do not use it in the size calculations anyway
-							// and it's lighter than a dummy stream.
-							stream = Buffer.alloc(0);
 						} else {
 							stream = await this.getPartStream(p.filename);
 						}
@@ -302,16 +316,8 @@ export class BalenaS3CompressedSource extends BalenaS3SourceBase {
 		);
 	}
 
-	private async getSize(): Promise<number> {
-		const parts = await this.getParts(true);
-		if (this.format === 'zip') {
-			return getZipSizeFromParts(parts);
-		}
-		return getGzipSizeFromParts(parts);
-	}
-
 	private async createStream() {
-		const parts = await this.getParts(false);
+		const parts = await this.getParts();
 		const stream =
 			this.format === 'zip'
 				? createZipStreamFromParts(parts)

--- a/lib/source-destination/compressed-source-types.ts
+++ b/lib/source-destination/compressed-source-types.ts
@@ -7,3 +7,11 @@ export interface ImageJSONPart {
 }
 
 export type ImageJSON = Record<string, { parts: ImageJSONPart[] }>;
+
+export interface ImagePartInfo {
+	filename: string;
+	parts: Array<{
+		zLen: number;
+		len: number;
+	}>;
+}

--- a/lib/source-destination/compressed-source-utils.ts
+++ b/lib/source-destination/compressed-source-utils.ts
@@ -4,6 +4,7 @@ import {
 } from 'gzip-stream';
 import { RawDeflatePart } from './raw-deflate-zip-stream';
 import { Stream } from 'node:stream';
+import type { ImagePartInfo } from './compressed-source-types';
 
 export const createGzipStreamFromParts = (parts: RawDeflatePart[]) => {
 	if (parts.length !== 1) {
@@ -14,7 +15,7 @@ export const createGzipStreamFromParts = (parts: RawDeflatePart[]) => {
 	return createGzipFromParts(parts[0].parts);
 };
 
-export const getGzipSizeFromParts = (parts: RawDeflatePart[]) => {
+export const getGzipSizeFromParts = (parts: ImagePartInfo[]) => {
 	if (parts.length !== 1) {
 		throw new Error(
 			'Using gzip is only supported for sources with a single part',

--- a/lib/source-destination/raw-deflate-zip-stream.ts
+++ b/lib/source-destination/raw-deflate-zip-stream.ts
@@ -7,6 +7,7 @@ import {
 	Transform,
 	promises as streamPromises,
 } from 'node:stream';
+import type { ImagePartInfo } from './compressed-source-types';
 
 // DEFLATE ending block
 const DEFLATE_END = Buffer.from([0x03, 0x00]);
@@ -163,7 +164,7 @@ export function createZipStreamFromParts(partsByImage: RawDeflatePart[]) {
 // ZIP specification reference: APPNOTE.TXT by PKWare
 // https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
 // Check §4.3.6 for a file format overview
-export function getZipSizeFromParts(partsByImage: RawDeflatePart[]): number {
+export function getZipSizeFromParts(partsByImage: ImagePartInfo[]): number {
 	const ZIP64_MAGIC = 0xffffffff;
 	const ZIP64_MAGIC_SHORT = 0xffff;
 

--- a/lib/source-destination/url-compressed-source.ts
+++ b/lib/source-destination/url-compressed-source.ts
@@ -322,10 +322,29 @@ export class URLCompressedSource extends SourceDestination {
 
 		await this.configure();
 		// The order is important, getSize() expects imageJSON and filename to be set and the image to be configured
-		this.size = await this.getSize();
+		this.size = this.getSize();
 	}
 
-	private async getParts(fake: boolean) {
+	private getSize(): number {
+		const partInfos = Object.entries(this.imageJSON).map(
+			([filename, { parts }]) => ({
+				filename,
+				parts: parts.map((p) => {
+					const configuredPart = this.configuredParts.get(p.filename);
+					return {
+						len: p.len,
+						zLen: (configuredPart ?? p).zLen,
+					};
+				}),
+			}),
+		);
+		if (this.format === 'zip') {
+			return getZipSizeFromParts(partInfos);
+		}
+		return getGzipSizeFromParts(partInfos);
+	}
+
+	private async getParts() {
 		return Promise.all(
 			Object.entries(this.imageJSON).map(async ([filename, { parts }]) => ({
 				filename,
@@ -336,11 +355,6 @@ export class URLCompressedSource extends SourceDestination {
 						const configuredPart = this.configuredParts.get(p.filename);
 						if (configuredPart !== undefined) {
 							({ buffer: stream, crc, zLen } = configuredPart);
-						} else if (fake) {
-							// We use an empty buffer when getting the parts to estimate
-							// the resulting size, since we do not use it in the size calculations anyway
-							// and it's lighter than a dummy stream.
-							stream = Buffer.alloc(0);
 						} else {
 							stream = await this.getPartStream(p.filename);
 						}
@@ -351,16 +365,8 @@ export class URLCompressedSource extends SourceDestination {
 		);
 	}
 
-	private async getSize(): Promise<number> {
-		const parts = await this.getParts(true);
-		if (this.format === 'zip') {
-			return getZipSizeFromParts(parts);
-		}
-		return getGzipSizeFromParts(parts);
-	}
-
 	private async createStream() {
-		const parts = await this.getParts(false);
+		const parts = await this.getParts();
 		const stream =
 			this.format === 'zip'
 				? createZipStreamFromParts(parts)


### PR DESCRIPTION

Change-type: patch
See: https://balena.fibery.io/Work/Project/2628